### PR TITLE
feat(ui): admin - add feedback visibility, NPS campaigns, and admin audit mode

### DIFF
--- a/.specify/specs/admin-feedback-nps.md
+++ b/.specify/specs/admin-feedback-nps.md
@@ -31,6 +31,7 @@ This feature closes the feedback loop so platform operators can monitor quality 
 - **NPS MongoDB collections**: `nps_responses` and `nps_campaigns` collections
 - **Admin NPS tab**: NPS score, breakdown, trend chart, campaign management, and individual responses
 - **Read-only admin audit**: Admins can view any conversation via feedback chat links in read-only mode
+- **Read-only sharing permissions**: Owners can share conversations as "Can view" (read-only) or "Can edit" (full access) per user/team
 - **Deep-linkable admin tabs**: Admin page supports `?tab=feedback` query parameter for direct navigation
 
 ### Out of Scope
@@ -147,8 +148,13 @@ interface NPSResponse {
 - [x] Campaign stop uses inline confirmation (no browser popup)
 - [x] Admin can filter NPS analytics by specific campaign
 - [x] Admin NPS tab shows: overall NPS score, breakdown, 30-day trend, recent responses, campaigns
-- [x] POST messages blocked for admin_audit access level (403)
-- [x] All new code has comprehensive tests (82 suites, 2006 tests pass)
+- [x] POST messages blocked for admin_audit and shared_readonly access levels (403)
+- [x] Sharing dialog supports "Can view" / "Can edit" permission per user and team
+- [x] Permission can be changed after sharing via PATCH endpoint
+- [x] Public shares are always read-only
+- [x] Legacy shares (without permission records) default to full access for backward compatibility
+- [x] Team shares store per-team permission in `sharing.team_permissions`
+- [x] All new code has comprehensive tests (83 suites, 2024 tests pass)
 - [x] Linting passes
 
 ## Implementation Plan
@@ -162,12 +168,16 @@ interface NPSResponse {
 - [x] Batch-fetch conversation titles for chat links
 - [x] Add "Feedback" tab to admin dashboard
 
-### Phase 3: Read-Only Admin Audit
+### Phase 3: Read-Only Admin Audit & Sharing Permissions
 - [x] Extend `requireConversationAccess` to return `{ conversation, access_level }`
-- [x] Add `admin_audit` access level for admins viewing non-owned conversations
-- [x] Block POST messages for `admin_audit` access
-- [x] Add `readOnly` prop to `ChatPanel` with audit banner and "Back to Feedback" link
+- [x] Add `admin_audit` and `shared_readonly` access levels
+- [x] Block POST messages for `admin_audit` and `shared_readonly` access
+- [x] Add `readOnly` and `readOnlyReason` props to `ChatPanel` with contextual banners
 - [x] Return `access_level` from `GET /api/chat/conversations/[id]`
+- [x] Add permission dropdown ("Can view" / "Can edit") to ShareDialog for users and teams
+- [x] Store per-team permissions in `sharing.team_permissions`
+- [x] Add `PATCH /api/chat/conversations/[id]/share` for changing permissions
+- [x] Default permission selector in ShareDialog for new shares
 
 ### Phase 4: Feature Flags & Config
 - [x] Add `feedbackEnabled` to `Config` interface and `getServerConfig()` (default: true)
@@ -203,12 +213,15 @@ interface NPSResponse {
 - [x] `admin-nps.test.ts` — 11 tests (analytics, campaign filtering, NPS calculation)
 - [x] `admin-audit-access.test.ts` — 11 tests (access levels, conversation route)
 - [x] `chat-messages.test.ts` — +3 tests (write blocking for audit access)
+- [x] `chat-sharing-readonly.test.ts` — 18 tests (permission-based access, PATCH, backward compat)
 - [x] Updated `config.test.ts` with `feedbackEnabled` default, env var override, and key presence tests
 - [x] Updated `admin-page.test.tsx` for new config keys and mocks
+- [x] Updated `chat-sharing-public.test.ts` for `shared_readonly` access level
+- [x] Updated `chat-sharing-teams.test.ts` for permission-aware access levels
 
 ## Testing Strategy
 
-### Automated Tests (2006 tests, 82 suites — all pass)
+### Automated Tests (2024 tests, 83 suites — all pass)
 - API route tests: auth, authz, MongoDB guard, feature flag guard, validation, business logic
 - Middleware tests: `requireConversationAccess` access levels
 - Config tests: `feedbackEnabled` and `npsEnabled` defaults, env var overrides, key presence

--- a/.specify/specs/admin-feedback-nps.md
+++ b/.specify/specs/admin-feedback-nps.md
@@ -151,10 +151,11 @@ interface NPSResponse {
 - [x] POST messages blocked for admin_audit and shared_readonly access levels (403)
 - [x] Sharing dialog supports "Can view" / "Can edit" permission per user and team
 - [x] Permission can be changed after sharing via PATCH endpoint
-- [x] Public shares are always read-only
+- [x] Public shares default to read/write; owner can switch to read-only via permission dropdown
+- [x] Public share permission stored in `sharing.public_permission` (default: comment)
 - [x] Legacy shares (without permission records) default to full access for backward compatibility
 - [x] Team shares store per-team permission in `sharing.team_permissions`
-- [x] All new code has comprehensive tests (83 suites, 2024 tests pass)
+- [x] All new code has comprehensive tests (83 suites, 2026 tests pass)
 - [x] Linting passes
 
 ## Implementation Plan
@@ -177,7 +178,8 @@ interface NPSResponse {
 - [x] Add permission dropdown ("Can view" / "Can edit") to ShareDialog for users and teams
 - [x] Store per-team permissions in `sharing.team_permissions`
 - [x] Add `PATCH /api/chat/conversations/[id]/share` for changing permissions
-- [x] Default permission selector in ShareDialog for new shares
+- [x] Default permission selector in ShareDialog for new shares (defaults to "Can edit")
+- [x] Permission dropdown on "Share with everyone" row with `public_permission` storage
 
 ### Phase 4: Feature Flags & Config
 - [x] Add `feedbackEnabled` to `Config` interface and `getServerConfig()` (default: true)
@@ -213,7 +215,7 @@ interface NPSResponse {
 - [x] `admin-nps.test.ts` — 11 tests (analytics, campaign filtering, NPS calculation)
 - [x] `admin-audit-access.test.ts` — 11 tests (access levels, conversation route)
 - [x] `chat-messages.test.ts` — +3 tests (write blocking for audit access)
-- [x] `chat-sharing-readonly.test.ts` — 18 tests (permission-based access, PATCH, backward compat)
+- [x] `chat-sharing-readonly.test.ts` — 20 tests (permission-based access, PATCH, backward compat, public permission)
 - [x] Updated `config.test.ts` with `feedbackEnabled` default, env var override, and key presence tests
 - [x] Updated `admin-page.test.tsx` for new config keys and mocks
 - [x] Updated `chat-sharing-public.test.ts` for `shared_readonly` access level
@@ -221,7 +223,7 @@ interface NPSResponse {
 
 ## Testing Strategy
 
-### Automated Tests (2024 tests, 83 suites — all pass)
+### Automated Tests (2026 tests, 83 suites — all pass)
 - API route tests: auth, authz, MongoDB guard, feature flag guard, validation, business logic
 - Middleware tests: `requireConversationAccess` access levels
 - Config tests: `feedbackEnabled` and `npsEnabled` defaults, env var overrides, key presence

--- a/.specify/specs/admin-feedback-nps.md
+++ b/.specify/specs/admin-feedback-nps.md
@@ -21,6 +21,7 @@ This feature closes the feedback loop so platform operators can monitor quality 
 - **Feedback persistence**: Save feedback to MongoDB when users submit it (alongside the existing Langfuse path)
 - **Admin Feedback tab**: New tab in `/admin` showing a filterable list of all feedback entries with user, message context, reason, timestamp, and link to conversation
 - **Admin feedback API**: `GET /api/admin/feedback` endpoint returning paginated feedback data
+- **Feedback as optional feature**: Controlled via `FEEDBACK_ENABLED` environment variable (default: on)
 - **NPS as optional feature**: Controlled via `NPS_ENABLED` environment variable (default: off)
 - **Admin-controlled NPS campaigns**: Admins create time-bounded campaigns; users see the survey only when a campaign is active
 - **NPS campaign management**: Create, list, and stop campaigns via `/api/admin/nps/campaigns`
@@ -132,6 +133,7 @@ interface NPSResponse {
 - [x] Read-only mode displays an audit banner and disables message input
 - [x] "Back to Feedback" button navigates to `/admin?tab=feedback`
 - [x] Admin page supports `?tab=` query param for deep linking
+- [x] Feedback is an optional feature controlled by `FEEDBACK_ENABLED` env var (default: on)
 - [x] NPS is an optional feature controlled by `NPS_ENABLED` env var
 - [x] NPS survey appears only when an admin-created campaign is active
 - [x] NPS survey displays the campaign name
@@ -144,7 +146,7 @@ interface NPSResponse {
 - [x] Admin can filter NPS analytics by specific campaign
 - [x] Admin NPS tab shows: overall NPS score, breakdown, 30-day trend, recent responses, campaigns
 - [x] POST messages blocked for admin_audit access level (403)
-- [x] All new code has comprehensive tests (79 suites, 1906 tests pass)
+- [x] All new code has comprehensive tests (79 suites, 1912 tests pass)
 - [x] Linting passes
 
 ## Implementation Plan
@@ -165,7 +167,11 @@ interface NPSResponse {
 - [x] Add `readOnly` prop to `ChatPanel` with audit banner and "Back to Feedback" link
 - [x] Return `access_level` from `GET /api/chat/conversations/[id]`
 
-### Phase 4: NPS Feature Flag & Config
+### Phase 4: Feature Flags & Config
+- [x] Add `feedbackEnabled` to `Config` interface and `getServerConfig()` (default: true)
+- [x] Gate `GET /api/admin/feedback` endpoint with `feedbackEnabled` check
+- [x] Conditionally render Feedback tab in admin dashboard
+- [x] Dynamically adjust tab grid columns based on enabled features
 - [x] Add `npsEnabled` to `Config` interface and `getServerConfig()`
 - [x] Gate all NPS endpoints and UI with `npsEnabled` check
 - [x] Conditionally render NPS tab and NPSSurvey component
@@ -189,20 +195,21 @@ interface NPSResponse {
 - [x] "Back to Feedback" navigates to `/admin?tab=feedback`
 
 ### Phase 8: Testing
-- [x] `admin-feedback.test.ts` — 10 tests (auth, authz, pagination, filtering, structure)
+- [x] `admin-feedback.test.ts` — 11 tests (auth, authz, feedback disabled guard, pagination, filtering, structure)
 - [x] `nps-submit.test.ts` — 19 tests (submit validation, active campaign detection)
 - [x] `nps-campaigns.test.ts` — 30 tests (create, list, stop, overlap, status computation)
 - [x] `admin-nps.test.ts` — 11 tests (analytics, campaign filtering, NPS calculation)
 - [x] `admin-audit-access.test.ts` — 11 tests (access levels, conversation route)
 - [x] `chat-messages.test.ts` — +3 tests (write blocking for audit access)
-- [x] Updated `config.test.ts` and `admin-page.test.tsx` for new config keys and mocks
+- [x] Updated `config.test.ts` with `feedbackEnabled` default, env var override, and key presence tests
+- [x] Updated `admin-page.test.tsx` for new config keys and mocks
 
 ## Testing Strategy
 
-### Automated Tests (1906 tests, 79 suites — all pass)
-- API route tests: auth, authz, MongoDB guard, validation, business logic
+### Automated Tests (1912 tests, 79 suites — all pass)
+- API route tests: auth, authz, MongoDB guard, feature flag guard, validation, business logic
 - Middleware tests: `requireConversationAccess` access levels
-- Config tests: `npsEnabled` key presence
+- Config tests: `feedbackEnabled` and `npsEnabled` defaults, env var overrides, key presence
 - Admin page tests: fetch mock coverage for new endpoints
 
 ### Manual Verification
@@ -217,8 +224,9 @@ interface NPSResponse {
 
 1. Merge to `prebuild/feat/admin-feedback-nps` branch
 2. Requires MongoDB (same as existing admin features)
-3. NPS is opt-in via `NPS_ENABLED=true` environment variable
-4. No infrastructure changes needed beyond existing MongoDB
+3. Feedback is enabled by default; opt-out via `FEEDBACK_ENABLED=false`
+4. NPS is opt-in via `NPS_ENABLED=true` environment variable
+5. No infrastructure changes needed beyond existing MongoDB
 
 ## Related
 

--- a/.specify/specs/admin-feedback-nps.md
+++ b/.specify/specs/admin-feedback-nps.md
@@ -1,0 +1,226 @@
+# Spec: Admin Feedback Visibility & NPS Score Dashboard
+
+## Overview
+
+Make user feedback visible to admins in a dedicated Feedback tab on the admin dashboard, and introduce a Net Promoter Score (NPS) survey system with admin-controlled campaigns, its own admin tab for tracking user satisfaction, and read-only admin audit access to conversations.
+
+## Motivation
+
+Currently, user feedback (thumbs up/down + reasons) is collected via `FeedbackButton` and sent to Langfuse, but it is **not persisted to MongoDB**. The admin dashboard's `feedback_summary` reads from MongoDB and always shows zeros. Admins have no way to:
+
+1. See individual feedback entries, who submitted them, what reasons were given, or what messages they relate to
+2. Track satisfaction trends over time
+3. Measure Net Promoter Score — a standard product health metric
+4. Audit conversations that received feedback without modifying them
+
+This feature closes the feedback loop so platform operators can monitor quality and act on user signals.
+
+## Scope
+
+### In Scope
+- **Feedback persistence**: Save feedback to MongoDB when users submit it (alongside the existing Langfuse path)
+- **Admin Feedback tab**: New tab in `/admin` showing a filterable list of all feedback entries with user, message context, reason, timestamp, and link to conversation
+- **Admin feedback API**: `GET /api/admin/feedback` endpoint returning paginated feedback data
+- **NPS as optional feature**: Controlled via `NPS_ENABLED` environment variable (default: off)
+- **Admin-controlled NPS campaigns**: Admins create time-bounded campaigns; users see the survey only when a campaign is active
+- **NPS campaign management**: Create, list, and stop campaigns via `/api/admin/nps/campaigns`
+- **NPS survey component**: In-app NPS survey (0–10 scale + optional comment) triggered by active campaigns
+- **Campaign-specific NPS results**: Admin can filter NPS analytics by individual campaign
+- **NPS API endpoints**: `POST /api/nps`, `GET /api/nps/active`, `GET /api/admin/nps`, `POST/GET/PATCH /api/admin/nps/campaigns`
+- **NPS MongoDB collections**: `nps_responses` and `nps_campaigns` collections
+- **Admin NPS tab**: NPS score, breakdown, trend chart, campaign management, and individual responses
+- **Read-only admin audit**: Admins can view any conversation via feedback chat links in read-only mode
+- **Deep-linkable admin tabs**: Admin page supports `?tab=feedback` query parameter for direct navigation
+
+### Out of Scope
+- Langfuse changes (existing Langfuse integration remains as-is)
+- Email/Slack NPS notifications
+- Export/CSV download of feedback or NPS data (future)
+
+## Design
+
+### Architecture
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Feedback Flow (Enhanced)                               │
+│  ─────────────────────────────────────────────          │
+│  User clicks thumbs up/down → FeedbackButton            │
+│    ├─→ POST /api/feedback → Langfuse (existing)         │
+│    └─→ PUT /api/chat/messages/[id] → MongoDB (NEW)      │
+│                                                         │
+│  Admin views:                                           │
+│    GET /api/admin/feedback → paginated feedback list     │
+│    └─→ Reads messages collection where feedback exists   │
+│    Click chat link → /chat/[id] → read-only audit mode  │
+└─────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────┐
+│  NPS Flow (Campaign-based)                              │
+│  ─────────────────────────────────────────────          │
+│  Admin creates campaign (date range) via dashboard       │
+│    POST /api/admin/nps/campaigns                        │
+│  User checks for active campaign:                       │
+│    GET /api/nps/active → { active, campaign }           │
+│  NPS survey shown when campaign is active:              │
+│    POST /api/nps → nps_responses (with campaign_id)     │
+│  Admin stops campaign early:                            │
+│    PATCH /api/admin/nps/campaigns                       │
+│                                                         │
+│  Admin views:                                           │
+│    GET /api/admin/nps?campaign_id=X → filtered results  │
+│    └─→ Score, breakdown, trend, responses, campaigns    │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Data Models
+
+**Feedback on messages** (existing `MessageFeedback` — now actually used):
+```typescript
+interface MessageFeedback {
+  rating: 'positive' | 'negative';
+  reason?: string;
+  comment?: string;
+  submitted_at: Date;
+  submitted_by?: string;
+}
+```
+
+**NPS Campaign** (new collection `nps_campaigns`):
+```typescript
+interface NPSCampaign {
+  _id: ObjectId;
+  name: string;
+  starts_at: Date;
+  ends_at: Date;
+  created_by: string;
+  created_at: Date;
+  stopped_by?: string;   // set when admin stops early
+  stopped_at?: Date;
+}
+```
+
+**NPS Response** (new collection `nps_responses`):
+```typescript
+interface NPSResponse {
+  _id: ObjectId;
+  user_email: string;
+  score: number;          // 0–10
+  comment?: string;
+  campaign_id?: string;   // linked to campaign
+  created_at: Date;
+}
+```
+
+### Components Affected
+- [x] UI (`ui/`) — FeedbackButton, admin page, NPS survey, API routes, config, middleware
+- [ ] Agents (`ai_platform_engineering/agents/`)
+- [ ] Multi-Agents (`ai_platform_engineering/multi_agents/`)
+- [ ] MCP Servers
+- [ ] Knowledge Bases (`ai_platform_engineering/knowledge_bases/`)
+- [ ] Documentation (`docs/`)
+- [ ] Helm Charts (`charts/`)
+
+## Acceptance Criteria
+
+- [x] User feedback (thumbs up/down) is persisted to MongoDB on the message document
+- [x] Admin dashboard shows a "Feedback" tab with all feedback entries
+- [x] Feedback tab shows: user, rating, reason, comment, message snippet, timestamp, chat link
+- [x] Feedback tab supports filtering by rating (positive/negative/all)
+- [x] Each feedback entry links to the source conversation so admins can view the full chat
+- [x] Clicking a chat link opens the conversation in read-only audit mode for admins
+- [x] Read-only mode displays an audit banner and disables message input
+- [x] "Back to Feedback" button navigates to `/admin?tab=feedback`
+- [x] Admin page supports `?tab=` query param for deep linking
+- [x] NPS is an optional feature controlled by `NPS_ENABLED` env var
+- [x] NPS survey appears only when an admin-created campaign is active
+- [x] NPS survey displays the campaign name
+- [x] NPS survey question: "How well does {appName} help you get your work done?"
+- [x] NPS survey collects 0–10 score and optional comment
+- [x] NPS responses are stored in `nps_responses` collection linked to campaign
+- [x] Admins can create, list, and stop NPS campaigns
+- [x] Overlapping campaigns are prevented
+- [x] Campaign stop uses inline confirmation (no browser popup)
+- [x] Admin can filter NPS analytics by specific campaign
+- [x] Admin NPS tab shows: overall NPS score, breakdown, 30-day trend, recent responses, campaigns
+- [x] POST messages blocked for admin_audit access level (403)
+- [x] All new code has comprehensive tests (79 suites, 1906 tests pass)
+- [x] Linting passes
+
+## Implementation Plan
+
+### Phase 1: Feedback Persistence to MongoDB
+- [x] Update `ChatPanel.tsx` to call `apiClient.updateMessage()` with feedback data
+- [x] Ensure `PUT /api/chat/messages/[id]` stores `feedback.submitted_by`
+
+### Phase 2: Admin Feedback API & Tab
+- [x] Create `GET /api/admin/feedback` endpoint with pagination and filtering
+- [x] Batch-fetch conversation titles for chat links
+- [x] Add "Feedback" tab to admin dashboard
+
+### Phase 3: Read-Only Admin Audit
+- [x] Extend `requireConversationAccess` to return `{ conversation, access_level }`
+- [x] Add `admin_audit` access level for admins viewing non-owned conversations
+- [x] Block POST messages for `admin_audit` access
+- [x] Add `readOnly` prop to `ChatPanel` with audit banner and "Back to Feedback" link
+- [x] Return `access_level` from `GET /api/chat/conversations/[id]`
+
+### Phase 4: NPS Feature Flag & Config
+- [x] Add `npsEnabled` to `Config` interface and `getServerConfig()`
+- [x] Gate all NPS endpoints and UI with `npsEnabled` check
+- [x] Conditionally render NPS tab and NPSSurvey component
+
+### Phase 5: Admin-Controlled NPS Campaigns
+- [x] Create `nps_campaigns` collection and CRUD API
+- [x] `POST /api/admin/nps/campaigns` — create campaign (with overlap prevention)
+- [x] `GET /api/admin/nps/campaigns` — list with response counts and status
+- [x] `PATCH /api/admin/nps/campaigns` — stop campaign early (inline confirmation)
+- [x] Rewrite NPSSurvey to check `/api/nps/active` for active campaign
+- [x] Display campaign name in survey popup
+- [x] Link NPS responses to campaign_id
+
+### Phase 6: Campaign-Specific Analytics
+- [x] Add `campaign_id` query param filter to `GET /api/admin/nps`
+- [x] Clickable campaign rows in admin NPS tab to filter results
+- [x] "Clear filter" banner when viewing campaign-specific data
+
+### Phase 7: Admin Tab Deep Linking
+- [x] Add `useSearchParams` for `?tab=` query param support
+- [x] "Back to Feedback" navigates to `/admin?tab=feedback`
+
+### Phase 8: Testing
+- [x] `admin-feedback.test.ts` — 10 tests (auth, authz, pagination, filtering, structure)
+- [x] `nps-submit.test.ts` — 19 tests (submit validation, active campaign detection)
+- [x] `nps-campaigns.test.ts` — 30 tests (create, list, stop, overlap, status computation)
+- [x] `admin-nps.test.ts` — 11 tests (analytics, campaign filtering, NPS calculation)
+- [x] `admin-audit-access.test.ts` — 11 tests (access levels, conversation route)
+- [x] `chat-messages.test.ts` — +3 tests (write blocking for audit access)
+- [x] Updated `config.test.ts` and `admin-page.test.tsx` for new config keys and mocks
+
+## Testing Strategy
+
+### Automated Tests (1906 tests, 79 suites — all pass)
+- API route tests: auth, authz, MongoDB guard, validation, business logic
+- Middleware tests: `requireConversationAccess` access levels
+- Config tests: `npsEnabled` key presence
+- Admin page tests: fetch mock coverage for new endpoints
+
+### Manual Verification
+- Submit feedback → verify in admin Feedback tab
+- Click chat link → verify read-only audit mode
+- "Back to Feedback" → verify deep link to feedback tab
+- Enable NPS → create campaign → verify survey appears for users
+- Stop campaign → verify survey stops appearing
+- Filter NPS by campaign → verify scoped results
+
+## Rollout Plan
+
+1. Merge to `prebuild/feat/admin-feedback-nps` branch
+2. Requires MongoDB (same as existing admin features)
+3. NPS is opt-in via `NPS_ENABLED=true` environment variable
+4. No infrastructure changes needed beyond existing MongoDB
+
+## Related
+
+- ADR: `docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md`
+- Related ADR: `docs/docs/changes/2026-01-30-admin-dashboard-with-oidc-group-rbac.md`

--- a/.specify/specs/admin-feedback-nps.md
+++ b/.specify/specs/admin-feedback-nps.md
@@ -138,6 +138,8 @@ interface NPSResponse {
 - [x] NPS survey appears only when an admin-created campaign is active
 - [x] NPS survey displays the campaign name
 - [x] NPS survey question: "How well does {appName} help you get your work done?"
+- [x] NPS survey shows subtle disclaimer: "Responses are tied to your account to help us follow up."
+- [x] Feedback popover shows subtle disclaimer: "Feedback is shared with your admin team to help improve the experience."
 - [x] NPS survey collects 0–10 score and optional comment
 - [x] NPS responses are stored in `nps_responses` collection linked to campaign
 - [x] Admins can create, list, and stop NPS campaigns
@@ -146,7 +148,7 @@ interface NPSResponse {
 - [x] Admin can filter NPS analytics by specific campaign
 - [x] Admin NPS tab shows: overall NPS score, breakdown, 30-day trend, recent responses, campaigns
 - [x] POST messages blocked for admin_audit access level (403)
-- [x] All new code has comprehensive tests (79 suites, 1912 tests pass)
+- [x] All new code has comprehensive tests (82 suites, 2006 tests pass)
 - [x] Linting passes
 
 ## Implementation Plan
@@ -206,7 +208,7 @@ interface NPSResponse {
 
 ## Testing Strategy
 
-### Automated Tests (1912 tests, 79 suites — all pass)
+### Automated Tests (2006 tests, 82 suites — all pass)
 - API route tests: auth, authz, MongoDB guard, feature flag guard, validation, business logic
 - Middleware tests: `requireConversationAccess` access levels
 - Config tests: `feedbackEnabled` and `npsEnabled` defaults, env var overrides, key presence

--- a/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
+++ b/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
@@ -62,12 +62,13 @@ Extended `requireConversationAccess` to return `{ conversation, access_level }` 
 The sharing model now supports per-user and per-team permission levels:
 - **Direct user shares**: Permission stored in `SharingAccess` collection (`'view'` or `'comment'`)
 - **Team shares**: Permission stored in `conversation.sharing.team_permissions` map
-- **Public shares**: Always read-only (`shared_readonly`)
+- **Public shares**: Permission stored in `conversation.sharing.public_permission` (default: `'comment'`/read-write); owner can switch to read-only via dropdown
 - **Backward compatibility**: Legacy shares without permission records default to `'comment'` (full access)
 
 The `ShareDialog` component now shows:
-- A default permission selector ("Can view" / "Can edit") next to the search input for new shares
+- A default permission selector ("Can view" / "Can edit") next to the search input for new shares (defaults to "Can edit")
 - A per-user/team permission dropdown in the access list for changing existing permissions
+- A permission dropdown on the "Share with everyone" row to control public access level
 - Permissions are changed via `PATCH /api/chat/conversations/[id]/share`
 
 ### NPS as Optional Feature
@@ -172,7 +173,7 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 
 ## Testing
 
-### Automated Tests (2024 tests, 83 suites — all pass)
+### Automated Tests (2026 tests, 83 suites — all pass)
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|
@@ -182,7 +183,7 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 | `admin-nps.test.ts` | 11 | NPS calculation, campaign filtering, trend, guards |
 | `admin-audit-access.test.ts` | 11 | Access levels (owner/shared/admin_audit), conversation route, 403/404 |
 | `chat-messages.test.ts` | +3 | Write blocking for admin_audit, owner allowed, GET for audit |
-| `chat-sharing-readonly.test.ts` | 18 | Permission-based access levels, PATCH permission updates, backward compat, message blocking |
+| `chat-sharing-readonly.test.ts` | 20 | Permission-based access levels, PATCH permission updates, backward compat, public permission, message blocking |
 | `config.test.ts` | +7 | `feedbackEnabled` defaults/env var tests, `npsEnabled` key presence |
 | `admin-page.test.tsx` | +fixes | Mock for `/api/admin/feedback`, `/api/admin/nps`, `useSearchParams` |
 

--- a/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
+++ b/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
@@ -12,7 +12,7 @@ title: "2026-03-03: Admin Feedback Visibility & NPS Score Dashboard"
 
 Added comprehensive feedback and NPS (Net Promoter Score) features to the admin dashboard:
 
-1. **Feedback tab**: Shows all user feedback (thumbs up/down) with reasons, comments, user attribution, message context, and clickable links to source conversations
+1. **Feedback tab** (optional, `FEEDBACK_ENABLED=true` by default): Shows all user feedback (thumbs up/down) with reasons, comments, user attribution, message context, and clickable links to source conversations
 2. **NPS tab** (optional, `NPS_ENABLED=true`): Admin-controlled campaign-based NPS tracking with score gauge, promoter/passive/detractor breakdown, trend chart, campaign management, and individual response list
 3. **Read-only admin audit**: Admins can view any conversation via feedback chat links in read-only mode without modifying it
 4. **Deep-linkable admin tabs**: Admin page supports `?tab=feedback` query parameter for direct navigation
@@ -34,6 +34,15 @@ Close the feedback loop by persisting feedback to MongoDB on the message documen
 The `FeedbackButton` submission flow now:
 1. Sends to Langfuse via `POST /api/feedback` (existing, unchanged)
 2. Saves to MongoDB via `PUT /api/chat/messages/[id]` with `feedback` payload (new)
+
+### Feedback as Optional Feature
+
+Feedback is controlled by the `FEEDBACK_ENABLED` environment variable (default: `true`). When disabled:
+- Feedback tab is hidden from admin dashboard
+- `GET /api/admin/feedback` returns 404 with `FEEDBACK_DISABLED` code
+- Tab grid columns adjust dynamically (6 base + feedback + NPS)
+
+Note: feedback *persistence* to MongoDB (the dual-write from ChatPanel) is not gated — it continues to write regardless. Only the admin-facing tab and API are gated.
 
 ### Admin Feedback Tab
 
@@ -113,6 +122,7 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 
 | Env Var | Default | Description |
 |---------|---------|-------------|
+| `FEEDBACK_ENABLED` | `true` | Enable/disable admin Feedback tab and API (set `false` to disable) |
 | `NPS_ENABLED` | `false` | Enable/disable NPS feature |
 
 ### Key Files
@@ -129,7 +139,7 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 | `ui/src/components/chat/ChatPanel.tsx` | Read-only audit mode, feedback persistence |
 | `ui/src/app/(app)/chat/[uuid]/page.tsx` | Wires `readOnly` prop based on access_level |
 | `ui/src/lib/api-middleware.ts` | `requireConversationAccess` with access levels |
-| `ui/src/lib/config.ts` | `npsEnabled` config key |
+| `ui/src/lib/config.ts` | `feedbackEnabled` and `npsEnabled` config keys |
 | `ui/scripts/seed-feedback-nps.mjs` | Seed script for test data |
 
 ## Security Considerations
@@ -139,22 +149,22 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 3. **Authenticated NPS submission**: NPS submissions require a valid session; anonymous submissions are rejected
 4. **Campaign overlap prevention**: Server-side check prevents overlapping active campaigns
 5. **No PII in feedback**: Feedback reasons are pre-defined chips; free-text is optional and user-initiated
-6. **Feature gating**: NPS is opt-in (`NPS_ENABLED=true`); all endpoints return disabled responses when off
+6. **Feature gating**: Feedback is enabled by default, opt-out via `FEEDBACK_ENABLED=false`; NPS is opt-in via `NPS_ENABLED=true`; all gated endpoints return disabled responses when off
 7. **MongoDB required**: Both features require MongoDB (same as existing admin features); returns 503 if not configured
 
 ## Testing
 
-### Automated Tests (1906 tests, 79 suites — all pass)
+### Automated Tests (1912 tests, 79 suites — all pass)
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|
-| `admin-feedback.test.ts` | 10 | Auth, authz, MongoDB guard, pagination, filtering, structure, truncation |
+| `admin-feedback.test.ts` | 11 | Auth, authz, feedback disabled guard, MongoDB guard, pagination, filtering, structure, truncation |
 | `nps-submit.test.ts` | 19 | Score validation, submit variations, active campaign detection, NPS disabled |
 | `nps-campaigns.test.ts` | 30 | Create, list, stop, overlap prevention, status computation, all guards |
 | `admin-nps.test.ts` | 11 | NPS calculation, campaign filtering, trend, guards |
 | `admin-audit-access.test.ts` | 11 | Access levels (owner/shared/admin_audit), conversation route, 403/404 |
 | `chat-messages.test.ts` | +3 | Write blocking for admin_audit, owner allowed, GET for audit |
-| `config.test.ts` | +2 fixes | `npsEnabled` in expected Config keys |
+| `config.test.ts` | +7 | `feedbackEnabled` defaults/env var tests, `npsEnabled` key presence |
 | `admin-page.test.tsx` | +fixes | Mock for `/api/admin/feedback`, `/api/admin/nps`, `useSearchParams` |
 
 ### Seed Script

--- a/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
+++ b/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
@@ -1,0 +1,180 @@
+---
+title: "2026-03-03: Admin Feedback Visibility & NPS Score Dashboard"
+---
+
+# Admin Feedback Visibility & NPS Score Dashboard
+
+**Date**: 2026-03-03
+**Status**: Implemented
+**Type**: Feature Addition
+
+## Summary
+
+Added comprehensive feedback and NPS (Net Promoter Score) features to the admin dashboard:
+
+1. **Feedback tab**: Shows all user feedback (thumbs up/down) with reasons, comments, user attribution, message context, and clickable links to source conversations
+2. **NPS tab** (optional, `NPS_ENABLED=true`): Admin-controlled campaign-based NPS tracking with score gauge, promoter/passive/detractor breakdown, trend chart, campaign management, and individual response list
+3. **Read-only admin audit**: Admins can view any conversation via feedback chat links in read-only mode without modifying it
+4. **Deep-linkable admin tabs**: Admin page supports `?tab=feedback` query parameter for direct navigation
+
+Also fixed the feedback persistence gap — user feedback is now saved to MongoDB alongside the existing Langfuse integration, making it visible to admins.
+
+## Context
+
+User feedback was collected via `FeedbackButton` (thumbs up/down + reasons) but only sent to Langfuse. It was never persisted to MongoDB, so the admin dashboard's `feedback_summary` in the Statistics tab always showed zeros. Admins had no visibility into individual feedback entries or satisfaction trends.
+
+Additionally, there was no mechanism for measuring Net Promoter Score — a standard product health metric used to gauge user loyalty and satisfaction. NPS should be admin-controlled (not automatic) so that admins decide when to launch surveys.
+
+## Decision
+
+### Feedback Persistence
+
+Close the feedback loop by persisting feedback to MongoDB on the message document when users submit it. The existing Langfuse path remains unchanged (dual-write).
+
+The `FeedbackButton` submission flow now:
+1. Sends to Langfuse via `POST /api/feedback` (existing, unchanged)
+2. Saves to MongoDB via `PUT /api/chat/messages/[id]` with `feedback` payload (new)
+
+### Admin Feedback Tab
+
+New `GET /api/admin/feedback` endpoint queries messages with `feedback.rating` set, batch-fetches conversation titles, and returns paginated results. The admin tab displays a filterable table with columns: user, rating, reason, message preview, timestamp, and a clickable chat link.
+
+### Read-Only Admin Audit
+
+Extended `requireConversationAccess` to return `{ conversation, access_level }` where `access_level` can be `'owner'`, `'shared'`, or `'admin_audit'`. Admins get `admin_audit` access to any conversation they don't own or have shared access to.
+
+- `GET /api/chat/conversations/[id]` returns `access_level` in response
+- `POST /api/chat/conversations/[id]/messages` blocks writes for `admin_audit` (403)
+- `ChatPanel` renders a read-only audit banner with "Back to Feedback" link when `readOnly` is true
+
+### NPS as Optional Feature
+
+NPS is controlled by the `NPS_ENABLED` environment variable (default: `false`). When disabled:
+- NPS tab is hidden from admin dashboard
+- NPSSurvey component does not render
+- All NPS API endpoints return appropriate disabled responses
+
+### Admin-Controlled NPS Campaigns
+
+Instead of automatic periodic surveys, admins create time-bounded campaigns:
+- `POST /api/admin/nps/campaigns` — create campaign with name, start/end dates (overlap prevention enforced)
+- `GET /api/admin/nps/campaigns` — list all campaigns with response counts and status (active/ended/scheduled)
+- `PATCH /api/admin/nps/campaigns` — stop a campaign early (sets `ends_at` to now, records `stopped_by`)
+- `GET /api/nps/active` — users check for an active campaign to determine if survey should show
+
+### NPS Survey Component
+
+`NPSSurvey` component checks for active campaigns and shows:
+- Campaign name
+- Question: "How well does {appName} help you get your work done?"
+- 0–10 score scale (color-coded: red detractors, yellow passives, green promoters)
+- Optional comment
+- Dismissal tracked per campaign in localStorage
+
+### Campaign-Specific NPS Analytics
+
+`GET /api/admin/nps` accepts optional `campaign_id` query parameter to filter all analytics (score, breakdown, trend, recent responses) to a specific campaign. The admin UI shows clickable campaign rows and a "Clear filter" banner.
+
+### Deep-Linkable Admin Tabs
+
+Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: `users`, `teams`, `stats`, `skills`, `feedback`, `nps`, `metrics`, `health`. The "Back to Feedback" button in audit mode navigates to `/admin?tab=feedback`.
+
+## Implementation
+
+### New API Endpoints
+
+| Method | Endpoint | Auth | Description |
+|--------|----------|------|-------------|
+| `GET` | `/api/admin/feedback` | `requireAdminView` | Paginated feedback list with conversation titles |
+| `POST` | `/api/nps` | authenticated | Submit NPS response (score 0–10, optional comment, campaign_id) |
+| `GET` | `/api/nps/active` | authenticated | Check for active NPS campaign |
+| `GET` | `/api/admin/nps` | `requireAdminView` | NPS analytics (filterable by campaign_id) |
+| `POST` | `/api/admin/nps/campaigns` | `requireAdmin` | Create NPS campaign |
+| `GET` | `/api/admin/nps/campaigns` | `requireAdminView` | List campaigns with response counts and status |
+| `PATCH` | `/api/admin/nps/campaigns` | `requireAdmin` | Stop campaign early |
+
+### Modified API Behavior
+
+| Method | Endpoint | Change |
+|--------|----------|--------|
+| `GET` | `/api/chat/conversations/[id]` | Returns `access_level` field |
+| `POST` | `/api/chat/conversations/[id]/messages` | Blocks writes for `admin_audit` (403) |
+| `PUT` | `/api/chat/messages/[id]` | Stores `feedback.submitted_by` from session |
+
+### MongoDB Collections
+
+| Collection | Fields | Notes |
+|------------|--------|-------|
+| `messages` (existing) | `feedback.{rating, reason, comment, submitted_at, submitted_by}` | Feedback stored on message doc |
+| `nps_responses` (new) | `user_email, score, comment, campaign_id, created_at` | Linked to campaigns |
+| `nps_campaigns` (new) | `name, starts_at, ends_at, created_by, created_at, stopped_by, stopped_at` | Campaign lifecycle |
+
+### Configuration
+
+| Env Var | Default | Description |
+|---------|---------|-------------|
+| `NPS_ENABLED` | `false` | Enable/disable NPS feature |
+
+### Key Files
+
+| File | Description |
+|------|-------------|
+| `ui/src/app/(app)/admin/page.tsx` | Admin dashboard with Feedback, NPS tabs, campaign management, deep-linkable tabs |
+| `ui/src/app/api/admin/feedback/route.ts` | Admin feedback list API |
+| `ui/src/app/api/admin/nps/route.ts` | Admin NPS analytics API (campaign-filterable) |
+| `ui/src/app/api/admin/nps/campaigns/route.ts` | Campaign CRUD + stop API |
+| `ui/src/app/api/nps/route.ts` | NPS submission API |
+| `ui/src/app/api/nps/active/route.ts` | Active campaign check API |
+| `ui/src/components/nps/NPSSurvey.tsx` | NPS survey component (campaign-aware) |
+| `ui/src/components/chat/ChatPanel.tsx` | Read-only audit mode, feedback persistence |
+| `ui/src/app/(app)/chat/[uuid]/page.tsx` | Wires `readOnly` prop based on access_level |
+| `ui/src/lib/api-middleware.ts` | `requireConversationAccess` with access levels |
+| `ui/src/lib/config.ts` | `npsEnabled` config key |
+| `ui/scripts/seed-feedback-nps.mjs` | Seed script for test data |
+
+## Security Considerations
+
+1. **Admin-only access**: All admin feedback/NPS endpoints check `requireAdminView` or `requireAdmin` — returns 403 for non-admin users
+2. **Read-only audit**: Admin audit access blocks message creation (403); admins cannot modify conversations they audit
+3. **Authenticated NPS submission**: NPS submissions require a valid session; anonymous submissions are rejected
+4. **Campaign overlap prevention**: Server-side check prevents overlapping active campaigns
+5. **No PII in feedback**: Feedback reasons are pre-defined chips; free-text is optional and user-initiated
+6. **Feature gating**: NPS is opt-in (`NPS_ENABLED=true`); all endpoints return disabled responses when off
+7. **MongoDB required**: Both features require MongoDB (same as existing admin features); returns 503 if not configured
+
+## Testing
+
+### Automated Tests (1906 tests, 79 suites — all pass)
+
+| Test File | Tests | Coverage |
+|-----------|-------|----------|
+| `admin-feedback.test.ts` | 10 | Auth, authz, MongoDB guard, pagination, filtering, structure, truncation |
+| `nps-submit.test.ts` | 19 | Score validation, submit variations, active campaign detection, NPS disabled |
+| `nps-campaigns.test.ts` | 30 | Create, list, stop, overlap prevention, status computation, all guards |
+| `admin-nps.test.ts` | 11 | NPS calculation, campaign filtering, trend, guards |
+| `admin-audit-access.test.ts` | 11 | Access levels (owner/shared/admin_audit), conversation route, 403/404 |
+| `chat-messages.test.ts` | +3 | Write blocking for admin_audit, owner allowed, GET for audit |
+| `config.test.ts` | +2 fixes | `npsEnabled` in expected Config keys |
+| `admin-page.test.tsx` | +fixes | Mock for `/api/admin/feedback`, `/api/admin/nps`, `useSearchParams` |
+
+### Seed Script
+
+`node ui/scripts/seed-feedback-nps.mjs` populates MongoDB with sample conversations, feedback, an NPS campaign, and NPS responses for manual testing.
+
+## Conventional Commit
+
+```
+feat(admin): add feedback visibility, NPS campaigns, and admin audit mode
+
+- Persist user feedback to MongoDB alongside Langfuse (dual-write)
+- Add admin Feedback tab with filterable table and chat links
+- Add read-only admin audit mode for viewing conversations
+- Add optional NPS feature (NPS_ENABLED env var)
+- Add admin-controlled NPS campaigns (create, list, stop)
+- Add NPS survey component triggered by active campaigns
+- Add campaign-specific NPS analytics filtering
+- Add deep-linkable admin tabs via ?tab= query param
+- Comprehensive test coverage (1906 tests, 79 suites)
+
+Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>
+```

--- a/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
+++ b/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
@@ -149,12 +149,13 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 3. **Authenticated NPS submission**: NPS submissions require a valid session; anonymous submissions are rejected
 4. **Campaign overlap prevention**: Server-side check prevents overlapping active campaigns
 5. **No PII in feedback**: Feedback reasons are pre-defined chips; free-text is optional and user-initiated
-6. **Feature gating**: Feedback is enabled by default, opt-out via `FEEDBACK_ENABLED=false`; NPS is opt-in via `NPS_ENABLED=true`; all gated endpoints return disabled responses when off
-7. **MongoDB required**: Both features require MongoDB (same as existing admin features); returns 503 if not configured
+6. **Transparency disclaimers**: Both the feedback popover and NPS survey show subtle notes informing users their responses are visible to admins
+7. **Feature gating**: Feedback is enabled by default, opt-out via `FEEDBACK_ENABLED=false`; NPS is opt-in via `NPS_ENABLED=true`; all gated endpoints return disabled responses when off
+8. **MongoDB required**: Both features require MongoDB (same as existing admin features); returns 503 if not configured
 
 ## Testing
 
-### Automated Tests (1912 tests, 79 suites — all pass)
+### Automated Tests (2006 tests, 82 suites — all pass)
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|

--- a/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
+++ b/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
@@ -15,7 +15,8 @@ Added comprehensive feedback and NPS (Net Promoter Score) features to the admin 
 1. **Feedback tab** (optional, `FEEDBACK_ENABLED=true` by default): Shows all user feedback (thumbs up/down) with reasons, comments, user attribution, message context, and clickable links to source conversations
 2. **NPS tab** (optional, `NPS_ENABLED=true`): Admin-controlled campaign-based NPS tracking with score gauge, promoter/passive/detractor breakdown, trend chart, campaign management, and individual response list
 3. **Read-only admin audit**: Admins can view any conversation via feedback chat links in read-only mode without modifying it
-4. **Deep-linkable admin tabs**: Admin page supports `?tab=feedback` query parameter for direct navigation
+4. **Read-only sharing permissions**: Owners can share conversations as "Can view" (read-only) or "Can edit" (full access) per user and team, with per-team permission storage and backward-compatible defaults
+5. **Deep-linkable admin tabs**: Admin page supports `?tab=feedback` query parameter for direct navigation
 
 Also fixed the feedback persistence gap — user feedback is now saved to MongoDB alongside the existing Langfuse integration, making it visible to admins.
 
@@ -50,11 +51,24 @@ New `GET /api/admin/feedback` endpoint queries messages with `feedback.rating` s
 
 ### Read-Only Admin Audit
 
-Extended `requireConversationAccess` to return `{ conversation, access_level }` where `access_level` can be `'owner'`, `'shared'`, or `'admin_audit'`. Admins get `admin_audit` access to any conversation they don't own or have shared access to.
+Extended `requireConversationAccess` to return `{ conversation, access_level }` where `access_level` can be `'owner'`, `'shared'`, `'shared_readonly'`, or `'admin_audit'`. Admins get `admin_audit` access to any conversation they don't own or have shared access to.
 
 - `GET /api/chat/conversations/[id]` returns `access_level` in response
-- `POST /api/chat/conversations/[id]/messages` blocks writes for `admin_audit` (403)
-- `ChatPanel` renders a read-only audit banner with "Back to Feedback" link when `readOnly` is true
+- `POST /api/chat/conversations/[id]/messages` blocks writes for `admin_audit` and `shared_readonly` (403)
+- `ChatPanel` renders contextual read-only banners: "Read-Only Audit Mode" for admins, "View Only" for shared_readonly users
+
+### Read-Only Sharing Permissions
+
+The sharing model now supports per-user and per-team permission levels:
+- **Direct user shares**: Permission stored in `SharingAccess` collection (`'view'` or `'comment'`)
+- **Team shares**: Permission stored in `conversation.sharing.team_permissions` map
+- **Public shares**: Always read-only (`shared_readonly`)
+- **Backward compatibility**: Legacy shares without permission records default to `'comment'` (full access)
+
+The `ShareDialog` component now shows:
+- A default permission selector ("Can view" / "Can edit") next to the search input for new shares
+- A per-user/team permission dropdown in the access list for changing existing permissions
+- Permissions are changed via `PATCH /api/chat/conversations/[id]/share`
 
 ### NPS as Optional Feature
 
@@ -101,13 +115,14 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 | `POST` | `/api/admin/nps/campaigns` | `requireAdmin` | Create NPS campaign |
 | `GET` | `/api/admin/nps/campaigns` | `requireAdminView` | List campaigns with response counts and status |
 | `PATCH` | `/api/admin/nps/campaigns` | `requireAdmin` | Stop campaign early |
+| `PATCH` | `/api/chat/conversations/[id]/share` | owner | Update user/team permission |
 
 ### Modified API Behavior
 
 | Method | Endpoint | Change |
 |--------|----------|--------|
 | `GET` | `/api/chat/conversations/[id]` | Returns `access_level` field |
-| `POST` | `/api/chat/conversations/[id]/messages` | Blocks writes for `admin_audit` (403) |
+| `POST` | `/api/chat/conversations/[id]/messages` | Blocks writes for `admin_audit` and `shared_readonly` (403) |
 | `PUT` | `/api/chat/messages/[id]` | Stores `feedback.submitted_by` from session |
 
 ### MongoDB Collections
@@ -138,7 +153,9 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 | `ui/src/components/nps/NPSSurvey.tsx` | NPS survey component (campaign-aware) |
 | `ui/src/components/chat/ChatPanel.tsx` | Read-only audit mode, feedback persistence |
 | `ui/src/app/(app)/chat/[uuid]/page.tsx` | Wires `readOnly` prop based on access_level |
-| `ui/src/lib/api-middleware.ts` | `requireConversationAccess` with access levels |
+| `ui/src/lib/api-middleware.ts` | `requireConversationAccess` with access levels (`owner`, `shared`, `shared_readonly`, `admin_audit`) |
+| `ui/src/components/chat/ShareDialog.tsx` | Share dialog with per-user/team permission dropdowns |
+| `ui/src/app/api/chat/conversations/[id]/share/route.ts` | Share API with PATCH for permission updates |
 | `ui/src/lib/config.ts` | `feedbackEnabled` and `npsEnabled` config keys |
 | `ui/scripts/seed-feedback-nps.mjs` | Seed script for test data |
 
@@ -155,7 +172,7 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 
 ## Testing
 
-### Automated Tests (2006 tests, 82 suites — all pass)
+### Automated Tests (2024 tests, 83 suites — all pass)
 
 | Test File | Tests | Coverage |
 |-----------|-------|----------|
@@ -165,6 +182,7 @@ Admin page reads `?tab=` from query params via `useSearchParams()`. Valid tabs: 
 | `admin-nps.test.ts` | 11 | NPS calculation, campaign filtering, trend, guards |
 | `admin-audit-access.test.ts` | 11 | Access levels (owner/shared/admin_audit), conversation route, 403/404 |
 | `chat-messages.test.ts` | +3 | Write blocking for admin_audit, owner allowed, GET for audit |
+| `chat-sharing-readonly.test.ts` | 18 | Permission-based access levels, PATCH permission updates, backward compat, message blocking |
 | `config.test.ts` | +7 | `feedbackEnabled` defaults/env var tests, `npsEnabled` key presence |
 | `admin-page.test.tsx` | +fixes | Mock for `/api/admin/feedback`, `/api/admin/nps`, `useSearchParams` |
 

--- a/ui/scripts/seed-feedback-nps.mjs
+++ b/ui/scripts/seed-feedback-nps.mjs
@@ -1,0 +1,284 @@
+#!/usr/bin/env node
+
+/**
+ * Seed script — inserts sample feedback on messages and NPS responses into MongoDB
+ * so the admin Feedback and NPS tabs have data to display.
+ *
+ * Usage:
+ *   node ui/scripts/seed-feedback-nps.mjs
+ *   MONGODB_URI=mongodb://... MONGODB_DATABASE=caipe node ui/scripts/seed-feedback-nps.mjs
+ */
+
+import { MongoClient, ObjectId } from "mongodb";
+import { randomUUID } from "crypto";
+
+const uri = process.env.MONGODB_URI || "mongodb://admin:changeme@localhost:27017";
+const dbName = process.env.MONGODB_DATABASE || "caipe";
+
+const SAMPLE_USERS = [
+  "alice@example.com",
+  "bob@example.com",
+  "carol@example.com",
+  "dave@example.com",
+  "eve@example.com",
+  "frank@example.com",
+  "grace@example.com",
+];
+
+const AGENTS = [
+  "platform-engineer",
+  "github-agent",
+  "argocd-agent",
+  "komodor-agent",
+  "splunk-agent",
+];
+
+const POSITIVE_REASONS = ["Very Helpful", "Accurate", "Simplified My Task"];
+const NEGATIVE_REASONS = ["Inaccurate", "Poorly Formatted", "Incomplete", "Off-topic"];
+
+const SAMPLE_USER_MESSAGES = [
+  "How do I deploy my app to Kubernetes?",
+  "Show me the ArgoCD sync status for prod",
+  "Create a GitHub PR to fix the login bug",
+  "What's the CPU usage for the payments service?",
+  "Investigate the 5xx errors in staging",
+  "Help me write a Helm chart for Redis",
+  "Why is my pod in CrashLoopBackOff?",
+  "Set up a new GitHub repo with CI/CD",
+  "Show me Splunk logs for the auth service",
+  "How do I scale my deployment to 5 replicas?",
+  "What Kubernetes events happened in the last hour?",
+  "Help me debug this Terraform plan failure",
+  "Can you summarize the recent incident?",
+  "Update the ArgoCD application manifest",
+  "List all open PRs in the platform repo",
+];
+
+const SAMPLE_ASSISTANT_MESSAGES = [
+  "I've analyzed the deployment configuration. Here's what I recommend for your Kubernetes deployment...",
+  "The ArgoCD sync status for production shows all applications are in sync. Here's the breakdown...",
+  "I've created a pull request #142 to fix the login bug. The changes include input validation and session handling improvements...",
+  "The payments service CPU usage over the last 24 hours shows an average of 45% with peaks at 78% during high traffic...",
+  "I found 23 5xx errors in staging over the last hour. The root cause appears to be a database connection timeout...",
+  "Here's a Helm chart for Redis with high availability configuration, persistent storage, and resource limits...",
+  "Your pod is in CrashLoopBackOff because the health check endpoint /healthz is returning 503. The application logs show...",
+  "I've created the repository `platform/new-service` with GitHub Actions CI/CD pipeline, branch protection rules...",
+  "Here are the Splunk logs for the auth service. I noticed elevated latency starting at 14:23 UTC...",
+  "I've scaled the deployment `payments-api` to 5 replicas. Current status shows 5/5 pods running...",
+  "In the last hour, there were 12 Kubernetes events: 3 pod restarts, 2 HPA scaling events, and 7 normal events...",
+  "The Terraform plan failed because the AWS provider version constraint conflicts with the required module version...",
+  "Here's a summary of the recent incident: Duration 47 minutes, root cause was a misconfigured ingress rule...",
+  "I've updated the ArgoCD application manifest with the new image tag and resource limits...",
+  "There are 8 open PRs in the platform repo. Here's a summary sorted by age...",
+];
+
+const NPS_COMMENTS = [
+  "Love the multi-agent approach — it saves me so much time!",
+  "The ArgoCD integration is incredibly useful for our team.",
+  "Sometimes the responses are slow, but accuracy is great.",
+  "Would be nice to have better Terraform support.",
+  "This has replaced half of my daily kubectl commands.",
+  "The GitHub PR creation feature is a game changer.",
+  "Needs better error messages when things fail.",
+  "I use this every day — can't imagine working without it.",
+  "The Splunk log analysis is decent but could be deeper.",
+  "Great tool, but the NPS survey is a bit annoying ;)",
+  "",
+  "",
+  "",
+  "",
+];
+
+function pick(arr) {
+  return arr[Math.floor(Math.random() * arr.length)];
+}
+
+function daysAgo(n) {
+  return new Date(Date.now() - n * 24 * 60 * 60 * 1000);
+}
+
+function hoursAgo(n) {
+  return new Date(Date.now() - n * 60 * 60 * 1000);
+}
+
+async function seed() {
+  console.log(`\nConnecting to MongoDB at ${uri.replace(/\/\/.*@/, "//***@")} (db: ${dbName})...\n`);
+
+  const client = new MongoClient(uri);
+  await client.connect();
+  const db = client.db(dbName);
+
+  const conversations = db.collection("conversations");
+  const messages = db.collection("messages");
+  const npsResponses = db.collection("nps_responses");
+  const npsCampaigns = db.collection("nps_campaigns");
+
+  // ─── Create sample conversations + messages with feedback ───────────
+
+  const feedbackCount = 25;
+  let insertedConvs = 0;
+  let insertedMsgs = 0;
+  let insertedFeedback = 0;
+
+  console.log(`Creating ${feedbackCount} feedback entries across conversations...\n`);
+
+  for (let i = 0; i < feedbackCount; i++) {
+    const user = pick(SAMPLE_USERS);
+    const agent = pick(AGENTS);
+    const convId = randomUUID();
+    const daysBack = Math.floor(Math.random() * 28) + 1;
+    const createdAt = daysAgo(daysBack);
+    const userMsgIdx = i % SAMPLE_USER_MESSAGES.length;
+    const assistantMsgIdx = i % SAMPLE_ASSISTANT_MESSAGES.length;
+
+    // Insert conversation
+    await conversations.insertOne({
+      _id: convId,
+      title: SAMPLE_USER_MESSAGES[userMsgIdx].slice(0, 60),
+      owner_id: user,
+      created_at: createdAt,
+      updated_at: createdAt,
+      metadata: {
+        agent_version: "1.0.0",
+        model_used: pick(["gpt-4o", "claude-sonnet-4-20250514", "gpt-5-mini"]),
+        total_messages: 2,
+      },
+      sharing: {
+        is_public: false,
+        shared_with: [],
+        shared_with_teams: [],
+        share_link_enabled: false,
+      },
+      tags: [],
+      is_archived: false,
+      is_pinned: false,
+    });
+    insertedConvs++;
+
+    const turnId = `turn-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
+
+    // Insert user message
+    await messages.insertOne({
+      message_id: randomUUID(),
+      conversation_id: convId,
+      owner_id: user,
+      role: "user",
+      content: SAMPLE_USER_MESSAGES[userMsgIdx],
+      created_at: createdAt,
+      sender_email: user,
+      metadata: { turn_id: turnId },
+    });
+    insertedMsgs++;
+
+    // Insert assistant message WITH feedback
+    const isPositive = Math.random() > 0.35; // ~65% positive
+    const rating = isPositive ? "positive" : "negative";
+    const reasons = isPositive ? POSITIVE_REASONS : NEGATIVE_REASONS;
+    const reason = pick(reasons);
+    const feedbackTime = new Date(createdAt.getTime() + 5 * 60 * 1000); // 5 min after
+
+    await messages.insertOne({
+      message_id: randomUUID(),
+      conversation_id: convId,
+      owner_id: user,
+      role: "assistant",
+      content: SAMPLE_ASSISTANT_MESSAGES[assistantMsgIdx],
+      created_at: new Date(createdAt.getTime() + 3000),
+      metadata: {
+        turn_id: turnId,
+        agent_name: agent,
+        is_final: true,
+        latency_ms: 1500 + Math.floor(Math.random() * 8000),
+      },
+      feedback: {
+        rating,
+        comment: reason,
+        submitted_at: feedbackTime,
+        submitted_by: user,
+      },
+    });
+    insertedMsgs++;
+    insertedFeedback++;
+  }
+
+  console.log(`  ✓ ${insertedConvs} conversations created`);
+  console.log(`  ✓ ${insertedMsgs} messages created (${insertedFeedback} with feedback)`);
+
+  // ─── Create NPS campaign ───────────────────────────────────────────
+
+  console.log(`\nCreating NPS campaign...\n`);
+
+  const campaignStart = daysAgo(14);
+  const campaignEnd = new Date(Date.now() + 14 * 24 * 60 * 60 * 1000);
+
+  const campaignResult = await npsCampaigns.insertOne({
+    name: "Q1 2026 NPS",
+    starts_at: campaignStart,
+    ends_at: campaignEnd,
+    created_by: "admin@example.com",
+    created_at: campaignStart,
+  });
+
+  const campaignId = campaignResult.insertedId.toString();
+  console.log(`  ✓ Campaign "Q1 2026 NPS" created (${campaignId})`);
+  console.log(`    Active: ${campaignStart.toISOString()} → ${campaignEnd.toISOString()}`);
+
+  // ─── Create NPS responses (linked to campaign) ────────────────────
+
+  const npsCount = 30;
+  const npsEntries = [];
+
+  console.log(`\nCreating ${npsCount} NPS responses...\n`);
+
+  for (let i = 0; i < npsCount; i++) {
+    const daysBack = Math.floor(Math.random() * 14) + 1;
+    // Weighted score distribution: skew toward 7-10 for a realistic positive NPS
+    let score;
+    const rand = Math.random();
+    if (rand < 0.15) score = Math.floor(Math.random() * 5);          // 0-4 (detractors)
+    else if (rand < 0.30) score = 5 + Math.floor(Math.random() * 2); // 5-6 (detractors)
+    else if (rand < 0.50) score = 7 + Math.floor(Math.random() * 2); // 7-8 (passives)
+    else score = 9 + Math.floor(Math.random() * 2);                  // 9-10 (promoters)
+
+    const comment = pick(NPS_COMMENTS);
+
+    npsEntries.push({
+      user_email: pick(SAMPLE_USERS),
+      score,
+      comment: comment || undefined,
+      campaign_id: campaignId,
+      created_at: daysAgo(daysBack),
+    });
+  }
+
+  await npsResponses.insertMany(npsEntries);
+
+  // Compute and display NPS summary
+  const promoters = npsEntries.filter((r) => r.score >= 9).length;
+  const passives = npsEntries.filter((r) => r.score >= 7 && r.score <= 8).length;
+  const detractors = npsEntries.filter((r) => r.score <= 6).length;
+  const npsScore = Math.round(((promoters - detractors) / npsCount) * 100);
+
+  console.log(`  ✓ ${npsCount} NPS responses created (linked to campaign)`);
+  console.log(`    Promoters (9-10): ${promoters}`);
+  console.log(`    Passives  (7-8):  ${passives}`);
+  console.log(`    Detractors (0-6): ${detractors}`);
+  console.log(`    NPS Score:        ${npsScore > 0 ? "+" : ""}${npsScore}`);
+
+  // ─── Summary ───────────────────────────────────────────────────────
+
+  console.log(`\n${"═".repeat(55)}`);
+  console.log(`  Seed complete!`);
+  console.log(`  ${insertedConvs} conversations, ${insertedMsgs} messages, ${insertedFeedback} feedback`);
+  console.log(`  1 NPS campaign, ${npsCount} NPS responses`);
+  console.log(`${"═".repeat(55)}`);
+  console.log(`\n  Open the admin dashboard → Feedback tab to view feedback`);
+  console.log(`  Open the admin dashboard → NPS tab to view NPS score and campaigns\n`);
+
+  await client.close();
+}
+
+seed().catch((err) => {
+  console.error("Seed failed:", err);
+  process.exit(1);
+});

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -27,6 +27,10 @@ jest.mock('next-auth/react', () => ({
   useSession: () => ({ data: { user: { email: 'test@example.com' } }, ...mockSessionStatus }),
 }));
 
+jest.mock('next/navigation', () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 jest.mock('@/components/auth-guard', () => ({
   AuthGuard: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
@@ -150,6 +154,31 @@ const mockTeamsResponse = {
   },
 };
 
+const mockFeedbackResponse = {
+  success: true,
+  data: {
+    entries: [],
+    pagination: { page: 1, limit: 50, total: 0, total_pages: 0 },
+  },
+};
+
+const mockNpsResponse = {
+  success: true,
+  data: {
+    nps_score: 0,
+    total_responses: 0,
+    breakdown: { promoters: 0, passives: 0, detractors: 0, promoter_pct: 0, passive_pct: 0, detractor_pct: 0 },
+    trend: [],
+    recent_responses: [],
+    campaigns: [],
+  },
+};
+
+const mockConfigResponse = {
+  success: true,
+  data: { npsEnabled: false },
+};
+
 function setupFetchMock(overrides: Record<string, any> = {}) {
   (global.fetch as jest.Mock) = jest.fn((url: string) => {
     if (url.includes('/api/admin/stats') && !url.includes('skills')) {
@@ -177,6 +206,27 @@ function setupFetchMock(overrides: Record<string, any> = {}) {
       return Promise.resolve({
         ok: true,
         json: () => Promise.resolve({ success: false }),
+      });
+    }
+    if (url.includes('/api/admin/feedback')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(overrides.feedback || mockFeedbackResponse),
+      });
+    }
+    if (url.includes('/api/admin/nps')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(overrides.nps || mockNpsResponse),
+      });
+    }
+    if (url.includes('/api/config')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve(overrides.config || mockConfigResponse),
       });
     }
     return Promise.resolve({

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
+import { useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { motion } from "framer-motion";
-import { Users, MessageSquare, TrendingUp, Activity, Database, Share2, ShieldCheck, ShieldOff, UserPlus, Trash2, UsersIcon, Loader2, Bot, ThumbsUp, ThumbsDown, Clock, Zap, CheckCircle2, AlertCircle, Layers, Eye } from "lucide-react";
+import { Users, MessageSquare, TrendingUp, Activity, Database, Share2, ShieldCheck, ShieldOff, UserPlus, Trash2, UsersIcon, Loader2, Bot, ThumbsUp, ThumbsDown, Clock, Zap, CheckCircle2, AlertCircle, Layers, Eye, Star, Filter, ExternalLink, Plus, Calendar, X } from "lucide-react";
 import { AuthGuard } from "@/components/auth-guard";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -24,6 +25,7 @@ import { CreateTeamDialog } from "@/components/admin/CreateTeamDialog";
 import { TeamDetailsDialog } from "@/components/admin/TeamDetailsDialog";
 import { useAdminRole } from "@/hooks/use-admin-role";
 import { apiClient } from "@/lib/api-client";
+import { getConfig } from "@/lib/config";
 import type { Team as TeamType } from "@/types/teams";
 import type { SkillMetricsAdmin } from "@/types/agent-config";
 
@@ -71,6 +73,65 @@ interface AdminStats {
   };
 }
 
+interface FeedbackEntry {
+  message_id: string;
+  conversation_id: string;
+  conversation_title?: string;
+  content_snippet: string;
+  role: string;
+  rating: 'positive' | 'negative';
+  reason?: string;
+  submitted_by: string;
+  submitted_at: string;
+}
+
+interface FeedbackData {
+  entries: FeedbackEntry[];
+  pagination: {
+    page: number;
+    limit: number;
+    total: number;
+    total_pages: number;
+  };
+}
+
+interface NPSCampaign {
+  _id: string;
+  name: string;
+  starts_at: string;
+  ends_at: string;
+  created_by: string;
+  created_at: string;
+  response_count: number;
+  status: 'active' | 'ended' | 'scheduled';
+}
+
+interface NPSData {
+  nps_score: number;
+  total_responses: number;
+  campaigns?: NPSCampaign[];
+  breakdown: {
+    promoters: number;
+    passives: number;
+    detractors: number;
+    promoter_pct: number;
+    passive_pct: number;
+    detractor_pct: number;
+  };
+  trend: Array<{
+    date: string;
+    avg_score: number | null;
+    count: number;
+    nps: number | null;
+  }>;
+  recent_responses: Array<{
+    user_email: string;
+    score: number;
+    comment?: string;
+    created_at: string;
+  }>;
+}
+
 interface UserInfo {
   email: string;
   name: string;
@@ -97,8 +158,11 @@ interface Team {
   }>;
 }
 
+const VALID_TABS = ['users', 'teams', 'stats', 'skills', 'feedback', 'nps', 'metrics', 'health'];
+
 function AdminPage() {
   const { status } = useSession();
+  const searchParams = useSearchParams();
   const { isAdmin } = useAdminRole();
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [skillStats, setSkillStats] = useState<SkillMetricsAdmin | null>(null);
@@ -107,12 +171,28 @@ function AdminPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [updatingRole, setUpdatingRole] = useState<string | null>(null);
-  const [activeTab, setActiveTab] = useState("users");
+  const initialTab = searchParams.get('tab');
+  const [activeTab, setActiveTab] = useState(
+    initialTab && VALID_TABS.includes(initialTab) ? initialTab : 'users'
+  );
   const [createTeamDialogOpen, setCreateTeamDialogOpen] = useState(false);
   const [teamDetailsOpen, setTeamDetailsOpen] = useState(false);
   const [selectedTeam, setSelectedTeam] = useState<TeamType | null>(null);
   const [teamDialogMode, setTeamDialogMode] = useState<"details" | "members">("details");
   const [deletingTeam, setDeletingTeam] = useState<string | null>(null);
+  const [feedbackData, setFeedbackData] = useState<FeedbackData | null>(null);
+  const [feedbackFilter, setFeedbackFilter] = useState<'all' | 'positive' | 'negative'>('all');
+  const [feedbackLoading, setFeedbackLoading] = useState(false);
+  const [npsData, setNpsData] = useState<NPSData | null>(null);
+  const [showCampaignForm, setShowCampaignForm] = useState(false);
+  const [campaignName, setCampaignName] = useState("");
+  const [campaignStartDate, setCampaignStartDate] = useState("");
+  const [campaignEndDate, setCampaignEndDate] = useState("");
+  const [creatingCampaign, setCreatingCampaign] = useState(false);
+  const [selectedCampaignId, setSelectedCampaignId] = useState<string | null>(null);
+  const [npsLoading, setNpsLoading] = useState(false);
+  const [stoppingCampaign, setStoppingCampaign] = useState<string | null>(null);
+  const [confirmStopCampaign, setConfirmStopCampaign] = useState<string | null>(null);
 
   useEffect(() => {
     // Only fetch admin data once the user is authenticated
@@ -126,12 +206,15 @@ function AdminPage() {
     setError(null);
 
     try {
-      // Fetch stats, users, teams, and skill metrics in parallel
-      const [statsRes, usersRes, teamsRes, skillStatsRes] = await Promise.all([
+      const npsOn = getConfig('npsEnabled');
+      // Fetch stats, users, teams, skill metrics, feedback, and NPS in parallel
+      const [statsRes, usersRes, teamsRes, skillStatsRes, feedbackRes, npsRes] = await Promise.all([
         fetch('/api/admin/stats'),
         fetch('/api/admin/users'),
         fetch('/api/admin/teams').catch(() => null),
         fetch('/api/admin/stats/skills').catch(() => null),
+        fetch('/api/admin/feedback').catch(() => null),
+        npsOn ? fetch('/api/admin/nps').catch(() => null) : null,
       ]);
 
       if (statsRes.status === 401 || usersRes.status === 401) {
@@ -168,11 +251,127 @@ function AdminPage() {
           setSkillStats(skillStatsResponse.data);
         }
       }
+
+      if (feedbackRes?.ok) {
+        const feedbackResponse = await feedbackRes.json().catch(() => ({ success: false }));
+        if (feedbackResponse.success) {
+          setFeedbackData(feedbackResponse.data);
+        }
+      }
+
+      if (npsRes?.ok) {
+        const npsResponse = await npsRes.json().catch(() => ({ success: false }));
+        if (npsResponse.success) {
+          setNpsData(npsResponse.data);
+        }
+      }
     } catch (err: any) {
       console.error('[Admin] Failed to load data:', err);
       setError(err.message || 'Failed to load admin data');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const loadFeedback = async (rating?: 'positive' | 'negative' | 'all', page = 1) => {
+    setFeedbackLoading(true);
+    try {
+      const params = new URLSearchParams({ page: String(page), limit: '50' });
+      if (rating && rating !== 'all') params.set('rating', rating);
+      const res = await fetch(`/api/admin/feedback?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.success) setFeedbackData(data.data);
+      }
+    } catch (err) {
+      console.error('[Admin] Failed to load feedback:', err);
+    } finally {
+      setFeedbackLoading(false);
+    }
+  };
+
+  const handleFeedbackFilterChange = (filter: 'all' | 'positive' | 'negative') => {
+    setFeedbackFilter(filter);
+    loadFeedback(filter);
+  };
+
+  const loadNpsData = async (campaignId?: string | null) => {
+    setNpsLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (campaignId) params.set('campaign_id', campaignId);
+      const res = await fetch(`/api/admin/nps?${params}`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.success) setNpsData(data.data);
+      }
+    } catch (err) {
+      console.error('[Admin] Failed to load NPS data:', err);
+    } finally {
+      setNpsLoading(false);
+    }
+  };
+
+  const handleCampaignSelect = (campaignId: string) => {
+    if (selectedCampaignId === campaignId) {
+      setSelectedCampaignId(null);
+      loadNpsData();
+    } else {
+      setSelectedCampaignId(campaignId);
+      loadNpsData(campaignId);
+    }
+  };
+
+  const handleCreateCampaign = async () => {
+    if (!campaignName.trim() || !campaignStartDate || !campaignEndDate) return;
+    setCreatingCampaign(true);
+    try {
+      const res = await fetch('/api/admin/nps/campaigns', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name: campaignName.trim(),
+          starts_at: new Date(campaignStartDate).toISOString(),
+          ends_at: new Date(campaignEndDate).toISOString(),
+        }),
+      });
+      const result = await res.json();
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to create campaign');
+      }
+      setCampaignName("");
+      setCampaignStartDate("");
+      setCampaignEndDate("");
+      setShowCampaignForm(false);
+      setSelectedCampaignId(null);
+      await loadNpsData();
+    } catch (err: any) {
+      console.error('[Admin] Failed to create campaign:', err);
+      alert(`Failed to create campaign: ${err.message}`);
+    } finally {
+      setCreatingCampaign(false);
+    }
+  };
+
+  const handleStopCampaign = async (campaignId: string) => {
+    setStoppingCampaign(campaignId);
+    setConfirmStopCampaign(null);
+    try {
+      const res = await fetch('/api/admin/nps/campaigns', {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ campaign_id: campaignId }),
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || 'Failed to stop campaign');
+      }
+      await loadNpsData(selectedCampaignId);
+    } catch (err: any) {
+      console.error('[Admin] Failed to stop campaign:', err);
+      alert(`Failed to stop campaign: ${err.message}`);
+    } finally {
+      setStoppingCampaign(null);
     }
   };
 
@@ -348,7 +547,7 @@ function AdminPage() {
 
             {/* Tabbed Content */}
             <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
-              <TabsList className="grid w-full grid-cols-6">
+              <TabsList className={`grid w-full ${getConfig('npsEnabled') ? 'grid-cols-8' : 'grid-cols-7'}`}>
                 <TabsTrigger value="users" className="gap-2">
                   <Users className="h-4 w-4" />
                   Users
@@ -361,6 +560,16 @@ function AdminPage() {
                   <Layers className="h-4 w-4" />
                   Skills
                 </TabsTrigger>
+                <TabsTrigger value="feedback" className="gap-2">
+                  <ThumbsUp className="h-4 w-4" />
+                  Feedback
+                </TabsTrigger>
+                {getConfig('npsEnabled') && (
+                <TabsTrigger value="nps" className="gap-2">
+                  <Star className="h-4 w-4" />
+                  NPS
+                </TabsTrigger>
+                )}
                 <TabsTrigger value="stats" className="gap-2">
                   <TrendingUp className="h-4 w-4" />
                   Statistics
@@ -680,6 +889,547 @@ function AdminPage() {
                   </Card>
                 )}
               </TabsContent>
+
+              {/* Feedback Tab */}
+              <TabsContent value="feedback" className="space-y-4">
+                <Card>
+                  <CardHeader>
+                    <div className="flex items-center justify-between">
+                      <div>
+                        <CardTitle className="flex items-center gap-2">
+                          <ThumbsUp className="h-5 w-5" />
+                          User Feedback
+                        </CardTitle>
+                        <CardDescription>
+                          All feedback submitted by users on assistant responses
+                        </CardDescription>
+                      </div>
+                      <div className="flex gap-1">
+                        {(['all', 'positive', 'negative'] as const).map((f) => (
+                          <Button
+                            key={f}
+                            size="sm"
+                            variant={feedbackFilter === f ? 'default' : 'outline'}
+                            onClick={() => handleFeedbackFilterChange(f)}
+                            className="gap-1.5 h-8 text-xs capitalize"
+                          >
+                            {f === 'positive' && <ThumbsUp className="h-3 w-3" />}
+                            {f === 'negative' && <ThumbsDown className="h-3 w-3" />}
+                            {f === 'all' && <Filter className="h-3 w-3" />}
+                            {f}
+                          </Button>
+                        ))}
+                      </div>
+                    </div>
+                  </CardHeader>
+                  <CardContent>
+                    {feedbackLoading ? (
+                      <div className="flex justify-center py-8">
+                        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                      </div>
+                    ) : feedbackData?.entries?.length > 0 ? (
+                      <div className="space-y-2">
+                        <div className="grid grid-cols-7 gap-4 pb-2 border-b text-xs font-medium text-muted-foreground">
+                          <div>User</div>
+                          <div>Rating</div>
+                          <div>Reason</div>
+                          <div className="col-span-2">Message Preview</div>
+                          <div>Date</div>
+                          <div>Chat</div>
+                        </div>
+                        {feedbackData.entries.map((entry, i) => (
+                          <div key={`${entry.message_id}-${i}`} className="grid grid-cols-7 gap-4 py-2 text-sm hover:bg-muted/50 rounded px-2 items-center">
+                            <div className="truncate text-xs">{entry.submitted_by}</div>
+                            <div>
+                              <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs ${
+                                entry.rating === 'positive'
+                                  ? 'bg-green-500/10 text-green-600 dark:text-green-400'
+                                  : 'bg-red-500/10 text-red-600 dark:text-red-400'
+                              }`}>
+                                {entry.rating === 'positive' ? (
+                                  <ThumbsUp className="h-3 w-3" />
+                                ) : (
+                                  <ThumbsDown className="h-3 w-3" />
+                                )}
+                                {entry.rating}
+                              </span>
+                            </div>
+                            <div className="text-xs text-muted-foreground truncate">
+                              {entry.reason || '—'}
+                            </div>
+                            <div className="col-span-2 text-xs text-muted-foreground truncate">
+                              {entry.content_snippet || '—'}
+                            </div>
+                            <div className="text-xs text-muted-foreground">
+                              {entry.submitted_at
+                                ? new Date(entry.submitted_at).toLocaleDateString()
+                                : '—'}
+                            </div>
+                            <div>
+                              {entry.conversation_id ? (
+                                <a
+                                  href={`/chat/${entry.conversation_id}`}
+                                  target="_blank"
+                                  rel="noopener noreferrer"
+                                  className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
+                                  title={entry.conversation_title || 'View conversation'}
+                                >
+                                  <ExternalLink className="h-3 w-3" />
+                                  {entry.conversation_title
+                                    ? entry.conversation_title.length > 20
+                                      ? entry.conversation_title.slice(0, 20) + '…'
+                                      : entry.conversation_title
+                                    : 'View'}
+                                </a>
+                              ) : (
+                                <span className="text-xs text-muted-foreground">—</span>
+                              )}
+                            </div>
+                          </div>
+                        ))}
+                        {feedbackData.pagination.total_pages > 1 && (
+                          <div className="flex justify-center gap-2 pt-4">
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              disabled={feedbackData.pagination.page <= 1}
+                              onClick={() => loadFeedback(feedbackFilter, feedbackData.pagination.page - 1)}
+                            >
+                              Previous
+                            </Button>
+                            <span className="text-sm text-muted-foreground flex items-center">
+                              Page {feedbackData.pagination.page} of {feedbackData.pagination.total_pages}
+                            </span>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              disabled={feedbackData.pagination.page >= feedbackData.pagination.total_pages}
+                              onClick={() => loadFeedback(feedbackFilter, feedbackData.pagination.page + 1)}
+                            >
+                              Next
+                            </Button>
+                          </div>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="text-center py-12">
+                        <ThumbsUp className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+                        <h3 className="text-lg font-semibold mb-2">No Feedback Yet</h3>
+                        <p className="text-muted-foreground">
+                          User feedback will appear here once users start rating assistant responses.
+                        </p>
+                      </div>
+                    )}
+                  </CardContent>
+                </Card>
+              </TabsContent>
+
+              {/* NPS Tab */}
+              {getConfig('npsEnabled') && <TabsContent value="nps" className="space-y-4">
+                {/* Campaign Management */}
+                {isAdmin && (
+                  <Card>
+                    <CardHeader>
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <CardTitle className="flex items-center gap-2">
+                            <Calendar className="h-5 w-5" />
+                            NPS Campaigns
+                          </CardTitle>
+                          <CardDescription>Create and manage NPS survey campaigns</CardDescription>
+                        </div>
+                        <Button
+                          size="sm"
+                          onClick={() => setShowCampaignForm(!showCampaignForm)}
+                          className="gap-1"
+                        >
+                          <Plus className="h-4 w-4" />
+                          Launch Campaign
+                        </Button>
+                      </div>
+                    </CardHeader>
+                    <CardContent>
+                      {/* Create Campaign Form */}
+                      {showCampaignForm && (
+                        <div className="mb-4 p-4 border border-border rounded-lg bg-muted/30 space-y-3">
+                          <div>
+                            <label className="text-xs font-medium text-muted-foreground">Campaign Name</label>
+                            <input
+                              type="text"
+                              value={campaignName}
+                              onChange={(e) => setCampaignName(e.target.value)}
+                              placeholder="e.g. Q1 2026 NPS"
+                              className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+                              maxLength={100}
+                            />
+                          </div>
+                          <div className="grid grid-cols-2 gap-3">
+                            <div>
+                              <label className="text-xs font-medium text-muted-foreground">Start Date</label>
+                              <input
+                                type="datetime-local"
+                                value={campaignStartDate}
+                                onChange={(e) => setCampaignStartDate(e.target.value)}
+                                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+                              />
+                            </div>
+                            <div>
+                              <label className="text-xs font-medium text-muted-foreground">End Date</label>
+                              <input
+                                type="datetime-local"
+                                value={campaignEndDate}
+                                onChange={(e) => setCampaignEndDate(e.target.value)}
+                                className="mt-1 w-full px-3 py-2 text-sm bg-background border border-border rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50"
+                              />
+                            </div>
+                          </div>
+                          <div className="flex gap-2 pt-1">
+                            <Button
+                              variant="outline"
+                              size="sm"
+                              onClick={() => setShowCampaignForm(false)}
+                            >
+                              Cancel
+                            </Button>
+                            <Button
+                              size="sm"
+                              onClick={handleCreateCampaign}
+                              disabled={!campaignName.trim() || !campaignStartDate || !campaignEndDate || creatingCampaign}
+                              className="gap-1"
+                            >
+                              {creatingCampaign && <Loader2 className="h-3 w-3 animate-spin" />}
+                              Create Campaign
+                            </Button>
+                          </div>
+                        </div>
+                      )}
+
+                      {/* Campaign List */}
+                      {npsData?.campaigns && npsData.campaigns.length > 0 ? (
+                        <div className="space-y-2">
+                          <div className="grid grid-cols-6 gap-4 pb-2 border-b text-xs font-medium text-muted-foreground">
+                            <div>Campaign</div>
+                            <div>Start</div>
+                            <div>End</div>
+                            <div>Responses</div>
+                            <div>Status</div>
+                            {isAdmin && <div></div>}
+                          </div>
+                          {npsData.campaigns.map((c) => (
+                            <div
+                              key={c._id}
+                              className={`grid grid-cols-6 gap-4 py-2 text-sm rounded px-2 items-center w-full transition-colors ${
+                                selectedCampaignId === c._id
+                                  ? 'bg-primary/10 ring-1 ring-primary/30'
+                                  : 'hover:bg-muted/50'
+                              }`}
+                            >
+                              <button
+                                onClick={() => handleCampaignSelect(c._id)}
+                                className="font-medium truncate text-left"
+                              >
+                                {c.name}
+                              </button>
+                              <button onClick={() => handleCampaignSelect(c._id)} className="text-xs text-muted-foreground text-left">
+                                {new Date(c.starts_at).toLocaleDateString()}
+                              </button>
+                              <button onClick={() => handleCampaignSelect(c._id)} className="text-xs text-muted-foreground text-left">
+                                {new Date(c.ends_at).toLocaleDateString()}
+                              </button>
+                              <button onClick={() => handleCampaignSelect(c._id)} className="text-xs text-left">
+                                {c.response_count}
+                              </button>
+                              <div>
+                                <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${
+                                  c.status === 'active'
+                                    ? 'bg-green-500/10 text-green-600 dark:text-green-400'
+                                    : c.status === 'scheduled'
+                                    ? 'bg-blue-500/10 text-blue-600 dark:text-blue-400'
+                                    : 'bg-muted text-muted-foreground'
+                                }`}>
+                                  {c.status === 'active' ? 'Active' : c.status === 'scheduled' ? 'Scheduled' : 'Ended'}
+                                </span>
+                              </div>
+                              <div className="flex items-center gap-1">
+                                {isAdmin && c.status !== 'ended' && (
+                                  stoppingCampaign === c._id ? (
+                                    <span className="inline-flex items-center gap-1 text-xs text-muted-foreground">
+                                      <Loader2 className="h-3 w-3 animate-spin" />
+                                      Stopping…
+                                    </span>
+                                  ) : confirmStopCampaign === c._id ? (
+                                    <>
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-6 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+                                        onClick={(e) => { e.stopPropagation(); handleStopCampaign(c._id); }}
+                                      >
+                                        Confirm
+                                      </Button>
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="h-6 px-2 text-xs"
+                                        onClick={(e) => { e.stopPropagation(); setConfirmStopCampaign(null); }}
+                                      >
+                                        Cancel
+                                      </Button>
+                                    </>
+                                  ) : (
+                                    <Button
+                                      variant="ghost"
+                                      size="sm"
+                                      className="h-6 px-2 text-xs text-destructive hover:text-destructive hover:bg-destructive/10"
+                                      onClick={(e) => { e.stopPropagation(); setConfirmStopCampaign(c._id); }}
+                                    >
+                                      <X className="h-3 w-3 mr-1" />
+                                      Stop
+                                    </Button>
+                                  )
+                                )}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      ) : (
+                        <p className="text-sm text-muted-foreground text-center py-4">
+                          No campaigns created yet. Launch your first NPS campaign to start collecting feedback.
+                        </p>
+                      )}
+                    </CardContent>
+                  </Card>
+                )}
+
+                {/* Campaign filter indicator */}
+                {selectedCampaignId && npsData?.campaigns && (
+                  <div className="flex items-center gap-2 px-1">
+                    <span className="text-sm text-muted-foreground">
+                      Viewing results for:
+                    </span>
+                    <span className="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium bg-primary/10 text-primary border border-primary/20">
+                      {npsData.campaigns.find((c) => c._id === selectedCampaignId)?.name || 'Campaign'}
+                    </span>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      className="h-6 px-2 text-xs text-muted-foreground"
+                      onClick={() => { setSelectedCampaignId(null); loadNpsData(); }}
+                    >
+                      <X className="h-3 w-3 mr-1" />
+                      Clear filter
+                    </Button>
+                  </div>
+                )}
+
+                {npsLoading ? (
+                  <div className="flex items-center justify-center py-12">
+                    <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                  </div>
+                ) : npsData && npsData.total_responses > 0 ? (
+                  <>
+                    {/* NPS Score + Breakdown */}
+                    <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+                      {/* NPS Score Card */}
+                      <Card className="lg:col-span-1">
+                        <CardHeader>
+                          <CardTitle className="flex items-center gap-2">
+                            <Star className="h-5 w-5" />
+                            NPS Score
+                          </CardTitle>
+                          <CardDescription>Net Promoter Score (-100 to +100)</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                          <div className="text-center">
+                            <p className={`text-6xl font-bold ${
+                              npsData.nps_score >= 50 ? 'text-green-500' :
+                              npsData.nps_score >= 0 ? 'text-amber-500' :
+                              'text-red-500'
+                            }`}>
+                              {npsData.nps_score > 0 ? '+' : ''}{npsData.nps_score}
+                            </p>
+                            <p className="text-sm text-muted-foreground mt-2">
+                              Based on {npsData.total_responses} response{npsData.total_responses !== 1 ? 's' : ''}
+                            </p>
+                            <p className={`text-xs mt-1 ${
+                              npsData.nps_score >= 50 ? 'text-green-500' :
+                              npsData.nps_score >= 0 ? 'text-amber-500' :
+                              'text-red-500'
+                            }`}>
+                              {npsData.nps_score >= 70 ? 'Excellent' :
+                               npsData.nps_score >= 50 ? 'Great' :
+                               npsData.nps_score >= 0 ? 'Good' :
+                               npsData.nps_score >= -50 ? 'Needs Improvement' :
+                               'Critical'}
+                            </p>
+                          </div>
+                        </CardContent>
+                      </Card>
+
+                      {/* Breakdown Card */}
+                      <Card className="lg:col-span-2">
+                        <CardHeader>
+                          <CardTitle>Response Breakdown</CardTitle>
+                          <CardDescription>Promoters (9-10), Passives (7-8), Detractors (0-6)</CardDescription>
+                        </CardHeader>
+                        <CardContent>
+                          <div className="space-y-4">
+                            {/* Stacked bar */}
+                            <div className="h-8 flex rounded-full overflow-hidden">
+                              {npsData.breakdown.promoter_pct > 0 && (
+                                <div
+                                  className="bg-green-500 flex items-center justify-center text-white text-xs font-medium"
+                                  style={{ width: `${npsData.breakdown.promoter_pct}%` }}
+                                >
+                                  {npsData.breakdown.promoter_pct}%
+                                </div>
+                              )}
+                              {npsData.breakdown.passive_pct > 0 && (
+                                <div
+                                  className="bg-amber-500 flex items-center justify-center text-white text-xs font-medium"
+                                  style={{ width: `${npsData.breakdown.passive_pct}%` }}
+                                >
+                                  {npsData.breakdown.passive_pct}%
+                                </div>
+                              )}
+                              {npsData.breakdown.detractor_pct > 0 && (
+                                <div
+                                  className="bg-red-500 flex items-center justify-center text-white text-xs font-medium"
+                                  style={{ width: `${npsData.breakdown.detractor_pct}%` }}
+                                >
+                                  {npsData.breakdown.detractor_pct}%
+                                </div>
+                              )}
+                            </div>
+
+                            <div className="grid grid-cols-3 gap-4 text-center">
+                              <div className="p-3 rounded-lg bg-green-500/10">
+                                <p className="text-2xl font-bold text-green-500">{npsData.breakdown.promoters}</p>
+                                <p className="text-xs text-muted-foreground">Promoters (9-10)</p>
+                              </div>
+                              <div className="p-3 rounded-lg bg-amber-500/10">
+                                <p className="text-2xl font-bold text-amber-500">{npsData.breakdown.passives}</p>
+                                <p className="text-xs text-muted-foreground">Passives (7-8)</p>
+                              </div>
+                              <div className="p-3 rounded-lg bg-red-500/10">
+                                <p className="text-2xl font-bold text-red-500">{npsData.breakdown.detractors}</p>
+                                <p className="text-xs text-muted-foreground">Detractors (0-6)</p>
+                              </div>
+                            </div>
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </div>
+
+                    {/* NPS Trend Chart */}
+                    {(() => {
+                      const trendWithData = npsData.trend.filter((d) => d.count > 0);
+                      return trendWithData.length > 0 ? (
+                        <Card>
+                          <CardHeader>
+                            <CardTitle>NPS Trend (Last 30 Days)</CardTitle>
+                            <CardDescription>Daily average score and response count</CardDescription>
+                          </CardHeader>
+                          <CardContent>
+                            <SimpleLineChart
+                              data={npsData.trend
+                                .filter((d) => d.avg_score !== null)
+                                .map((d) => ({
+                                  label: new Date(d.date).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }),
+                                  value: d.avg_score!,
+                                }))}
+                              height={200}
+                              color="rgb(234, 179, 8)"
+                            />
+                            <div className="mt-4 grid grid-cols-3 gap-4 text-center">
+                              <div>
+                                <p className="text-lg font-bold">
+                                  {(trendWithData.reduce((sum, d) => sum + (d.avg_score || 0), 0) / trendWithData.length).toFixed(1)}
+                                </p>
+                                <p className="text-xs text-muted-foreground">Avg Score (30d)</p>
+                              </div>
+                              <div>
+                                <p className="text-lg font-bold">
+                                  {trendWithData.reduce((sum, d) => sum + d.count, 0)}
+                                </p>
+                                <p className="text-xs text-muted-foreground">Responses (30d)</p>
+                              </div>
+                              <div>
+                                <p className="text-lg font-bold">
+                                  {(trendWithData.reduce((sum, d) => sum + d.count, 0) / 30).toFixed(1)}
+                                </p>
+                                <p className="text-xs text-muted-foreground">Avg/Day</p>
+                              </div>
+                            </div>
+                          </CardContent>
+                        </Card>
+                      ) : null;
+                    })()}
+
+                    {/* Recent NPS Responses */}
+                    <Card>
+                      <CardHeader>
+                        <CardTitle>Recent Responses</CardTitle>
+                        <CardDescription>Latest NPS survey submissions</CardDescription>
+                      </CardHeader>
+                      <CardContent>
+                        <div className="space-y-2">
+                          <div className="grid grid-cols-4 gap-4 pb-2 border-b text-xs font-medium text-muted-foreground">
+                            <div>User</div>
+                            <div>Score</div>
+                            <div>Comment</div>
+                            <div>Date</div>
+                          </div>
+                          {npsData.recent_responses.map((resp, i) => (
+                            <div key={`${resp.user_email}-${i}`} className="grid grid-cols-4 gap-4 py-2 text-sm hover:bg-muted/50 rounded px-2 items-center">
+                              <div className="truncate text-xs">{resp.user_email}</div>
+                              <div>
+                                <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+                                  resp.score >= 9 ? 'bg-green-500/10 text-green-600 dark:text-green-400' :
+                                  resp.score >= 7 ? 'bg-amber-500/10 text-amber-600 dark:text-amber-400' :
+                                  'bg-red-500/10 text-red-600 dark:text-red-400'
+                                }`}>
+                                  {resp.score}/10
+                                </span>
+                              </div>
+                              <div className="text-xs text-muted-foreground truncate">
+                                {resp.comment || '—'}
+                              </div>
+                              <div className="text-xs text-muted-foreground">
+                                {new Date(resp.created_at).toLocaleDateString()}
+                              </div>
+                            </div>
+                          ))}
+                        </div>
+                      </CardContent>
+                    </Card>
+                  </>
+                ) : (
+                  <Card>
+                    <CardContent className="pt-6 text-center py-12">
+                      <Star className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+                      <h3 className="text-lg font-semibold mb-2">
+                        {selectedCampaignId ? 'No Responses for This Campaign' : 'No NPS Data'}
+                      </h3>
+                      <p className="text-muted-foreground">
+                        {selectedCampaignId
+                          ? 'This campaign has not received any NPS responses yet.'
+                          : 'NPS survey responses will appear here once users start submitting them.'}
+                      </p>
+                      {selectedCampaignId && (
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="mt-4"
+                          onClick={() => { setSelectedCampaignId(null); loadNpsData(); }}
+                        >
+                          View All Results
+                        </Button>
+                      )}
+                    </CardContent>
+                  </Card>
+                )}
+              </TabsContent>}
 
               {/* Usage Statistics Tab */}
               <TabsContent value="stats" className="space-y-4">

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -206,6 +206,7 @@ function AdminPage() {
     setError(null);
 
     try {
+      const feedbackOn = getConfig('feedbackEnabled');
       const npsOn = getConfig('npsEnabled');
       // Fetch stats, users, teams, skill metrics, feedback, and NPS in parallel
       const [statsRes, usersRes, teamsRes, skillStatsRes, feedbackRes, npsRes] = await Promise.all([
@@ -213,7 +214,7 @@ function AdminPage() {
         fetch('/api/admin/users'),
         fetch('/api/admin/teams').catch(() => null),
         fetch('/api/admin/stats/skills').catch(() => null),
-        fetch('/api/admin/feedback').catch(() => null),
+        feedbackOn ? fetch('/api/admin/feedback').catch(() => null) : null,
         npsOn ? fetch('/api/admin/nps').catch(() => null) : null,
       ]);
 
@@ -547,7 +548,11 @@ function AdminPage() {
 
             {/* Tabbed Content */}
             <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
-              <TabsList className={`grid w-full ${getConfig('npsEnabled') ? 'grid-cols-8' : 'grid-cols-7'}`}>
+              <TabsList className={`grid w-full ${
+                getConfig('feedbackEnabled') && getConfig('npsEnabled') ? 'grid-cols-8' :
+                getConfig('feedbackEnabled') || getConfig('npsEnabled') ? 'grid-cols-7' :
+                'grid-cols-6'
+              }`}>
                 <TabsTrigger value="users" className="gap-2">
                   <Users className="h-4 w-4" />
                   Users
@@ -560,10 +565,12 @@ function AdminPage() {
                   <Layers className="h-4 w-4" />
                   Skills
                 </TabsTrigger>
+                {getConfig('feedbackEnabled') && (
                 <TabsTrigger value="feedback" className="gap-2">
                   <ThumbsUp className="h-4 w-4" />
                   Feedback
                 </TabsTrigger>
+                )}
                 {getConfig('npsEnabled') && (
                 <TabsTrigger value="nps" className="gap-2">
                   <Star className="h-4 w-4" />
@@ -891,7 +898,7 @@ function AdminPage() {
               </TabsContent>
 
               {/* Feedback Tab */}
-              <TabsContent value="feedback" className="space-y-4">
+              {getConfig('feedbackEnabled') && <TabsContent value="feedback" className="space-y-4">
                 <Card>
                   <CardHeader>
                     <div className="flex items-center justify-between">
@@ -1022,7 +1029,7 @@ function AdminPage() {
                     )}
                   </CardContent>
                 </Card>
-              </TabsContent>
+              </TabsContent>}
 
               {/* NPS Tab */}
               {getConfig('npsEnabled') && <TabsContent value="nps" className="space-y-4">

--- a/ui/src/app/(app)/chat/[uuid]/page.tsx
+++ b/ui/src/app/(app)/chat/[uuid]/page.tsx
@@ -339,7 +339,8 @@ function ChatUUIDPage() {
             endpoint={caipeUrl}
             conversationId={uuid}
             conversationTitle={conversationTitle}
-            readOnly={accessLevel === 'admin_audit'}
+            readOnly={accessLevel === 'admin_audit' || accessLevel === 'shared_readonly'}
+            readOnlyReason={accessLevel === 'admin_audit' ? 'admin_audit' : accessLevel === 'shared_readonly' ? 'shared_readonly' : undefined}
           />
         </motion.div>
       </div>

--- a/ui/src/app/(app)/chat/[uuid]/page.tsx
+++ b/ui/src/app/(app)/chat/[uuid]/page.tsx
@@ -62,6 +62,7 @@ function ChatUUIDPage() {
   const existingConv = useChatStore.getState().conversations.find((c) => c.id === uuid);
 
   const [conversation, setConversation] = useState<Conversation | LocalConversation | null>(existingConv || null);
+  const [accessLevel, setAccessLevel] = useState<string | null>(null);
   // Track whether the async fetch is still in flight.
   const [fetchInProgress, setFetchInProgress] = useState(
     storageMode === 'mongodb' && !storeHasMessages
@@ -146,6 +147,10 @@ function ChatUUIDPage() {
           console.log("[ChatUUID] Loading from MongoDB...");
           try {
             const conv = await apiClient.getConversation(uuid);
+            // Capture access level from API response for readonly enforcement
+            if ((conv as any).access_level) {
+              setAccessLevel((conv as any).access_level);
+            }
             // Convert MongoDB conversation to local format
             const localConv: LocalConversation = {
               id: conv._id,
@@ -334,6 +339,7 @@ function ChatUUIDPage() {
             endpoint={caipeUrl}
             conversationId={uuid}
             conversationTitle={conversationTitle}
+            readOnly={accessLevel === 'admin_audit'}
           />
         </motion.div>
       </div>

--- a/ui/src/app/(app)/layout.tsx
+++ b/ui/src/app/(app)/layout.tsx
@@ -3,7 +3,9 @@
 import React from "react";
 import { AppHeader } from "@/components/layout/AppHeader";
 import { LiveStreamBanner } from "@/components/layout/LiveStreamBanner";
+import { NPSSurvey } from "@/components/nps/NPSSurvey";
 import { useUserInit } from "@/hooks/use-user-init";
+import { getConfig } from "@/lib/config";
 
 export default function AppLayout({
   children,
@@ -18,6 +20,7 @@ export default function AppLayout({
       <AppHeader />
       <LiveStreamBanner />
       {children}
+      {getConfig('npsEnabled') && <NPSSurvey />}
     </div>
   );
 }

--- a/ui/src/app/api/__tests__/admin-audit-access.test.ts
+++ b/ui/src/app/api/__tests__/admin-audit-access.test.ts
@@ -1,0 +1,397 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: any[]) => mockGetServerSession(...args),
+}));
+jest.mock('@/lib/auth-config', () => ({ authOptions: {} }));
+jest.mock('@/lib/config', () => ({
+  getConfig: (key: string) => key === 'ssoEnabled',
+}));
+
+const mockCollections: Record<string, any> = {};
+const mockGetCollection = jest.fn((name: string) => {
+  if (!mockCollections[name]) mockCollections[name] = createMockCollection();
+  return Promise.resolve(mockCollections[name]);
+});
+jest.mock('@/lib/mongodb', () => ({
+  getCollection: (...args: any[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+function createMockCollection() {
+  const findReturnValue = {
+    project: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    }),
+    sort: jest.fn().mockReturnValue({
+      skip: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+    }),
+    skip: jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    }),
+    limit: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    toArray: jest.fn().mockResolvedValue([]),
+  };
+  return {
+    find: jest.fn().mockReturnValue(findReturnValue),
+    findOne: jest.fn().mockResolvedValue(null),
+    insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
+    insertMany: jest.fn().mockResolvedValue({ insertedCount: 0 }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: jest.fn().mockResolvedValue(0),
+  };
+}
+
+const CONV_ID = 'conv-123';
+const VALID_UUID = '550e8400-e29b-41d4-a716-446655440000';
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost:3000'));
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+});
+
+describe('requireConversationAccess — admin audit', () => {
+  let requireConversationAccess: any;
+  let ApiError: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import('@/lib/api-middleware');
+    requireConversationAccess = mod.requireConversationAccess;
+    ApiError = mod.ApiError;
+  });
+
+  it('returns access_level owner when user is the conversation owner', async () => {
+    const conv = {
+      _id: CONV_ID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const result = await requireConversationAccess(
+      CONV_ID,
+      'owner@example.com',
+      mockGetCollection
+    );
+
+    expect(result.access_level).toBe('owner');
+    expect(result.conversation).toEqual(conv);
+  });
+
+  it('returns access_level shared when user is in shared_with', async () => {
+    const conv = {
+      _id: CONV_ID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: ['shared@example.com'], shared_with_teams: [] },
+    };
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const result = await requireConversationAccess(
+      CONV_ID,
+      'shared@example.com',
+      mockGetCollection
+    );
+
+    expect(result.access_level).toBe('shared');
+    expect(result.conversation).toEqual(conv);
+  });
+
+  it('returns access_level admin_audit when admin session is provided and user is not owner/shared', async () => {
+    const conv = {
+      _id: CONV_ID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const result = await requireConversationAccess(
+      CONV_ID,
+      'admin@example.com',
+      mockGetCollection,
+      { role: 'admin' }
+    );
+
+    expect(result.access_level).toBe('admin_audit');
+    expect(result.conversation).toEqual(conv);
+  });
+
+  it('returns access_level admin_audit when canViewAdmin=true session is provided', async () => {
+    const conv = {
+      _id: CONV_ID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const result = await requireConversationAccess(
+      CONV_ID,
+      'auditor@example.com',
+      mockGetCollection,
+      { role: 'user', canViewAdmin: true }
+    );
+
+    expect(result.access_level).toBe('admin_audit');
+    expect(result.conversation).toEqual(conv);
+  });
+
+  it('throws 403 when non-admin non-shared non-owner user without session', async () => {
+    const conv = {
+      _id: CONV_ID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const err = requireConversationAccess(CONV_ID, 'other@example.com', mockGetCollection);
+    await expect(err).rejects.toThrow(ApiError);
+    await expect(err).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('throws 403 when non-admin user even with session (role=user, canViewAdmin=false)', async () => {
+    const conv = {
+      _id: CONV_ID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const err = requireConversationAccess(CONV_ID, 'other@example.com', mockGetCollection, {
+      role: 'user',
+      canViewAdmin: false,
+    });
+    await expect(err).rejects.toThrow(ApiError);
+    await expect(err).rejects.toMatchObject({ statusCode: 403 });
+  });
+
+  it('throws 404 when conversation not found', async () => {
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(null);
+    mockCollections['conversations'] = convsCol;
+
+    const err = requireConversationAccess(
+      'non-existent',
+      'owner@example.com',
+      mockGetCollection
+    );
+    await expect(err).rejects.toThrow(ApiError);
+    await expect(err).rejects.toMatchObject({
+      statusCode: 404,
+      message: 'Conversation not found',
+    });
+  });
+
+  it('returns { conversation, access_level } instead of raw conversation', async () => {
+    const conv = {
+      _id: CONV_ID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const result = await requireConversationAccess(
+      CONV_ID,
+      'owner@example.com',
+      mockGetCollection
+    );
+
+    expect(result).toHaveProperty('conversation');
+    expect(result).toHaveProperty('access_level');
+    expect(result.conversation).toEqual(conv);
+    expect(result.access_level).toBe('owner');
+  });
+});
+
+describe('GET /api/chat/conversations/[id] — access_level in response', () => {
+  let GET: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    const mod = await import('@/app/api/chat/conversations/[id]/route');
+    GET = mod.GET;
+  });
+
+  it('returns access_level owner when user is the owner', async () => {
+    const conv = {
+      _id: VALID_UUID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'owner@example.com', name: 'Owner' },
+      role: 'user',
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const req = makeRequest(`/api/chat/conversations/${VALID_UUID}`);
+    const res = await GET(req, {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.access_level).toBe('owner');
+    expect(body.data._id).toBe(VALID_UUID);
+  });
+
+  it('returns access_level admin_audit when admin accesses another user conversation', async () => {
+    const conv = {
+      _id: VALID_UUID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'admin@example.com', name: 'Admin' },
+      role: 'admin',
+      canViewAdmin: true,
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const req = makeRequest(`/api/chat/conversations/${VALID_UUID}`);
+    const res = await GET(req, {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.access_level).toBe('admin_audit');
+    expect(body.data.owner_id).toBe('owner@example.com');
+  });
+
+  it('non-admin non-owner user gets 403', async () => {
+    const conv = {
+      _id: VALID_UUID,
+      owner_id: 'owner@example.com',
+      title: 'Test',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    };
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'other@example.com', name: 'Other' },
+      role: 'user',
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const req = makeRequest(`/api/chat/conversations/${VALID_UUID}`);
+    const res = await GET(req, {
+      params: Promise.resolve({ id: VALID_UUID }),
+    });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('Forbidden');
+  });
+});

--- a/ui/src/app/api/__tests__/admin-feedback.test.ts
+++ b/ui/src/app/api/__tests__/admin-feedback.test.ts
@@ -35,8 +35,12 @@ jest.mock('@/lib/auth-config', () => ({
   authOptions: {},
 }));
 
+let mockFeedbackEnabled = true;
 jest.mock('@/lib/config', () => ({
-  getConfig: (key: string) => key === 'ssoEnabled',
+  getConfig: (key: string) => {
+    if (key === 'feedbackEnabled') return mockFeedbackEnabled;
+    return key === 'ssoEnabled';
+  },
 }));
 
 const mockCollections: Record<string, any> = {};
@@ -139,9 +143,19 @@ describe('GET /api/admin/feedback', () => {
     Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
     mockGetCollection.mockClear();
     mockIsMongoDBConfigured = true;
+    mockFeedbackEnabled = true;
 
     const mod = await import('@/app/api/admin/feedback/route');
     GET = mod.GET;
+  });
+
+  it('returns 404 when feedback feature is disabled', async () => {
+    mockFeedbackEnabled = false;
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('FEEDBACK_DISABLED');
   });
 
   it('returns 401 when not authenticated', async () => {

--- a/ui/src/app/api/__tests__/admin-feedback.test.ts
+++ b/ui/src/app/api/__tests__/admin-feedback.test.ts
@@ -1,0 +1,350 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for Admin Feedback API Route
+ *
+ * Covers:
+ * - GET /api/admin/feedback — paginated feedback entries for admin dashboard
+ *
+ * Features tested:
+ * - Authentication: 401 when unauthenticated
+ * - Authorization: 403 when non-admin
+ * - MongoDB guard: 503 when MongoDB is not configured
+ * - Pagination (page, limit, skip)
+ * - Rating filter (positive, negative, all)
+ * - Conversation title batch-fetching
+ * - Content snippet truncation
+ * - Response structure
+ * - Empty database returns empty entries
+ */
+
+import { NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: any[]) => mockGetServerSession(...args),
+}));
+
+jest.mock('@/lib/auth-config', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/config', () => ({
+  getConfig: (key: string) => key === 'ssoEnabled',
+}));
+
+const mockCollections: Record<string, any> = {};
+const mockGetCollection = jest.fn((name: string) => {
+  if (!mockCollections[name]) {
+    mockCollections[name] = createMockCollection();
+  }
+  return Promise.resolve(mockCollections[name]);
+});
+
+let mockIsMongoDBConfigured = true;
+jest.mock('@/lib/mongodb', () => ({
+  getCollection: (...args: any[]) => mockGetCollection(...args),
+  get isMongoDBConfigured() {
+    return mockIsMongoDBConfigured;
+  },
+}));
+
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockCollection() {
+  const findReturnValue = {
+    sort: jest.fn().mockReturnValue({
+      skip: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    toArray: jest.fn().mockResolvedValue([]),
+  };
+
+  return {
+    find: jest.fn().mockReturnValue(findReturnValue),
+    findOne: jest.fn().mockResolvedValue(null),
+    insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: jest.fn().mockResolvedValue(0),
+    aggregate: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+  };
+}
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost:3000'));
+}
+
+function adminSession() {
+  return {
+    user: { email: 'admin@example.com', name: 'Admin' },
+    role: 'admin',
+    canViewAdmin: true,
+  };
+}
+
+function userSession() {
+  return {
+    user: { email: 'user@example.com', name: 'User' },
+    role: 'user',
+    canViewAdmin: false,
+  };
+}
+
+function makeFeedbackMessage(overrides: Partial<any> = {}) {
+  return {
+    _id: new ObjectId(),
+    message_id: 'msg-1',
+    conversation_id: 'conv-1',
+    content: 'Test assistant response content',
+    role: 'assistant',
+    feedback: {
+      rating: 'positive',
+      comment: 'Very Helpful',
+      submitted_at: new Date('2026-03-01'),
+      submitted_by: 'user@example.com',
+    },
+    created_at: new Date('2026-03-01'),
+    owner_id: 'user@example.com',
+    ...overrides,
+  };
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('GET /api/admin/feedback', () => {
+  let GET: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+    mockGetCollection.mockClear();
+    mockIsMongoDBConfigured = true;
+
+    const mod = await import('@/app/api/admin/feedback/route');
+    GET = mod.GET;
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 503 when MongoDB is not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('MONGODB_NOT_CONFIGURED');
+  });
+
+  it('returns empty entries on fresh database', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const msgCol = createMockCollection();
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    });
+    msgCol.countDocuments.mockResolvedValue(0);
+    mockCollections['messages'] = msgCol;
+
+    const convCol = createMockCollection();
+    mockCollections['conversations'] = convCol;
+
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.entries).toEqual([]);
+    expect(body.data.pagination.total).toBe(0);
+  });
+
+  it('returns feedback entries with correct structure', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const msg = makeFeedbackMessage();
+    const msgCol = createMockCollection();
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([msg]),
+          }),
+        }),
+      }),
+    });
+    msgCol.countDocuments.mockResolvedValue(1);
+    mockCollections['messages'] = msgCol;
+
+    const convCol = createMockCollection();
+    convCol.find.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([{ _id: 'conv-1', title: 'My Chat' }]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+
+    const entry = body.data.entries[0];
+    expect(entry.message_id).toBe('msg-1');
+    expect(entry.conversation_id).toBe('conv-1');
+    expect(entry.conversation_title).toBe('My Chat');
+    expect(entry.rating).toBe('positive');
+    expect(entry.reason).toBe('Very Helpful');
+    expect(entry.submitted_by).toBe('user@example.com');
+    expect(entry.role).toBe('assistant');
+  });
+
+  it('truncates long content to 200 chars + ellipsis', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const longContent = 'x'.repeat(300);
+    const msg = makeFeedbackMessage({ content: longContent });
+    const msgCol = createMockCollection();
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([msg]),
+          }),
+        }),
+      }),
+    });
+    msgCol.countDocuments.mockResolvedValue(1);
+    mockCollections['messages'] = msgCol;
+
+    const convCol = createMockCollection();
+    convCol.find.mockReturnValue({ toArray: jest.fn().mockResolvedValue([]) });
+    mockCollections['conversations'] = convCol;
+
+    const res = await GET(makeRequest('/api/admin/feedback'));
+    const body = await res.json();
+    expect(body.data.entries[0].content_snippet).toHaveLength(203); // 200 + '...'
+    expect(body.data.entries[0].content_snippet).toMatch(/\.\.\.$/);
+  });
+
+  it('filters by positive rating', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const msgCol = createMockCollection();
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    });
+    msgCol.countDocuments.mockResolvedValue(0);
+    mockCollections['messages'] = msgCol;
+    mockCollections['conversations'] = createMockCollection();
+
+    await GET(makeRequest('/api/admin/feedback?rating=positive'));
+    const findCall = msgCol.find.mock.calls[0][0];
+    expect(findCall['feedback.rating']).toBe('positive');
+  });
+
+  it('filters by negative rating', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const msgCol = createMockCollection();
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    });
+    msgCol.countDocuments.mockResolvedValue(0);
+    mockCollections['messages'] = msgCol;
+    mockCollections['conversations'] = createMockCollection();
+
+    await GET(makeRequest('/api/admin/feedback?rating=negative'));
+    const findCall = msgCol.find.mock.calls[0][0];
+    expect(findCall['feedback.rating']).toBe('negative');
+  });
+
+  it('returns all ratings when no filter is set', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const msgCol = createMockCollection();
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    });
+    msgCol.countDocuments.mockResolvedValue(0);
+    mockCollections['messages'] = msgCol;
+    mockCollections['conversations'] = createMockCollection();
+
+    await GET(makeRequest('/api/admin/feedback'));
+    const findCall = msgCol.find.mock.calls[0][0];
+    expect(findCall['feedback.rating']).toEqual({ $exists: true });
+  });
+
+  it('respects pagination parameters', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const msgCol = createMockCollection();
+    const mockSkip = jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({ skip: mockSkip }),
+    });
+    msgCol.countDocuments.mockResolvedValue(100);
+    mockCollections['messages'] = msgCol;
+    mockCollections['conversations'] = createMockCollection();
+
+    const res = await GET(makeRequest('/api/admin/feedback?page=3&limit=10'));
+    expect(mockSkip).toHaveBeenCalledWith(20); // (3-1)*10
+    const body = await res.json();
+    expect(body.data.pagination.page).toBe(3);
+    expect(body.data.pagination.limit).toBe(10);
+    expect(body.data.pagination.total).toBe(100);
+    expect(body.data.pagination.total_pages).toBe(10);
+  });
+});

--- a/ui/src/app/api/__tests__/admin-nps.test.ts
+++ b/ui/src/app/api/__tests__/admin-nps.test.ts
@@ -1,0 +1,329 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: any[]) => mockGetServerSession(...args),
+}));
+jest.mock('@/lib/auth-config', () => ({ authOptions: {} }));
+
+let mockNpsEnabled = true;
+jest.mock('@/lib/config', () => ({
+  getConfig: (key: string) => {
+    if (key === 'npsEnabled') return mockNpsEnabled;
+    return key === 'ssoEnabled';
+  },
+}));
+
+const mockCollections: Record<string, any> = {};
+const mockGetCollection = jest.fn((name: string) => {
+  if (!mockCollections[name]) mockCollections[name] = createMockCollection();
+  return Promise.resolve(mockCollections[name]);
+});
+let mockIsMongoDBConfigured = true;
+jest.mock('@/lib/mongodb', () => ({
+  getCollection: (...args: any[]) => mockGetCollection(...args),
+  get isMongoDBConfigured() {
+    return mockIsMongoDBConfigured;
+  },
+}));
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+function createMockCollection() {
+  const findReturnValue = {
+    sort: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    toArray: jest.fn().mockResolvedValue([]),
+  };
+  return {
+    find: jest.fn().mockReturnValue(findReturnValue),
+    findOne: jest.fn().mockResolvedValue(null),
+    insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: jest.fn().mockResolvedValue(0),
+    aggregate: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+  };
+}
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost:3000'));
+}
+
+const adminSession = {
+  user: { email: 'admin@example.com', name: 'Admin' },
+  role: 'admin',
+  canViewAdmin: true,
+};
+
+const userSession = {
+  user: { email: 'user@example.com', name: 'User' },
+  role: 'user',
+  canViewAdmin: false,
+};
+
+describe('GET /api/admin/nps', () => {
+  let GET: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+    mockGetCollection.mockClear();
+    mockNpsEnabled = true;
+    mockIsMongoDBConfigured = true;
+
+    const mod = await import('@/app/api/admin/nps/route');
+    GET = mod.GET;
+  });
+
+  it('returns 404 when npsEnabled is false', async () => {
+    mockNpsEnabled = false;
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('NPS_DISABLED');
+  });
+
+  it('returns 503 when MongoDB not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('MONGODB_NOT_CONFIGURED');
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user lacks admin view access', async () => {
+    mockGetServerSession.mockResolvedValue(userSession);
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns correct NPS score and breakdown for mixed responses', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const responses = [
+      { score: 10, user_email: 'a@e.com', created_at: new Date(), comment: 'great' },
+      { score: 9, user_email: 'b@e.com', created_at: new Date() },
+      { score: 7, user_email: 'c@e.com', created_at: new Date() },
+      { score: 3, user_email: 'd@e.com', created_at: new Date(), comment: 'bad' },
+    ];
+    const npsCol = createMockCollection();
+    npsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue(responses),
+      }),
+    });
+    npsCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['nps_responses'] = npsCol;
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.nps_score).toBe(25);
+    expect(body.data.total_responses).toBe(4);
+    expect(body.data.breakdown.promoters).toBe(2);
+    expect(body.data.breakdown.passives).toBe(1);
+    expect(body.data.breakdown.detractors).toBe(1);
+  });
+
+  it('returns zero NPS for empty database', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const npsCol = createMockCollection();
+    npsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    npsCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['nps_responses'] = npsCol;
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.nps_score).toBe(0);
+    expect(body.data.total_responses).toBe(0);
+  });
+
+  it('returns 30-day trend array with 30 entries', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const npsCol = createMockCollection();
+    npsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    npsCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['nps_responses'] = npsCol;
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.trend).toHaveLength(30);
+  });
+
+  it('returns recent_responses capped at 20', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const manyResponses = Array.from({ length: 25 }, (_, i) => ({
+      score: 8,
+      user_email: `u${i}@e.com`,
+      created_at: new Date(),
+    }));
+    const npsCol = createMockCollection();
+    npsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue(manyResponses),
+      }),
+    });
+    npsCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['nps_responses'] = npsCol;
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.recent_responses).toHaveLength(20);
+  });
+
+  it('returns campaigns array with response_count and status', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignId = new ObjectId();
+    const campaigns = [
+      {
+        _id: campaignId,
+        name: 'Q1 NPS',
+        starts_at: new Date('2026-01-01'),
+        ends_at: new Date('2026-01-31'),
+        created_by: 'admin@example.com',
+        created_at: new Date('2025-12-01'),
+      },
+    ];
+    const npsCol = createMockCollection();
+    npsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    npsCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    npsCol.countDocuments.mockResolvedValue(15);
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue(campaigns),
+      }),
+    });
+    mockCollections['nps_responses'] = npsCol;
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await GET(makeRequest('/api/admin/nps'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.campaigns).toHaveLength(1);
+    expect(body.data.campaigns[0].response_count).toBe(15);
+    expect(body.data.campaigns[0].status).toBeDefined();
+  });
+
+  it('passes campaign_id to find filter when query param is set', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const npsCol = createMockCollection();
+    npsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    npsCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['nps_responses'] = npsCol;
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    await GET(makeRequest('/api/admin/nps?campaign_id=abc123'));
+    expect(npsCol.find.mock.calls[0][0]).toEqual({ campaign_id: 'abc123' });
+  });
+
+  it('does not filter when no campaign_id is specified', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const npsCol = createMockCollection();
+    npsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    npsCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['nps_responses'] = npsCol;
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    await GET(makeRequest('/api/admin/nps'));
+    expect(npsCol.find.mock.calls[0][0]).toEqual({});
+  });
+});

--- a/ui/src/app/api/__tests__/chat-messages.test.ts
+++ b/ui/src/app/api/__tests__/chat-messages.test.ts
@@ -1313,3 +1313,144 @@ describe('Cross-device message persistence', () => {
     expect(body.data.items[1].metadata.is_final).toBe(true);
   });
 });
+
+// ============================================================================
+// Admin Audit Access — Write Blocking
+// ============================================================================
+
+describe('POST /api/chat/conversations/[id]/messages — admin audit write blocking', () => {
+  const testConversationId = '550e8400-e29b-41d4-a716-446655440000';
+
+  let POST: any;
+  let GET: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+    mockGetCollection.mockClear();
+
+    const mod = await import(
+      '@/app/api/chat/conversations/[id]/messages/route'
+    );
+    POST = mod.POST;
+    GET = mod.GET;
+  });
+
+  function setupConversationMocks(ownerEmail: string) {
+    const convCol = createMockCollection();
+    convCol.findOne.mockResolvedValue({
+      _id: testConversationId,
+      owner_id: ownerEmail,
+      title: 'Test Conversation',
+      sharing: { shared_with: [], shared_with_teams: [] },
+    });
+    mockCollections['conversations'] = convCol;
+
+    const sharingCol = createMockCollection();
+    sharingCol.findOne.mockResolvedValue(null);
+    mockCollections['sharing_access'] = sharingCol;
+
+    const teamsCol = createMockCollection();
+    teamsCol.find.mockReturnValue({
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['teams'] = teamsCol;
+
+    return convCol;
+  }
+
+  it('blocks POST when admin has audit-only access', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'admin@example.com', name: 'Admin' },
+      role: 'admin',
+      canViewAdmin: true,
+    });
+
+    setupConversationMocks('owner@example.com');
+    mockCollections['messages'] = createMockCollection();
+
+    const req = makeRequest(
+      `/api/chat/conversations/${testConversationId}/messages`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          message_id: 'blocked-msg',
+          role: 'user',
+          content: 'Should not be saved',
+        }),
+      }
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: testConversationId }),
+    });
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe('FORBIDDEN');
+  });
+
+  it('allows POST when user is the conversation owner', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'owner@example.com', name: 'Owner' },
+      role: 'user',
+    });
+
+    const convCol = setupConversationMocks('owner@example.com');
+    const msgCol = createMockCollection();
+    msgCol.updateOne.mockResolvedValue({
+      upsertedId: new ObjectId(),
+      upsertedCount: 1,
+      matchedCount: 0,
+      modifiedCount: 0,
+      acknowledged: true,
+    });
+    msgCol.findOne.mockResolvedValue({
+      _id: new ObjectId(),
+      message_id: 'owner-msg',
+      conversation_id: testConversationId,
+      content: 'Hello',
+      role: 'user',
+    });
+    mockCollections['messages'] = msgCol;
+
+    const req = makeRequest(
+      `/api/chat/conversations/${testConversationId}/messages`,
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          message_id: 'owner-msg',
+          role: 'user',
+          content: 'Hello',
+        }),
+      }
+    );
+
+    const res = await POST(req, {
+      params: Promise.resolve({ id: testConversationId }),
+    });
+    expect(res.status).toBe(201);
+  });
+
+  it('allows GET for admin audit (read-only access)', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: 'admin@example.com', name: 'Admin' },
+      role: 'admin',
+      canViewAdmin: true,
+    });
+
+    setupConversationMocks('owner@example.com');
+    const msgCol = createMockCollection();
+    msgCol.countDocuments.mockResolvedValue(0);
+    mockCollections['messages'] = msgCol;
+
+    const req = makeRequest(
+      `/api/chat/conversations/${testConversationId}/messages`
+    );
+    const res = await GET(req, {
+      params: Promise.resolve({ id: testConversationId }),
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/ui/src/app/api/__tests__/chat-sharing-public.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-public.test.ts
@@ -158,7 +158,7 @@ describe('requireConversationAccess — public (is_public) access', () => {
 
     expect(result).toBeDefined();
     expect(result.conversation._id).toBe(conv._id);
-    expect(result.access_level).toBe('shared_readonly');
+    expect(result.access_level).toBe('shared');
   });
 
   it('denies access when is_public is false and user has no other access', async () => {
@@ -214,7 +214,7 @@ describe('requireConversationAccess — public (is_public) access', () => {
 
     expect(result).toBeDefined();
     expect(result.conversation.sharing.is_public).toBe(true);
-    expect(result.access_level).toBe('shared_readonly');
+    expect(result.access_level).toBe('shared');
   });
 
   it('does not check teams or sharing_access when is_public is true', async () => {

--- a/ui/src/app/api/__tests__/chat-sharing-public.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-public.test.ts
@@ -158,7 +158,7 @@ describe('requireConversationAccess — public (is_public) access', () => {
 
     expect(result).toBeDefined();
     expect(result.conversation._id).toBe(conv._id);
-    expect(result.access_level).toBe('shared');
+    expect(result.access_level).toBe('shared_readonly');
   });
 
   it('denies access when is_public is false and user has no other access', async () => {
@@ -214,7 +214,7 @@ describe('requireConversationAccess — public (is_public) access', () => {
 
     expect(result).toBeDefined();
     expect(result.conversation.sharing.is_public).toBe(true);
-    expect(result.access_level).toBe('shared');
+    expect(result.access_level).toBe('shared_readonly');
   });
 
   it('does not check teams or sharing_access when is_public is true', async () => {

--- a/ui/src/app/api/__tests__/chat-sharing-public.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-public.test.ts
@@ -157,7 +157,8 @@ describe('requireConversationAccess — public (is_public) access', () => {
     const result = await requireConversationAccess(conv._id, STRANGER_EMAIL, mockGetCollection);
 
     expect(result).toBeDefined();
-    expect(result._id).toBe(conv._id);
+    expect(result.conversation._id).toBe(conv._id);
+    expect(result.access_level).toBe('shared');
   });
 
   it('denies access when is_public is false and user has no other access', async () => {
@@ -192,7 +193,8 @@ describe('requireConversationAccess — public (is_public) access', () => {
     const result = await requireConversationAccess(conv._id, OWNER_EMAIL, mockGetCollection);
 
     expect(result).toBeDefined();
-    expect(result._id).toBe(conv._id);
+    expect(result.conversation._id).toBe(conv._id);
+    expect(result.access_level).toBe('owner');
   });
 
   it('grants access via is_public even when shared_with and shared_with_teams are empty', async () => {
@@ -211,7 +213,8 @@ describe('requireConversationAccess — public (is_public) access', () => {
     const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
 
     expect(result).toBeDefined();
-    expect(result.sharing.is_public).toBe(true);
+    expect(result.conversation.sharing.is_public).toBe(true);
+    expect(result.access_level).toBe('shared');
   });
 
   it('does not check teams or sharing_access when is_public is true', async () => {

--- a/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
@@ -186,7 +186,7 @@ describe('requireConversationAccess — readonly sharing permissions', () => {
   });
 
   describe('public shares', () => {
-    it('always returns shared_readonly for public conversations', async () => {
+    it('returns shared (comment) by default for public conversations', async () => {
       const conv = makeConversation({
         sharing: { is_public: true, shared_with: [], shared_with_teams: [] },
       });
@@ -196,7 +196,33 @@ describe('requireConversationAccess — readonly sharing permissions', () => {
 
       const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
 
+      expect(result.access_level).toBe('shared');
+    });
+
+    it('returns shared_readonly when public_permission is view', async () => {
+      const conv = makeConversation({
+        sharing: { is_public: true, public_permission: 'view', shared_with: [], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
+
       expect(result.access_level).toBe('shared_readonly');
+    });
+
+    it('returns shared when public_permission is comment', async () => {
+      const conv = makeConversation({
+        sharing: { is_public: true, public_permission: 'comment', shared_with: [], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared');
     });
 
     it('owner still gets owner access on public conversations', async () => {

--- a/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
@@ -1,0 +1,613 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for Read-Only Sharing Permissions
+ *
+ * Covers the sharing permission model:
+ * - 'view' permission → shared_readonly access (cannot send messages)
+ * - 'comment' permission → shared access (can send messages)
+ * - Public shares → always shared_readonly
+ * - Team shares with per-team permissions
+ * - Permission changes via PATCH
+ * - Backward compatibility: legacy shares without permission records default to 'comment'
+ */
+
+import { NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: any[]) => mockGetServerSession(...args),
+}));
+
+jest.mock('@/lib/auth-config', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/config', () => ({
+  getConfig: (key: string) => key === 'ssoEnabled',
+}));
+
+const mockCollections: Record<string, any> = {};
+const mockGetCollection = jest.fn((name: string) => {
+  if (!mockCollections[name]) {
+    mockCollections[name] = createMockCollection();
+  }
+  return Promise.resolve(mockCollections[name]);
+});
+
+jest.mock('@/lib/mongodb', () => ({
+  getCollection: (...args: any[]) => mockGetCollection(...args),
+  isMongoDBConfigured: true,
+}));
+
+jest.mock('uuid', () => ({
+  v4: () => 'mock-uuid-1234',
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockCollection() {
+  return {
+    findOne: jest.fn().mockResolvedValue(null),
+    find: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+      project: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
+    insertMany: jest.fn().mockResolvedValue({ insertedCount: 0 }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: jest.fn().mockResolvedValue(0),
+  };
+}
+
+const OWNER_EMAIL = 'owner@example.com';
+const VIEWER_EMAIL = 'viewer@example.com';
+const EDITOR_EMAIL = 'editor@example.com';
+const TEAM_MEMBER_EMAIL = 'team-member@example.com';
+const TEAM_ID = new ObjectId().toHexString();
+const TEST_CONV_ID = '12345678-1234-1234-1234-123456789abc';
+
+function makeConversation(overrides: any = {}) {
+  return {
+    _id: TEST_CONV_ID,
+    title: 'Test Conversation',
+    owner_id: OWNER_EMAIL,
+    created_at: new Date(),
+    updated_at: new Date(),
+    metadata: { agent_version: '1.0', model_used: 'test', total_messages: 0 },
+    sharing: {
+      is_public: false,
+      shared_with: [],
+      shared_with_teams: [],
+      share_link_enabled: false,
+      ...overrides.sharing,
+    },
+    tags: [],
+    is_archived: false,
+    is_pinned: false,
+    ...overrides,
+    // Keep sharing merge at top level
+  };
+}
+
+// ============================================================================
+// Import after mocks
+// ============================================================================
+
+import { requireConversationAccess } from '@/lib/api-middleware';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
+});
+
+describe('requireConversationAccess — readonly sharing permissions', () => {
+  describe('direct user shares', () => {
+    it('returns shared_readonly when user has view permission', async () => {
+      const conv = makeConversation({
+        sharing: { shared_with: [VIEWER_EMAIL], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const sharingAccessCol = createMockCollection();
+      sharingAccessCol.findOne.mockResolvedValue({
+        conversation_id: conv._id,
+        granted_to: VIEWER_EMAIL,
+        permission: 'view',
+      });
+      mockCollections['sharing_access'] = sharingAccessCol;
+
+      const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared_readonly');
+      expect(result.conversation._id).toBe(conv._id);
+    });
+
+    it('returns shared when user has comment permission', async () => {
+      const conv = makeConversation({
+        sharing: { shared_with: [EDITOR_EMAIL], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const sharingAccessCol = createMockCollection();
+      sharingAccessCol.findOne.mockResolvedValue({
+        conversation_id: conv._id,
+        granted_to: EDITOR_EMAIL,
+        permission: 'comment',
+      });
+      mockCollections['sharing_access'] = sharingAccessCol;
+
+      const result = await requireConversationAccess(conv._id, EDITOR_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared');
+    });
+
+    it('defaults to shared (comment) for legacy shares without a SharingAccess record', async () => {
+      const conv = makeConversation({
+        sharing: { shared_with: [VIEWER_EMAIL], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const sharingAccessCol = createMockCollection();
+      sharingAccessCol.findOne.mockResolvedValue(null);
+      mockCollections['sharing_access'] = sharingAccessCol;
+
+      const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared');
+    });
+  });
+
+  describe('public shares', () => {
+    it('always returns shared_readonly for public conversations', async () => {
+      const conv = makeConversation({
+        sharing: { is_public: true, shared_with: [], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared_readonly');
+    });
+
+    it('owner still gets owner access on public conversations', async () => {
+      const conv = makeConversation({
+        sharing: { is_public: true, shared_with: [], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const result = await requireConversationAccess(conv._id, OWNER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('owner');
+    });
+  });
+
+  describe('team shares with permissions', () => {
+    it('returns shared_readonly when team has view permission', async () => {
+      const conv = makeConversation({
+        sharing: {
+          shared_with: [],
+          shared_with_teams: [TEAM_ID],
+          team_permissions: { [TEAM_ID]: 'view' },
+        },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const teamsCol = createMockCollection();
+      teamsCol.find.mockReturnValue({
+        project: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            { _id: new ObjectId(TEAM_ID) },
+          ]),
+        }),
+      });
+      mockCollections['teams'] = teamsCol;
+
+      const result = await requireConversationAccess(conv._id, TEAM_MEMBER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared_readonly');
+    });
+
+    it('returns shared when team has comment permission', async () => {
+      const conv = makeConversation({
+        sharing: {
+          shared_with: [],
+          shared_with_teams: [TEAM_ID],
+          team_permissions: { [TEAM_ID]: 'comment' },
+        },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const teamsCol = createMockCollection();
+      teamsCol.find.mockReturnValue({
+        project: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            { _id: new ObjectId(TEAM_ID) },
+          ]),
+        }),
+      });
+      mockCollections['teams'] = teamsCol;
+
+      const result = await requireConversationAccess(conv._id, TEAM_MEMBER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared');
+    });
+
+    it('defaults to shared (comment) for legacy team shares without team_permissions', async () => {
+      const conv = makeConversation({
+        sharing: {
+          shared_with: [],
+          shared_with_teams: [TEAM_ID],
+        },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const teamsCol = createMockCollection();
+      teamsCol.find.mockReturnValue({
+        project: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            { _id: new ObjectId(TEAM_ID) },
+          ]),
+        }),
+      });
+      mockCollections['teams'] = teamsCol;
+
+      const result = await requireConversationAccess(conv._id, TEAM_MEMBER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared');
+    });
+  });
+
+  describe('sharing_access fallback', () => {
+    it('returns shared_readonly when sharing_access record has view permission', async () => {
+      const conv = makeConversation({
+        sharing: { shared_with: [], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const sharingAccessCol = createMockCollection();
+      sharingAccessCol.findOne.mockResolvedValue({
+        conversation_id: conv._id,
+        granted_to: VIEWER_EMAIL,
+        permission: 'view',
+      });
+      mockCollections['sharing_access'] = sharingAccessCol;
+
+      const result = await requireConversationAccess(conv._id, VIEWER_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared_readonly');
+    });
+
+    it('returns shared when sharing_access record has comment permission', async () => {
+      const conv = makeConversation({
+        sharing: { shared_with: [], shared_with_teams: [] },
+      });
+      const convsCol = createMockCollection();
+      convsCol.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convsCol;
+
+      const sharingAccessCol = createMockCollection();
+      sharingAccessCol.findOne.mockResolvedValue({
+        conversation_id: conv._id,
+        granted_to: EDITOR_EMAIL,
+        permission: 'comment',
+      });
+      mockCollections['sharing_access'] = sharingAccessCol;
+
+      const result = await requireConversationAccess(conv._id, EDITOR_EMAIL, mockGetCollection);
+
+      expect(result.access_level).toBe('shared');
+    });
+  });
+});
+
+describe('POST /api/chat/conversations/[id]/messages — readonly sharing', () => {
+  it('blocks message creation for shared_readonly users', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [VIEWER_EMAIL], shared_with_teams: [] },
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue({
+      conversation_id: conv._id,
+      granted_to: VIEWER_EMAIL,
+      permission: 'view',
+    });
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: VIEWER_EMAIL, name: 'Viewer' },
+    });
+
+    const { POST } = await import('@/app/api/chat/conversations/[id]/messages/route');
+
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/messages`, {
+      method: 'POST',
+      body: JSON.stringify({ role: 'user', content: 'test message' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('Read-only');
+  });
+
+  it('allows message creation for shared (comment) users', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [EDITOR_EMAIL], shared_with_teams: [] },
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    sharingAccessCol.findOne.mockResolvedValue({
+      conversation_id: conv._id,
+      granted_to: EDITOR_EMAIL,
+      permission: 'comment',
+    });
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    const msgCol = createMockCollection();
+    mockCollections['messages'] = msgCol;
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: EDITOR_EMAIL, name: 'Editor' },
+    });
+
+    const { POST } = await import('@/app/api/chat/conversations/[id]/messages/route');
+
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/messages`, {
+      method: 'POST',
+      body: JSON.stringify({ role: 'user', content: 'test message' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('PATCH /api/chat/conversations/[id]/share — permission updates', () => {
+  it('updates user permission via PATCH', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [VIEWER_EMAIL], shared_with_teams: [] },
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne
+      .mockResolvedValueOnce(conv)
+      .mockResolvedValue({ ...conv });
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+    });
+
+    const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
+
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'PATCH',
+      body: JSON.stringify({ email: VIEWER_EMAIL, permission: 'comment' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+    expect(sharingAccessCol.updateOne).toHaveBeenCalledWith(
+      { conversation_id: conv._id, granted_to: VIEWER_EMAIL, revoked_at: null },
+      { $set: { permission: 'comment' } }
+    );
+  });
+
+  it('updates team permission via PATCH', async () => {
+    const conv = makeConversation({
+      sharing: {
+        shared_with: [],
+        shared_with_teams: [TEAM_ID],
+        team_permissions: { [TEAM_ID]: 'view' },
+      },
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne
+      .mockResolvedValueOnce(conv)
+      .mockResolvedValue({ ...conv });
+    mockCollections['conversations'] = convsCol;
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+    });
+
+    const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
+
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'PATCH',
+      body: JSON.stringify({ team_id: TEAM_ID, permission: 'comment' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+    expect(convsCol.updateOne).toHaveBeenCalledWith(
+      { _id: conv._id },
+      { $set: { 'sharing.team_permissions': { [TEAM_ID]: 'comment' } } }
+    );
+  });
+
+  it('rejects PATCH with invalid permission value', async () => {
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+    });
+
+    const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
+
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'PATCH',
+      body: JSON.stringify({ email: VIEWER_EMAIL, permission: 'admin' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ id: TEST_CONV_ID }) });
+
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects PATCH from non-owner', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [VIEWER_EMAIL], shared_with_teams: [] },
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: VIEWER_EMAIL, name: 'Viewer' },
+    });
+
+    const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
+
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'PATCH',
+      body: JSON.stringify({ email: VIEWER_EMAIL, permission: 'comment' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/chat/conversations/[id]/share — permission storage', () => {
+  it('stores permission in SharingAccess when sharing with users', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [], shared_with_teams: [] },
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne
+      .mockResolvedValueOnce(conv)
+      .mockResolvedValue({ ...conv, sharing: { ...conv.sharing, shared_with: [VIEWER_EMAIL] } });
+    mockCollections['conversations'] = convsCol;
+
+    const sharingAccessCol = createMockCollection();
+    mockCollections['sharing_access'] = sharingAccessCol;
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+    });
+
+    const { POST } = await import('@/app/api/chat/conversations/[id]/share/route');
+
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'POST',
+      body: JSON.stringify({
+        user_emails: [VIEWER_EMAIL],
+        permission: 'view',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+    expect(sharingAccessCol.insertMany).toHaveBeenCalled();
+    const insertedRecords = sharingAccessCol.insertMany.mock.calls[0][0];
+    expect(insertedRecords[0].permission).toBe('view');
+    expect(insertedRecords[0].granted_to).toBe(VIEWER_EMAIL);
+  });
+
+  it('stores team_permissions when sharing with teams', async () => {
+    const teamObjId = new ObjectId();
+    const teamIdStr = teamObjId.toHexString();
+
+    const conv = makeConversation({
+      sharing: { shared_with: [], shared_with_teams: [] },
+    });
+
+    const convsCol = createMockCollection();
+    convsCol.findOne
+      .mockResolvedValueOnce(conv)
+      .mockResolvedValue({ ...conv });
+    mockCollections['conversations'] = convsCol;
+
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue({ _id: teamObjId, name: 'Test Team' });
+    mockCollections['teams'] = teamsCol;
+
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+    });
+
+    const { POST } = await import('@/app/api/chat/conversations/[id]/share/route');
+
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'POST',
+      body: JSON.stringify({
+        team_ids: [teamIdStr],
+        permission: 'view',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+    const updateCall = convsCol.updateOne.mock.calls[0][1];
+    expect(updateCall.$set['sharing.team_permissions']).toEqual({ [teamIdStr]: 'view' });
+  });
+});

--- a/ui/src/app/api/__tests__/chat-sharing-teams.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-teams.test.ts
@@ -228,7 +228,8 @@ describe('requireConversationAccess — team-based access', () => {
     const result = await requireConversationAccess(conv._id, OWNER_EMAIL, mockGetCollection);
 
     expect(result).toBeDefined();
-    expect(result._id).toBe(conv._id);
+    expect(result.conversation._id).toBe(conv._id);
+    expect(result.access_level).toBe('owner');
   });
 
   it('grants access when user is in shared_with (direct share)', async () => {
@@ -242,7 +243,8 @@ describe('requireConversationAccess — team-based access', () => {
     const result = await requireConversationAccess(conv._id, MEMBER_EMAIL, mockGetCollection);
 
     expect(result).toBeDefined();
-    expect(result._id).toBe(conv._id);
+    expect(result.conversation._id).toBe(conv._id);
+    expect(result.access_level).toBe('shared');
   });
 
   it('grants access when user belongs to a shared team', async () => {
@@ -268,7 +270,8 @@ describe('requireConversationAccess — team-based access', () => {
     const result = await requireConversationAccess(conv._id, MEMBER_EMAIL, mockGetCollection);
 
     expect(result).toBeDefined();
-    expect(result._id).toBe(conv._id);
+    expect(result.conversation._id).toBe(conv._id);
+    expect(result.access_level).toBe('shared');
   });
 
   it('denies access when user does not belong to any shared team', async () => {
@@ -359,7 +362,8 @@ describe('requireConversationAccess — team-based access', () => {
     const result = await requireConversationAccess(conv._id, MEMBER_EMAIL, mockGetCollection);
 
     expect(result).toBeDefined();
-    expect(result._id).toBe(conv._id);
+    expect(result.conversation._id).toBe(conv._id);
+    expect(result.access_level).toBe('shared');
   });
 
   it('throws 404 when conversation does not exist', async () => {

--- a/ui/src/app/api/__tests__/chat-sharing-teams.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-teams.test.ts
@@ -350,7 +350,7 @@ describe('requireConversationAccess — team-based access', () => {
     });
     mockCollections['teams'] = teamsCol;
 
-    // But has sharing_access record
+    // But has sharing_access record with view permission → shared_readonly
     const sharingAccessCol = createMockCollection();
     sharingAccessCol.findOne.mockResolvedValue({
       conversation_id: conv._id,
@@ -363,7 +363,7 @@ describe('requireConversationAccess — team-based access', () => {
 
     expect(result).toBeDefined();
     expect(result.conversation._id).toBe(conv._id);
-    expect(result.access_level).toBe('shared');
+    expect(result.access_level).toBe('shared_readonly');
   });
 
   it('throws 404 when conversation does not exist', async () => {

--- a/ui/src/app/api/__tests__/nps-campaigns.test.ts
+++ b/ui/src/app/api/__tests__/nps-campaigns.test.ts
@@ -1,0 +1,598 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: any[]) => mockGetServerSession(...args),
+}));
+jest.mock('@/lib/auth-config', () => ({ authOptions: {} }));
+
+let mockNpsEnabled = true;
+jest.mock('@/lib/config', () => ({
+  getConfig: (key: string) => {
+    if (key === 'npsEnabled') return mockNpsEnabled;
+    return key === 'ssoEnabled';
+  },
+}));
+
+const mockCollections: Record<string, any> = {};
+const mockGetCollection = jest.fn((name: string) => {
+  if (!mockCollections[name]) mockCollections[name] = createMockCollection();
+  return Promise.resolve(mockCollections[name]);
+});
+let mockIsMongoDBConfigured = true;
+jest.mock('@/lib/mongodb', () => ({
+  getCollection: (...args: any[]) => mockGetCollection(...args),
+  get isMongoDBConfigured() {
+    return mockIsMongoDBConfigured;
+  },
+}));
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+function createMockCollection() {
+  const findReturnValue = {
+    sort: jest.fn().mockReturnValue({
+      skip: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    toArray: jest.fn().mockResolvedValue([]),
+  };
+  return {
+    find: jest.fn().mockReturnValue(findReturnValue),
+    findOne: jest.fn().mockResolvedValue(null),
+    insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: jest.fn().mockResolvedValue(0),
+    aggregate: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+  };
+}
+
+function makeRequest(url: string, options: RequestInit = {}): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost:3000'), options);
+}
+
+const adminSession = {
+  user: { email: 'admin@example.com', name: 'Admin' },
+  role: 'admin',
+  canViewAdmin: true,
+};
+
+const userSession = {
+  user: { email: 'user@example.com', name: 'User' },
+  role: 'user',
+  canViewAdmin: false,
+};
+
+const viewerSession = {
+  user: { email: 'viewer@example.com', name: 'Viewer' },
+  role: 'user',
+  canViewAdmin: true,
+};
+
+describe('POST /api/admin/nps/campaigns', () => {
+  let POST: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+    mockNpsEnabled = true;
+    mockIsMongoDBConfigured = true;
+
+    const mod = await import('@/app/api/admin/nps/campaigns/route');
+    POST = mod.POST;
+  });
+
+  it('returns 404 when npsEnabled is false', async () => {
+    mockNpsEnabled = false;
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('NPS_DISABLED');
+  });
+
+  it('returns 503 when MongoDB not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('MONGODB_NOT_CONFIGURED');
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin (viewer can\'t create)', async () => {
+    mockGetServerSession.mockResolvedValue(viewerSession);
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('name');
+  });
+
+  it('returns 400 when starts_at or ends_at is missing', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('starts_at');
+  });
+
+  it('returns 400 when ends_at is before starts_at', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: '2026-03-31', ends_at: '2026-03-01' }),
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('ends_at');
+  });
+
+  it('returns 400 when dates are invalid', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: 'not-a-date', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toContain('valid dates');
+  });
+
+  it('returns 409 when campaign overlaps with existing one', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignsCol = createMockCollection();
+    campaignsCol.findOne.mockResolvedValue({
+      _id: new ObjectId(),
+      name: 'Existing Campaign',
+      starts_at: new Date('2026-03-15'),
+      ends_at: new Date('2026-04-15'),
+    });
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toContain('overlaps');
+  });
+
+  it('successfully creates campaign with valid data (returns 201)', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignsCol = createMockCollection();
+    campaignsCol.findOne.mockResolvedValue(null);
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.name).toBe('Q1 NPS');
+    expect(body.data._id).toBeDefined();
+  });
+
+  it('stores created_by as admin email', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignsCol = createMockCollection();
+    campaignsCol.findOne.mockResolvedValue(null);
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: 'Q1 NPS', starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    const inserted = campaignsCol.insertOne.mock.calls[0][0];
+    expect(inserted.created_by).toBe('admin@example.com');
+  });
+
+  it('trims campaign name', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignsCol = createMockCollection();
+    campaignsCol.findOne.mockResolvedValue(null);
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await POST(
+      makeRequest('/api/admin/nps/campaigns', {
+        method: 'POST',
+        body: JSON.stringify({ name: '  Q1 NPS  ', starts_at: '2026-03-01', ends_at: '2026-03-31' }),
+      })
+    );
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.data.name).toBe('Q1 NPS');
+  });
+});
+
+describe('GET /api/admin/nps/campaigns', () => {
+  let GET: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+    mockNpsEnabled = true;
+    mockIsMongoDBConfigured = true;
+
+    const mod = await import('@/app/api/admin/nps/campaigns/route');
+    GET = mod.GET;
+  });
+
+  it('returns 404 when npsEnabled is false', async () => {
+    mockNpsEnabled = false;
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await GET(makeRequest('/api/admin/nps/campaigns'));
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('NPS_DISABLED');
+  });
+
+  it('returns 503 when MongoDB not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await GET(makeRequest('/api/admin/nps/campaigns'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('MONGODB_NOT_CONFIGURED');
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET(makeRequest('/api/admin/nps/campaigns'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user lacks admin view access', async () => {
+    mockGetServerSession.mockResolvedValue(userSession);
+    const res = await GET(makeRequest('/api/admin/nps/campaigns'));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns empty campaigns array when none exist', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['nps_campaigns'] = campaignsCol;
+    mockCollections['nps_responses'] = createMockCollection();
+
+    const res = await GET(makeRequest('/api/admin/nps/campaigns'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.campaigns).toEqual([]);
+  });
+
+  it('returns campaigns with response_count and status', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignId = new ObjectId();
+    const campaigns = [
+      {
+        _id: campaignId,
+        name: 'Q1 NPS',
+        starts_at: new Date('2026-01-01'),
+        ends_at: new Date('2026-01-31'),
+        created_at: new Date('2025-12-01'),
+      },
+    ];
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue(campaigns),
+      }),
+    });
+    const responsesCol = createMockCollection();
+    responsesCol.countDocuments.mockResolvedValue(42);
+    mockCollections['nps_campaigns'] = campaignsCol;
+    mockCollections['nps_responses'] = responsesCol;
+
+    const res = await GET(makeRequest('/api/admin/nps/campaigns'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.campaigns).toHaveLength(1);
+    expect(body.data.campaigns[0].response_count).toBe(42);
+    expect(body.data.campaigns[0].status).toBeDefined();
+  });
+
+  it('admin viewer (canViewAdmin=true) can list campaigns', async () => {
+    mockGetServerSession.mockResolvedValue(viewerSession);
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockCollections['nps_campaigns'] = campaignsCol;
+    mockCollections['nps_responses'] = createMockCollection();
+
+    const res = await GET(makeRequest('/api/admin/nps/campaigns'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.campaigns).toEqual([]);
+  });
+
+  it('correctly computes campaign status: active, ended, scheduled', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const now = new Date('2026-03-15');
+    jest.useFakeTimers();
+    jest.setSystemTime(now);
+
+    const pastCampaign = {
+      _id: new ObjectId(),
+      name: 'Past',
+      starts_at: new Date('2026-01-01'),
+      ends_at: new Date('2026-01-31'),
+      created_at: new Date('2025-12-01'),
+    };
+    const activeCampaign = {
+      _id: new ObjectId(),
+      name: 'Active',
+      starts_at: new Date('2026-03-01'),
+      ends_at: new Date('2026-03-31'),
+      created_at: new Date('2026-02-01'),
+    };
+    const futureCampaign = {
+      _id: new ObjectId(),
+      name: 'Future',
+      starts_at: new Date('2026-04-01'),
+      ends_at: new Date('2026-04-30'),
+      created_at: new Date('2026-03-01'),
+    };
+
+    const campaignsCol = createMockCollection();
+    campaignsCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([pastCampaign, activeCampaign, futureCampaign]),
+      }),
+    });
+    const responsesCol = createMockCollection();
+    responsesCol.countDocuments.mockResolvedValue(0);
+    mockCollections['nps_campaigns'] = campaignsCol;
+    mockCollections['nps_responses'] = responsesCol;
+
+    const res = await GET(makeRequest('/api/admin/nps/campaigns'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+
+    const past = body.data.campaigns.find((c: any) => c.name === 'Past');
+    const active = body.data.campaigns.find((c: any) => c.name === 'Active');
+    const future = body.data.campaigns.find((c: any) => c.name === 'Future');
+
+    expect(past.status).toBe('ended');
+    expect(active.status).toBe('active');
+    expect(future.status).toBe('scheduled');
+
+    jest.useRealTimers();
+  });
+});
+
+describe('PATCH /api/admin/nps/campaigns', () => {
+  let PATCH: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+    mockNpsEnabled = true;
+    mockIsMongoDBConfigured = true;
+
+    const mod = await import('@/app/api/admin/nps/campaigns/route');
+    PATCH = mod.PATCH;
+  });
+
+  it('returns 404 when npsEnabled is false', async () => {
+    mockNpsEnabled = false;
+    jest.resetModules();
+    const mod = await import('@/app/api/admin/nps/campaigns/route');
+    const res = await mod.PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: new ObjectId().toString() }),
+    }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 503 when MongoDB not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    jest.resetModules();
+    const mod = await import('@/app/api/admin/nps/campaigns/route');
+    const res = await mod.PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: new ObjectId().toString() }),
+    }));
+    expect(res.status).toBe(503);
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: new ObjectId().toString() }),
+    }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not admin', async () => {
+    mockGetServerSession.mockResolvedValue(viewerSession);
+    const res = await PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: new ObjectId().toString() }),
+    }));
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 when campaign_id is missing', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const res = await PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({}),
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 400 when campaign_id format is invalid', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignsCol = createMockCollection();
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: 'not-a-valid-objectid' }),
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 404 when campaign not found', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignsCol = createMockCollection();
+    campaignsCol.findOne.mockResolvedValue(null);
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: new ObjectId().toString() }),
+    }));
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 when campaign has already ended', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignsCol = createMockCollection();
+    campaignsCol.findOne.mockResolvedValue({
+      _id: new ObjectId(),
+      name: 'Old Campaign',
+      ends_at: new Date('2025-01-01'),
+    });
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: new ObjectId().toString() }),
+    }));
+    expect(res.status).toBe(400);
+  });
+
+  it('successfully stops an active campaign', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignId = new ObjectId();
+    const campaignsCol = createMockCollection();
+    campaignsCol.findOne.mockResolvedValue({
+      _id: campaignId,
+      name: 'Active Campaign',
+      starts_at: new Date('2026-01-01'),
+      ends_at: new Date('2026-12-31'),
+    });
+    campaignsCol.updateOne.mockResolvedValue({ modifiedCount: 1 });
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: campaignId.toString() }),
+    }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.stopped).toBe(true);
+    expect(body.data.ended_at).toBeDefined();
+
+    expect(campaignsCol.updateOne).toHaveBeenCalledWith(
+      { _id: campaignId },
+      expect.objectContaining({
+        $set: expect.objectContaining({
+          stopped_by: 'admin@example.com',
+        }),
+      })
+    );
+  });
+
+  it('records stopped_by and stopped_at in the update', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession);
+    const campaignId = new ObjectId();
+    const campaignsCol = createMockCollection();
+    campaignsCol.findOne.mockResolvedValue({
+      _id: campaignId,
+      name: 'Scheduled Campaign',
+      starts_at: new Date('2026-06-01'),
+      ends_at: new Date('2026-06-30'),
+    });
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    await PATCH(makeRequest('/api/admin/nps/campaigns', {
+      method: 'PATCH',
+      body: JSON.stringify({ campaign_id: campaignId.toString() }),
+    }));
+
+    const updateCall = campaignsCol.updateOne.mock.calls[0][1];
+    expect(updateCall.$set.stopped_by).toBe('admin@example.com');
+    expect(updateCall.$set.stopped_at).toBeInstanceOf(Date);
+    expect(updateCall.$set.ends_at).toBeInstanceOf(Date);
+  });
+});

--- a/ui/src/app/api/__tests__/nps-submit.test.ts
+++ b/ui/src/app/api/__tests__/nps-submit.test.ts
@@ -1,0 +1,381 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: any[]) => mockGetServerSession(...args),
+}));
+jest.mock('@/lib/auth-config', () => ({ authOptions: {} }));
+
+let mockNpsEnabled = true;
+jest.mock('@/lib/config', () => ({
+  getConfig: (key: string) => {
+    if (key === 'npsEnabled') return mockNpsEnabled;
+    return key === 'ssoEnabled';
+  },
+}));
+
+const mockCollections: Record<string, any> = {};
+const mockGetCollection = jest.fn((name: string) => {
+  if (!mockCollections[name]) mockCollections[name] = createMockCollection();
+  return Promise.resolve(mockCollections[name]);
+});
+let mockIsMongoDBConfigured = true;
+jest.mock('@/lib/mongodb', () => ({
+  getCollection: (...args: any[]) => mockGetCollection(...args),
+  get isMongoDBConfigured() {
+    return mockIsMongoDBConfigured;
+  },
+}));
+jest.spyOn(console, 'error').mockImplementation(() => {});
+jest.spyOn(console, 'log').mockImplementation(() => {});
+jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+function createMockCollection() {
+  const findReturnValue = {
+    sort: jest.fn().mockReturnValue({
+      skip: jest.fn().mockReturnValue({
+        limit: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([]),
+        }),
+      }),
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+    toArray: jest.fn().mockResolvedValue([]),
+  };
+  return {
+    find: jest.fn().mockReturnValue(findReturnValue),
+    findOne: jest.fn().mockResolvedValue(null),
+    insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: jest.fn().mockResolvedValue(0),
+    aggregate: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+  };
+}
+
+function makeRequest(url: string, options: RequestInit = {}): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost:3000'), options);
+}
+
+function userSession() {
+  return {
+    user: { email: 'user@example.com', name: 'User' },
+    role: 'user',
+    canViewAdmin: false,
+  };
+}
+
+function adminSession() {
+  return {
+    user: { email: 'admin@example.com', name: 'Admin' },
+    role: 'admin',
+    canViewAdmin: true,
+  };
+}
+
+describe('POST /api/nps', () => {
+  let POST: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+    mockGetCollection.mockClear();
+    mockNpsEnabled = true;
+    mockIsMongoDBConfigured = true;
+
+    const mod = await import('@/app/api/nps/route');
+    POST = mod.POST;
+  });
+
+  it('returns 404 when npsEnabled is false', async () => {
+    mockNpsEnabled = false;
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 9 }),
+      })
+    );
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('NPS_DISABLED');
+  });
+
+  it('returns 503 when MongoDB not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 9 }),
+      })
+    );
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('MONGODB_NOT_CONFIGURED');
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 9 }),
+      })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects score -1', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: -1 }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects score 11', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 11 }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects score 5.5', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 5.5 }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('rejects score "abc"', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 'abc' }),
+      })
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('successfully submits with score only (no comment)', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 9 }),
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.submitted).toBe(true);
+
+    const col = mockCollections['nps_responses'];
+    expect(col.insertOne).toHaveBeenCalledTimes(1);
+    const inserted = col.insertOne.mock.calls[0][0];
+    expect(inserted.score).toBe(9);
+    expect(inserted.comment).toBeUndefined();
+    expect(inserted.campaign_id).toBeUndefined();
+  });
+
+  it('successfully submits with score + comment', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 8, comment: 'great product' }),
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.submitted).toBe(true);
+
+    const col = mockCollections['nps_responses'];
+    const inserted = col.insertOne.mock.calls[0][0];
+    expect(inserted.score).toBe(8);
+    expect(inserted.comment).toBe('great product');
+  });
+
+  it('successfully submits with score + campaign_id', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 9, campaign_id: 'camp-123' }),
+      })
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.submitted).toBe(true);
+
+    const col = mockCollections['nps_responses'];
+    const inserted = col.insertOne.mock.calls[0][0];
+    expect(inserted.score).toBe(9);
+    expect(inserted.campaign_id).toBe('camp-123');
+  });
+
+  it('truncates comment to 1000 chars', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const longComment = 'x'.repeat(1500);
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 7, comment: longComment }),
+      })
+    );
+    expect(res.status).toBe(200);
+
+    const col = mockCollections['nps_responses'];
+    const inserted = col.insertOne.mock.calls[0][0];
+    expect(inserted.comment).toHaveLength(1000);
+  });
+
+  it('stores user_email from session', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 10 }),
+      })
+    );
+
+    const col = mockCollections['nps_responses'];
+    const inserted = col.insertOne.mock.calls[0][0];
+    expect(inserted.user_email).toBe('user@example.com');
+  });
+
+  it('returns { submitted: true } on success', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await POST(
+      makeRequest('/api/nps', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ score: 9 }),
+      })
+    );
+    const body = await res.json();
+    expect(body.data).toEqual({ submitted: true });
+  });
+});
+
+describe('GET /api/nps/active', () => {
+  let GET: any;
+
+  beforeEach(async () => {
+    jest.resetModules();
+    Object.keys(mockCollections).forEach((k) => delete mockCollections[k]);
+    mockGetCollection.mockClear();
+    mockNpsEnabled = true;
+    mockIsMongoDBConfigured = true;
+
+    const modActive = await import('@/app/api/nps/active/route');
+    GET = modActive.GET;
+  });
+
+  it('returns { active: false } when npsEnabled is false (200 status, not 404)', async () => {
+    mockNpsEnabled = false;
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await GET(makeRequest('/api/nps/active'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.data.active).toBe(false);
+  });
+
+  it('returns 503 when MongoDB not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    mockGetServerSession.mockResolvedValue(userSession());
+    const res = await GET(makeRequest('/api/nps/active'));
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('MONGODB_NOT_CONFIGURED');
+  });
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await GET(makeRequest('/api/nps/active'));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns { active: false } when no active campaign', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const campaignsCol = mockCollections['nps_campaigns'] || createMockCollection();
+    campaignsCol.findOne.mockResolvedValue(null);
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await GET(makeRequest('/api/nps/active'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.active).toBe(false);
+  });
+
+  it('returns { active: true, campaign: { id, name, ends_at } } when campaign exists', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const campaignId = new ObjectId();
+    const startsAt = new Date('2026-01-01');
+    const endsAt = new Date('2026-12-31');
+    const campaignDoc = {
+      _id: campaignId,
+      name: 'Q1 2026 NPS',
+      starts_at: startsAt,
+      ends_at: endsAt,
+    };
+
+    const campaignsCol = mockCollections['nps_campaigns'] || createMockCollection();
+    campaignsCol.findOne.mockResolvedValue(campaignDoc);
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    const res = await GET(makeRequest('/api/nps/active'));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.active).toBe(true);
+    expect(body.data.campaign.id).toBe(campaignId.toString());
+    expect(body.data.campaign.name).toBe('Q1 2026 NPS');
+    expect(body.data.campaign.ends_at).toBe(endsAt.toISOString());
+  });
+
+  it('only matches campaigns where now is between starts_at and ends_at', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+    const campaignsCol = mockCollections['nps_campaigns'] || createMockCollection();
+    campaignsCol.findOne.mockResolvedValue(null);
+    mockCollections['nps_campaigns'] = campaignsCol;
+
+    await GET(makeRequest('/api/nps/active'));
+
+    const findOneCall = campaignsCol.findOne.mock.calls[0][0];
+    expect(findOneCall.starts_at).toEqual({ $lte: expect.any(Date) });
+    expect(findOneCall.ends_at).toEqual({ $gte: expect.any(Date) });
+  });
+});

--- a/ui/src/app/api/admin/feedback/route.ts
+++ b/ui/src/app/api/admin/feedback/route.ts
@@ -1,0 +1,98 @@
+// GET /api/admin/feedback - Get paginated feedback entries for admin dashboard
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import {
+  withAuth,
+  withErrorHandler,
+  successResponse,
+  requireAdminView,
+} from '@/lib/api-middleware';
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'MongoDB not configured - admin features require MongoDB',
+        code: 'MONGODB_NOT_CONFIGURED',
+      },
+      { status: 503 }
+    );
+  }
+
+  return withAuth(request, async (req, user, session) => {
+    requireAdminView(session);
+
+    const { searchParams } = new URL(req.url);
+    const rating = searchParams.get('rating'); // 'positive' | 'negative' | null (all)
+    const page = Math.max(1, parseInt(searchParams.get('page') || '1', 10));
+    const limit = Math.min(100, Math.max(1, parseInt(searchParams.get('limit') || '50', 10)));
+    const skip = (page - 1) * limit;
+
+    const messages = await getCollection('messages');
+
+    const filter: Record<string, any> = {
+      'feedback.rating': { $exists: true },
+    };
+    if (rating === 'positive' || rating === 'negative') {
+      filter['feedback.rating'] = rating;
+    }
+
+    const conversations = await getCollection('conversations');
+
+    const [feedbackEntries, totalCount] = await Promise.all([
+      messages
+        .find(filter, {
+          projection: {
+            _id: 1,
+            message_id: 1,
+            conversation_id: 1,
+            content: 1,
+            role: 1,
+            feedback: 1,
+            created_at: 1,
+            owner_id: 1,
+          },
+        })
+        .sort({ 'feedback.submitted_at': -1 })
+        .skip(skip)
+        .limit(limit)
+        .toArray(),
+      messages.countDocuments(filter),
+    ]);
+
+    // Batch-fetch conversation titles for all unique conversation IDs
+    const convIds = [...new Set(feedbackEntries.map((m: any) => m.conversation_id).filter(Boolean))];
+    const convDocs = convIds.length > 0
+      ? await conversations
+          .find({ _id: { $in: convIds } }, { projection: { _id: 1, title: 1 } })
+          .toArray()
+      : [];
+    const convTitleMap = new Map(convDocs.map((c: any) => [c._id, c.title]));
+
+    const entries = feedbackEntries.map((msg: any) => ({
+      message_id: msg.message_id || msg._id?.toString(),
+      conversation_id: msg.conversation_id,
+      conversation_title: convTitleMap.get(msg.conversation_id) || undefined,
+      content_snippet: typeof msg.content === 'string'
+        ? msg.content.slice(0, 200) + (msg.content.length > 200 ? '...' : '')
+        : '',
+      role: msg.role,
+      rating: msg.feedback?.rating,
+      reason: msg.feedback?.comment,
+      submitted_by: msg.feedback?.submitted_by || msg.owner_id || 'unknown',
+      submitted_at: msg.feedback?.submitted_at,
+    }));
+
+    return successResponse({
+      entries,
+      pagination: {
+        page,
+        limit,
+        total: totalCount,
+        total_pages: Math.ceil(totalCount / limit),
+      },
+    });
+  });
+});

--- a/ui/src/app/api/admin/feedback/route.ts
+++ b/ui/src/app/api/admin/feedback/route.ts
@@ -2,6 +2,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getConfig } from '@/lib/config';
 import {
   withAuth,
   withErrorHandler,
@@ -10,6 +11,13 @@ import {
 } from '@/lib/api-middleware';
 
 export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!getConfig('feedbackEnabled')) {
+    return NextResponse.json(
+      { success: false, error: 'Feedback feature is not enabled', code: 'FEEDBACK_DISABLED' },
+      { status: 404 }
+    );
+  }
+
   if (!isMongoDBConfigured) {
     return NextResponse.json(
       {

--- a/ui/src/app/api/admin/nps/campaigns/route.ts
+++ b/ui/src/app/api/admin/nps/campaigns/route.ts
@@ -1,0 +1,170 @@
+// POST  /api/admin/nps/campaigns - Create a new NPS campaign
+// GET   /api/admin/nps/campaigns - List all campaigns
+// PATCH /api/admin/nps/campaigns - Stop (end early) a campaign
+
+import { NextRequest, NextResponse } from 'next/server';
+import { ObjectId } from 'mongodb';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getConfig } from '@/lib/config';
+import {
+  withAuth,
+  withErrorHandler,
+  successResponse,
+  requireAdmin,
+  requireAdminView,
+  ApiError,
+} from '@/lib/api-middleware';
+
+function npsDisabledResponse() {
+  return NextResponse.json(
+    { success: false, error: 'NPS feature is not enabled', code: 'NPS_DISABLED' },
+    { status: 404 }
+  );
+}
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  if (!getConfig('npsEnabled')) return npsDisabledResponse();
+
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  return withAuth(request, async (req, user, session) => {
+    requireAdmin(session);
+
+    const body = await request.json();
+
+    const { name, starts_at, ends_at } = body;
+
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      throw new ApiError('name is required', 400);
+    }
+    if (!starts_at || !ends_at) {
+      throw new ApiError('starts_at and ends_at are required', 400);
+    }
+
+    const startDate = new Date(starts_at);
+    const endDate = new Date(ends_at);
+
+    if (isNaN(startDate.getTime()) || isNaN(endDate.getTime())) {
+      throw new ApiError('starts_at and ends_at must be valid dates', 400);
+    }
+    if (endDate <= startDate) {
+      throw new ApiError('ends_at must be after starts_at', 400);
+    }
+
+    const campaigns = await getCollection('nps_campaigns');
+
+    // Prevent overlapping active campaigns
+    const overlapping = await campaigns.findOne({
+      $or: [
+        { starts_at: { $lte: endDate }, ends_at: { $gte: startDate } },
+      ],
+    });
+
+    if (overlapping) {
+      throw new ApiError(
+        `Campaign "${overlapping.name}" overlaps with the requested date range`,
+        409
+      );
+    }
+
+    const doc = {
+      name: name.trim(),
+      starts_at: startDate,
+      ends_at: endDate,
+      created_by: user.email,
+      created_at: new Date(),
+    };
+
+    const result = await campaigns.insertOne(doc);
+
+    return successResponse({ ...doc, _id: result.insertedId }, 201);
+  });
+});
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!getConfig('npsEnabled')) return npsDisabledResponse();
+
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  return withAuth(request, async (req, user, session) => {
+    requireAdminView(session);
+
+    const campaigns = await getCollection('nps_campaigns');
+    const npsResponses = await getCollection('nps_responses');
+
+    const allCampaigns = await campaigns.find({}).sort({ created_at: -1 }).toArray();
+
+    const now = new Date();
+    const enriched = await Promise.all(
+      allCampaigns.map(async (c: any) => {
+        const responseCount = await npsResponses.countDocuments({ campaign_id: c._id.toString() });
+        const isActive = new Date(c.starts_at) <= now && new Date(c.ends_at) >= now;
+        return {
+          ...c,
+          response_count: responseCount,
+          status: isActive ? 'active' : new Date(c.ends_at) < now ? 'ended' : 'scheduled',
+        };
+      })
+    );
+
+    return successResponse({ campaigns: enriched });
+  });
+});
+
+export const PATCH = withErrorHandler(async (request: NextRequest) => {
+  if (!getConfig('npsEnabled')) return npsDisabledResponse();
+
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  return withAuth(request, async (req, user, session) => {
+    requireAdmin(session);
+
+    const body = await request.json();
+    const { campaign_id } = body;
+
+    if (!campaign_id || typeof campaign_id !== 'string') {
+      throw new ApiError('campaign_id is required', 400);
+    }
+
+    const campaigns = await getCollection('nps_campaigns');
+
+    let objectId: ObjectId;
+    try {
+      objectId = new ObjectId(campaign_id);
+    } catch {
+      throw new ApiError('Invalid campaign_id format', 400);
+    }
+
+    const campaign = await campaigns.findOne({ _id: objectId });
+    if (!campaign) {
+      throw new ApiError('Campaign not found', 404);
+    }
+
+    const now = new Date();
+    if (new Date(campaign.ends_at) < now) {
+      throw new ApiError('Campaign has already ended', 400);
+    }
+
+    await campaigns.updateOne(
+      { _id: objectId },
+      { $set: { ends_at: now, stopped_by: user.email, stopped_at: now } }
+    );
+
+    return successResponse({ stopped: true, ended_at: now });
+  });
+});

--- a/ui/src/app/api/admin/nps/route.ts
+++ b/ui/src/app/api/admin/nps/route.ts
@@ -1,0 +1,166 @@
+// GET /api/admin/nps - Get NPS analytics for admin dashboard
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getConfig } from '@/lib/config';
+import {
+  withAuth,
+  withErrorHandler,
+  successResponse,
+  requireAdminView,
+} from '@/lib/api-middleware';
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!getConfig('npsEnabled')) {
+    return NextResponse.json(
+      { success: false, error: 'NPS feature is not enabled', code: 'NPS_DISABLED' },
+      { status: 404 }
+    );
+  }
+
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'MongoDB not configured - admin features require MongoDB',
+        code: 'MONGODB_NOT_CONFIGURED',
+      },
+      { status: 503 }
+    );
+  }
+
+  return withAuth(request, async (req, user, session) => {
+    requireAdminView(session);
+
+    const url = new URL(request.url);
+    const campaignIdFilter = url.searchParams.get('campaign_id') || undefined;
+
+    const npsResponses = await getCollection('nps_responses');
+    const now = new Date();
+    const last30Days = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+
+    const responseFilter: Record<string, any> = {};
+    if (campaignIdFilter) {
+      responseFilter.campaign_id = campaignIdFilter;
+    }
+
+    // Overall breakdown (filtered by campaign when specified)
+    const allResponses = await npsResponses
+      .find(responseFilter)
+      .sort({ created_at: -1 })
+      .toArray();
+
+    const totalResponses = allResponses.length;
+
+    let promoters = 0;
+    let passives = 0;
+    let detractors = 0;
+
+    for (const r of allResponses) {
+      if (r.score >= 9) promoters++;
+      else if (r.score >= 7) passives++;
+      else detractors++;
+    }
+
+    const npsScore = totalResponses > 0
+      ? Math.round(((promoters - detractors) / totalResponses) * 100)
+      : 0;
+
+    // 30-day daily trend (filtered by campaign when specified)
+    const trendMatch: Record<string, any> = { created_at: { $gte: last30Days } };
+    if (campaignIdFilter) {
+      trendMatch.campaign_id = campaignIdFilter;
+    }
+
+    const dailyAgg = await npsResponses.aggregate([
+      { $match: trendMatch },
+      {
+        $group: {
+          _id: { $dateToString: { format: '%Y-%m-%d', date: '$created_at' } },
+          avg_score: { $avg: '$score' },
+          count: { $sum: 1 },
+          promoters: {
+            $sum: { $cond: [{ $gte: ['$score', 9] }, 1, 0] },
+          },
+          detractors: {
+            $sum: { $cond: [{ $lt: ['$score', 7] }, 1, 0] },
+          },
+        },
+      },
+      { $sort: { _id: 1 } },
+    ]).toArray();
+
+    // Build 30-day trend with filled gaps
+    const trendMap = new Map(
+      dailyAgg.map((d: any) => [
+        d._id,
+        {
+          avg_score: Math.round(d.avg_score * 10) / 10,
+          count: d.count,
+          nps: d.count > 0
+            ? Math.round(((d.promoters - d.detractors) / d.count) * 100)
+            : null,
+        },
+      ])
+    );
+
+    const trend = [];
+    for (let i = 29; i >= 0; i--) {
+      const dayStart = new Date(now.getTime() - i * 24 * 60 * 60 * 1000);
+      dayStart.setHours(0, 0, 0, 0);
+      const dateKey = dayStart.toISOString().split('T')[0];
+      const dayData = trendMap.get(dateKey);
+      trend.push({
+        date: dateKey,
+        avg_score: dayData?.avg_score ?? null,
+        count: dayData?.count ?? 0,
+        nps: dayData?.nps ?? null,
+      });
+    }
+
+    // Recent responses (last 20)
+    const recentResponses = allResponses.slice(0, 20).map((r: any) => ({
+      user_email: r.user_email,
+      score: r.score,
+      comment: r.comment,
+      created_at: r.created_at,
+    }));
+
+    // Fetch campaigns with response counts
+    const campaignsCol = await getCollection('nps_campaigns');
+    const allCampaigns = await campaignsCol.find({}).sort({ created_at: -1 }).toArray();
+
+    const campaigns = await Promise.all(
+      allCampaigns.map(async (c: any) => {
+        const responseCount = await npsResponses.countDocuments({ campaign_id: c._id.toString() });
+        const isActive = new Date(c.starts_at) <= now && new Date(c.ends_at) >= now;
+        return {
+          _id: c._id,
+          name: c.name,
+          starts_at: c.starts_at,
+          ends_at: c.ends_at,
+          created_by: c.created_by,
+          created_at: c.created_at,
+          response_count: responseCount,
+          status: isActive ? 'active' : new Date(c.ends_at) < now ? 'ended' : 'scheduled',
+        };
+      })
+    );
+
+    return successResponse({
+      nps_score: npsScore,
+      total_responses: totalResponses,
+      breakdown: {
+        promoters,
+        passives,
+        detractors,
+        promoter_pct: totalResponses > 0 ? Math.round((promoters / totalResponses) * 100) : 0,
+        passive_pct: totalResponses > 0 ? Math.round((passives / totalResponses) * 100) : 0,
+        detractor_pct: totalResponses > 0 ? Math.round((detractors / totalResponses) * 100) : 0,
+      },
+      trend,
+      recent_responses: recentResponses,
+      campaigns,
+    });
+  });
+});

--- a/ui/src/app/api/chat/conversations/[id]/messages/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/messages/route.ts
@@ -74,9 +74,9 @@ export const POST = withErrorHandler(async (
       conversationId, user.email, getCollection, session
     );
 
-    // Admin audit access is read-only — block writes
-    if (access_level === 'admin_audit') {
-      throw new ApiError('Read-only audit access — cannot add messages', 403, 'FORBIDDEN');
+    // Read-only access — block writes
+    if (access_level === 'admin_audit' || access_level === 'shared_readonly') {
+      throw new ApiError('Read-only access — cannot add messages', 403, 'FORBIDDEN');
     }
 
     const conversations = await getCollection<Conversation>('conversations');

--- a/ui/src/app/api/chat/conversations/[id]/messages/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/messages/route.ts
@@ -21,7 +21,7 @@ export const GET = withErrorHandler(async (
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) => {
-  return withAuth(request, async (req, user) => {
+  return withAuth(request, async (req, user, session) => {
     const params = await context.params;
     const conversationId = params.id;
 
@@ -29,8 +29,8 @@ export const GET = withErrorHandler(async (
       throw new ApiError('Invalid conversation ID format', 400);
     }
 
-    // Verify user has access
-    await requireConversationAccess(conversationId, user.email, getCollection);
+    // Verify user has access (admins get read-only audit access)
+    await requireConversationAccess(conversationId, user.email, getCollection, session);
 
     const { page, pageSize, skip } = getPaginationParams(request);
 
@@ -58,7 +58,7 @@ export const POST = withErrorHandler(async (
   request: NextRequest,
   context: { params: Promise<{ id: string }> }
 ) => {
-  return withAuth(request, async (req, user) => {
+  return withAuth(request, async (req, user, session) => {
     const params = await context.params;
     const conversationId = params.id;
     const body: AddMessageRequest = await request.json();
@@ -70,7 +70,14 @@ export const POST = withErrorHandler(async (
     validateRequired(body, ['role', 'content']);
 
     // Verify user has access and get conversation for owner_id
-    await requireConversationAccess(conversationId, user.email, getCollection);
+    const { access_level } = await requireConversationAccess(
+      conversationId, user.email, getCollection, session
+    );
+
+    // Admin audit access is read-only — block writes
+    if (access_level === 'admin_audit') {
+      throw new ApiError('Read-only audit access — cannot add messages', 403, 'FORBIDDEN');
+    }
 
     const conversations = await getCollection<Conversation>('conversations');
     const conversation = await conversations.findOne({ _id: conversationId });

--- a/ui/src/app/api/chat/conversations/[id]/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/route.ts
@@ -32,7 +32,7 @@ export const GET = withErrorHandler(async (
     );
   }
 
-  return withAuth(request, async (req, user) => {
+  return withAuth(request, async (req, user, session) => {
     const params = await context.params;
     const conversationId = params.id;
 
@@ -40,13 +40,14 @@ export const GET = withErrorHandler(async (
       throw new ApiError('Invalid conversation ID format', 400);
     }
 
-    const conversation = await requireConversationAccess(
+    const { conversation, access_level } = await requireConversationAccess(
       conversationId,
       user.email,
-      getCollection
+      getCollection,
+      session
     );
 
-    return successResponse(conversation);
+    return successResponse({ ...conversation, access_level });
   });
 });
 

--- a/ui/src/app/api/chat/conversations/[id]/share/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/share/route.ts
@@ -148,6 +148,14 @@ export const POST = withErrorHandler(async (
       // Update conversation shared_with_teams
       const existingSharedWithTeams = conversation.sharing?.shared_with_teams || [];
       update['sharing.shared_with_teams'] = [...new Set([...existingSharedWithTeams, ...body.team_ids])];
+
+      // Store per-team permission
+      const existingTeamPerms = conversation.sharing?.team_permissions || {};
+      const newTeamPerms = { ...existingTeamPerms };
+      for (const teamId of body.team_ids) {
+        newTeamPerms[teamId] = body.permission;
+      }
+      update['sharing.team_permissions'] = newTeamPerms;
     }
 
     if (body.is_public !== undefined) {
@@ -169,6 +177,58 @@ export const POST = withErrorHandler(async (
 
     const updated = await conversations.findOne({ _id: conversationId });
 
+    return successResponse(updated);
+  });
+});
+
+// PATCH /api/chat/conversations/[id]/share — update permission for a user or team
+export const PATCH = withErrorHandler(async (
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) => {
+  return withAuth(request, async (req, user) => {
+    const params = await context.params;
+    const conversationId = params.id;
+    const body = await request.json();
+
+    if (!validateUUID(conversationId)) {
+      throw new ApiError('Invalid conversation ID format', 400);
+    }
+
+    const { email, team_id, permission } = body;
+    if (!permission || !['view', 'comment'].includes(permission)) {
+      throw new ApiError('permission must be "view" or "comment"', 400);
+    }
+    if (!email && !team_id) {
+      throw new ApiError('email or team_id is required', 400);
+    }
+
+    const conversations = await getCollection<Conversation>('conversations');
+    const conversation = await conversations.findOne({ _id: conversationId });
+    if (!conversation) {
+      throw new ApiError('Conversation not found', 404);
+    }
+
+    requireOwnership(conversation.owner_id, user.email);
+
+    if (email) {
+      const sharingAccess = await getCollection<SharingAccess>('sharing_access');
+      await sharingAccess.updateOne(
+        { conversation_id: conversationId, granted_to: email, revoked_at: null },
+        { $set: { permission } }
+      );
+    }
+
+    if (team_id) {
+      const teamPerms = conversation.sharing?.team_permissions || {};
+      teamPerms[team_id] = permission;
+      await conversations.updateOne(
+        { _id: conversationId },
+        { $set: { 'sharing.team_permissions': teamPerms } }
+      );
+    }
+
+    const updated = await conversations.findOne({ _id: conversationId });
     return successResponse(updated);
   });
 });

--- a/ui/src/app/api/chat/conversations/[id]/share/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/share/route.ts
@@ -162,6 +162,10 @@ export const POST = withErrorHandler(async (
       update['sharing.is_public'] = body.is_public;
     }
 
+    if (body.public_permission) {
+      update['sharing.public_permission'] = body.public_permission;
+    }
+
     if (body.enable_link !== undefined) {
       update['sharing.share_link_enabled'] = body.enable_link;
     }

--- a/ui/src/app/api/chat/messages/[id]/route.ts
+++ b/ui/src/app/api/chat/messages/[id]/route.ts
@@ -47,6 +47,7 @@ export const PUT = withErrorHandler(async (
         rating: body.feedback.rating,
         comment: body.feedback.comment,
         submitted_at: new Date(),
+        submitted_by: user.email,
       };
     }
 

--- a/ui/src/app/api/nps/active/route.ts
+++ b/ui/src/app/api/nps/active/route.ts
@@ -1,0 +1,49 @@
+// GET /api/nps/active - Check for an active NPS campaign for the current user
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getConfig } from '@/lib/config';
+import {
+  withAuth,
+  withErrorHandler,
+  successResponse,
+} from '@/lib/api-middleware';
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!getConfig('npsEnabled')) {
+    return NextResponse.json(
+      { success: false, data: { active: false } },
+      { status: 200 }
+    );
+  }
+
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+      { status: 503 }
+    );
+  }
+
+  return withAuth(request, async (req, user) => {
+    const campaigns = await getCollection('nps_campaigns');
+    const now = new Date();
+
+    const activeCampaign = await campaigns.findOne({
+      starts_at: { $lte: now },
+      ends_at: { $gte: now },
+    });
+
+    if (!activeCampaign) {
+      return successResponse({ active: false });
+    }
+
+    return successResponse({
+      active: true,
+      campaign: {
+        id: activeCampaign._id.toString(),
+        name: activeCampaign.name,
+        ends_at: activeCampaign.ends_at,
+      },
+    });
+  });
+});

--- a/ui/src/app/api/nps/route.ts
+++ b/ui/src/app/api/nps/route.ts
@@ -1,0 +1,55 @@
+// POST /api/nps - Submit NPS (Net Promoter Score) response
+
+import { NextRequest, NextResponse } from 'next/server';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getConfig } from '@/lib/config';
+import {
+  withAuth,
+  withErrorHandler,
+  successResponse,
+  ApiError,
+} from '@/lib/api-middleware';
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  if (!getConfig('npsEnabled')) {
+    return NextResponse.json(
+      { success: false, error: 'NPS feature is not enabled', code: 'NPS_DISABLED' },
+      { status: 404 }
+    );
+  }
+
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      {
+        success: false,
+        error: 'MongoDB not configured',
+        code: 'MONGODB_NOT_CONFIGURED',
+      },
+      { status: 503 }
+    );
+  }
+
+  return withAuth(request, async (req, user) => {
+    const body = await request.json();
+
+    const score = body.score;
+    if (typeof score !== 'number' || score < 0 || score > 10 || !Number.isInteger(score)) {
+      throw new ApiError('score must be an integer between 0 and 10', 400);
+    }
+
+    const comment = typeof body.comment === 'string' ? body.comment.trim().slice(0, 1000) : undefined;
+    const campaign_id = typeof body.campaign_id === 'string' ? body.campaign_id : undefined;
+
+    const npsResponses = await getCollection('nps_responses');
+
+    await npsResponses.insertOne({
+      user_email: user.email,
+      score,
+      comment: comment || undefined,
+      ...(campaign_id && { campaign_id }),
+      created_at: new Date(),
+    });
+
+    return successResponse({ submitted: true });
+  });
+});

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -3,7 +3,7 @@
 import React, { useState, useRef, useEffect, useCallback, useMemo } from "react";
 import { useSession } from "next-auth/react";
 import { motion, AnimatePresence } from "framer-motion";
-import { Send, Square, User, Bot, Sparkles, Copy, Check, Loader2, ChevronDown, ChevronUp, ArrowDown, RotateCcw, Gitlab, Slack, Video, Activity, MessageSquare, Clock } from "lucide-react";
+import { Send, Square, User, Bot, Sparkles, Copy, Check, Loader2, ChevronDown, ChevronUp, ArrowDown, ArrowLeft, RotateCcw, Gitlab, Slack, Video, Activity, MessageSquare, Clock, ShieldCheck } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
@@ -18,6 +18,7 @@ import { isFeatureEnabled, useFeatureFlagStore } from "@/store/feature-flag-stor
 import { cn, deduplicateByKey } from "@/lib/utils";
 import { ChatMessage as ChatMessageType, A2AEvent } from "@/types/a2a";
 import { getConfig } from "@/lib/config";
+import { apiClient } from "@/lib/api-client";
 import { FeedbackButton, Feedback } from "./FeedbackButton";
 import { DEFAULT_AGENTS, CustomCall } from "./CustomCallButtons";
 import { AGENT_LOGOS } from "@/components/shared/AgentLogos";
@@ -27,9 +28,10 @@ interface ChatPanelProps {
   endpoint: string;
   conversationId?: string; // MongoDB conversation UUID
   conversationTitle?: string;
+  readOnly?: boolean;
 }
 
-export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatPanelProps) {
+export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnly }: ChatPanelProps) {
   const { data: session } = useSession();
   const autoScrollEnabled = useFeatureFlagStore((s) => s.flags.autoScroll ?? true);
   const showTimestamps = useFeatureFlagStore((s) => s.flags.showTimestamps ?? false);
@@ -730,10 +732,19 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
     }
   }, [activeConversationId, updateMessageFeedback]);
 
-  // Stable callback for feedback submission
+  // Stable callback for feedback submission — persist to MongoDB alongside Langfuse
   const handleFeedbackSubmit = useCallback(async (messageId: string, feedback: Feedback) => {
-    console.log("Feedback submitted:", { messageId, feedback });
-    // Future: Send to /api/feedback endpoint
+    if (!feedback.type || getConfig('storageMode') !== 'mongodb') return;
+    try {
+      await apiClient.updateMessage(messageId, {
+        feedback: {
+          rating: feedback.type === 'like' ? 'positive' : 'negative',
+          comment: feedback.reason === 'Other' ? feedback.additionalFeedback : feedback.reason,
+        },
+      });
+    } catch (err) {
+      console.error('[ChatPanel] Failed to persist feedback to MongoDB:', err);
+    }
   }, []);
 
   // Handle user input form submission via HITL resume (not plain text)
@@ -1131,6 +1142,24 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
       </AnimatePresence>
 
       {/* Input Area - Fixed bottom, doesn't scroll */}
+      {readOnly ? (
+        <div className="border-t border-border bg-amber-500/10 shrink-0">
+          <div className="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
+            <div className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
+              <ShieldCheck className="h-4 w-4 shrink-0" />
+              <span className="text-sm font-medium">Read-Only Audit Mode</span>
+              <span className="text-xs text-amber-600 dark:text-amber-500">— You are viewing this conversation as an admin auditor.</span>
+            </div>
+            <a
+              href="/admin?tab=feedback"
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-amber-600/20 text-amber-700 dark:text-amber-300 hover:bg-amber-600/30 transition-colors"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              Back to Feedback
+            </a>
+          </div>
+        </div>
+      ) : (
       <div className="border-t border-border bg-background shrink-0">
         <div className="max-w-7xl mx-auto px-6 py-3 space-y-2">
           {/* Queued Messages Display */}
@@ -1263,6 +1292,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle }: ChatP
           </p>
         </div>
       </div>
+      )}
     </div>
   );
 }

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -24,14 +24,17 @@ import { DEFAULT_AGENTS, CustomCall } from "./CustomCallButtons";
 import { AGENT_LOGOS } from "@/components/shared/AgentLogos";
 import { MetadataInputForm, type UserInputMetadata, type InputField } from "./MetadataInputForm";
 
+type ReadOnlyReason = 'admin_audit' | 'shared_readonly';
+
 interface ChatPanelProps {
   endpoint: string;
   conversationId?: string; // MongoDB conversation UUID
   conversationTitle?: string;
   readOnly?: boolean;
+  readOnlyReason?: ReadOnlyReason;
 }
 
-export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnly }: ChatPanelProps) {
+export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnly, readOnlyReason }: ChatPanelProps) {
   const { data: session } = useSession();
   const autoScrollEnabled = useFeatureFlagStore((s) => s.flags.autoScroll ?? true);
   const showTimestamps = useFeatureFlagStore((s) => s.flags.showTimestamps ?? false);
@@ -1147,9 +1150,19 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
           <div className="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
             <div className="flex items-center gap-2 text-amber-700 dark:text-amber-400">
               <ShieldCheck className="h-4 w-4 shrink-0" />
-              <span className="text-sm font-medium">Read-Only Audit Mode</span>
-              <span className="text-xs text-amber-600 dark:text-amber-500">— You are viewing this conversation as an admin auditor.</span>
+              {readOnlyReason === 'admin_audit' ? (
+                <>
+                  <span className="text-sm font-medium">Read-Only Audit Mode</span>
+                  <span className="text-xs text-amber-600 dark:text-amber-500">— You are viewing this conversation as an admin auditor.</span>
+                </>
+              ) : (
+                <>
+                  <span className="text-sm font-medium">View Only</span>
+                  <span className="text-xs text-amber-600 dark:text-amber-500">— This conversation was shared with you as read-only.</span>
+                </>
+              )}
             </div>
+            {readOnlyReason === 'admin_audit' && (
             <a
               href="/admin?tab=feedback"
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-amber-600/20 text-amber-700 dark:text-amber-300 hover:bg-amber-600/30 transition-colors"
@@ -1157,6 +1170,7 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
               <ArrowLeft className="h-3 w-3" />
               Back to Feedback
             </a>
+            )}
           </div>
         </div>
       ) : (

--- a/ui/src/components/chat/FeedbackButton.tsx
+++ b/ui/src/components/chat/FeedbackButton.tsx
@@ -206,6 +206,10 @@ export function FeedbackButton({
           )}
         </AnimatePresence>
 
+        <p className="text-[10px] text-muted-foreground/60 mb-2 text-center">
+          Feedback is shared with your platform engineering team to help improve the experience.
+        </p>
+
         {/* Submit Button */}
         <Button
           size="sm"

--- a/ui/src/components/chat/ShareDialog.tsx
+++ b/ui/src/components/chat/ShareDialog.tsx
@@ -39,7 +39,8 @@ export function ShareDialog({
   const [togglingPublic, setTogglingPublic] = useState(false);
   const [userPermissions, setUserPermissions] = useState<Record<string, SharePermission>>({});
   const [teamPermissions, setTeamPermissions] = useState<Record<string, SharePermission>>({});
-  const [defaultPermission, setDefaultPermission] = useState<SharePermission>('view');
+  const [defaultPermission, setDefaultPermission] = useState<SharePermission>('comment');
+  const [publicPermission, setPublicPermission] = useState<SharePermission>('comment');
 
   const shareUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/chat/${conversationId}`;
 
@@ -74,6 +75,9 @@ export function ShareDialog({
 
         // Build per-team permission map from sharing.team_permissions
         setTeamPermissions(sharing?.team_permissions || {});
+
+        // Load public share permission
+        setPublicPermission(sharing?.public_permission || 'comment');
 
         // Update store with sharing info so Sidebar shows icon immediately
         if (sharing) {
@@ -338,6 +342,21 @@ export function ShareDialog({
     }
   };
 
+  const handlePublicPermissionChange = async (newPermission: SharePermission) => {
+    try {
+      const response = await fetch(`/api/chat/conversations/${conversationId}/share`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ is_public: true, public_permission: newPermission }),
+      });
+      if (response.ok) {
+        setPublicPermission(newPermission);
+      }
+    } catch (err) {
+      console.error('Failed to update public permission:', err);
+    }
+  };
+
   const handleTogglePublic = async () => {
     setTogglingPublic(true);
     const newPublicState = !isPublic;
@@ -487,8 +506,8 @@ export function ShareDialog({
                 <div className="text-sm font-medium">Share with everyone</div>
                 <div className="text-xs text-muted-foreground">
                   {isPublic
-                    ? 'Anyone in the organization can view this conversation'
-                    : 'Only people and teams you add can view'}
+                    ? `Anyone in the organization can ${publicPermission === 'comment' ? 'view and edit' : 'view'} this conversation`
+                    : 'Only people and teams you add can access'}
                 </div>
               </div>
             </div>
@@ -642,7 +661,14 @@ export function ShareDialog({
                       <div className="text-xs text-muted-foreground">All organization members</div>
                     </div>
                   </div>
-                  <span className="text-xs text-muted-foreground">Can view</span>
+                  <select
+                    value={publicPermission}
+                    onChange={(e) => handlePublicPermissionChange(e.target.value as SharePermission)}
+                    className="text-xs bg-transparent border border-green-500/30 rounded px-1.5 py-1 text-muted-foreground hover:text-foreground cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/50"
+                  >
+                    <option value="view">Can view</option>
+                    <option value="comment">Can edit</option>
+                  </select>
                 </div>
               )}
               {/* People */}

--- a/ui/src/components/chat/ShareDialog.tsx
+++ b/ui/src/components/chat/ShareDialog.tsx
@@ -2,11 +2,13 @@
 
 import React, { useState, useEffect } from "react";
 import { createPortal } from "react-dom";
-import { X, UserPlus, Copy, Check, Mail, Trash2, Users, Globe } from "lucide-react";
+import { X, UserPlus, Copy, Check, Mail, Trash2, Users, Globe, ChevronDown } from "lucide-react";
 import { apiClient } from "@/lib/api-client";
 import { useChatStore } from "@/store/chat-store";
 import type { UserPublicInfo } from "@/types/mongodb";
 import type { Team } from "@/types/teams";
+
+type SharePermission = 'view' | 'comment';
 
 interface ShareDialogProps {
   conversationId: string;
@@ -35,6 +37,9 @@ export function ShareDialog({
   const [isLegacyConversation, setIsLegacyConversation] = useState(false);
   const [isPublic, setIsPublic] = useState(false);
   const [togglingPublic, setTogglingPublic] = useState(false);
+  const [userPermissions, setUserPermissions] = useState<Record<string, SharePermission>>({});
+  const [teamPermissions, setTeamPermissions] = useState<Record<string, SharePermission>>({});
+  const [defaultPermission, setDefaultPermission] = useState<SharePermission>('view');
 
   const shareUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/chat/${conversationId}`;
 
@@ -56,6 +61,19 @@ export function ShareDialog({
         setSharedWithTeams(teamIds);
         setIsPublic(sharing?.is_public || false);
         setIsLegacyConversation(false);
+
+        // Build per-user permission map from access_list
+        const accessList = data.data?.access_list || [];
+        const userPerms: Record<string, SharePermission> = {};
+        for (const entry of accessList) {
+          if (entry.granted_to && entry.permission) {
+            userPerms[entry.granted_to] = entry.permission;
+          }
+        }
+        setUserPermissions(userPerms);
+
+        // Build per-team permission map from sharing.team_permissions
+        setTeamPermissions(sharing?.team_permissions || {});
 
         // Update store with sharing info so Sidebar shows icon immediately
         if (sharing) {
@@ -186,10 +204,11 @@ export function ShareDialog({
     try {
       const updatedConversation = await apiClient.shareConversation(conversationId, {
         user_emails: [email],
-        permission: "view",
+        permission: defaultPermission,
       });
 
       setSharedWith([...sharedWith, email]);
+      setUserPermissions({ ...userPermissions, [email]: defaultPermission });
       
       // Update store with new sharing info so Sidebar shows icon immediately
       if (updatedConversation?.sharing) {
@@ -229,7 +248,7 @@ export function ShareDialog({
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           team_ids: [teamId],
-          permission: "view",
+          permission: defaultPermission,
         }),
       });
 
@@ -294,6 +313,28 @@ export function ShareDialog({
       setTimeout(() => setCopied(false), 2000);
     } catch (err) {
       console.error("Failed to copy:", err);
+    }
+  };
+
+  const handlePermissionChange = async (
+    target: { email?: string; team_id?: string },
+    newPermission: SharePermission
+  ) => {
+    try {
+      const response = await fetch(`/api/chat/conversations/${conversationId}/share`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...target, permission: newPermission }),
+      });
+      if (!response.ok) return;
+      if (target.email) {
+        setUserPermissions((prev) => ({ ...prev, [target.email!]: newPermission }));
+      }
+      if (target.team_id) {
+        setTeamPermissions((prev) => ({ ...prev, [target.team_id!]: newPermission }));
+      }
+    } catch (err) {
+      console.error('Failed to update permission:', err);
     }
   };
 
@@ -475,14 +516,23 @@ export function ShareDialog({
           <label className="text-sm font-medium mb-2 block">
             People, Teams
           </label>
-          <div className="relative">
+          <div className="relative flex gap-2">
             <input
               type="text"
               placeholder="Search by email or team name..."
               value={searchInput}
               onChange={(e) => setSearchInput(e.target.value)}
-              className="w-full px-3 py-2 text-sm border rounded-md"
+              className="flex-1 px-3 py-2 text-sm border rounded-md"
             />
+            <select
+              value={defaultPermission}
+              onChange={(e) => setDefaultPermission(e.target.value as SharePermission)}
+              className="text-xs border rounded-md px-2 py-2 bg-background text-muted-foreground hover:text-foreground cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/50"
+              title="Permission for new shares"
+            >
+              <option value="view">Can view</option>
+              <option value="comment">Can edit</option>
+            </select>
             
             {/* Search results dropdown */}
             {((userResults.length > 0 || teamResults.length > 0 || noResults) && searchInput.length >= 2) && (
@@ -601,21 +651,31 @@ export function ShareDialog({
                   key={email}
                   className="flex items-center justify-between py-2 px-3 bg-muted rounded-md"
                 >
-                  <div className="flex items-center gap-2">
-                    <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-medium text-sm">
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <div className="h-8 w-8 rounded-full bg-primary/10 flex items-center justify-center text-primary font-medium text-sm shrink-0">
                       {email.charAt(0).toUpperCase()}
                     </div>
-                    <div className="text-sm">{email}</div>
+                    <div className="text-sm truncate">{email}</div>
                   </div>
-                  <button
-                    className="text-muted-foreground hover:text-destructive"
-                    onClick={() => {
-                      // TODO: Implement remove access
-                      setSharedWith(sharedWith.filter(e => e !== email));
-                    }}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <select
+                      value={userPermissions[email] || 'view'}
+                      onChange={(e) => handlePermissionChange({ email }, e.target.value as SharePermission)}
+                      className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-muted-foreground hover:text-foreground cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/50"
+                    >
+                      <option value="view">Can view</option>
+                      <option value="comment">Can edit</option>
+                    </select>
+                    <button
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => {
+                        // TODO: Implement remove access
+                        setSharedWith(sharedWith.filter(e => e !== email));
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
                 </div>
               ))}
               {/* Teams */}
@@ -624,23 +684,33 @@ export function ShareDialog({
                   key={teamId}
                   className="flex items-center justify-between py-2 px-3 bg-muted rounded-md"
                 >
-                  <div className="flex items-center gap-2">
-                    <div className="h-8 w-8 rounded-full bg-blue-500/10 flex items-center justify-center text-blue-600 dark:text-blue-400">
+                  <div className="flex items-center gap-2 flex-1 min-w-0">
+                    <div className="h-8 w-8 rounded-full bg-blue-500/10 flex items-center justify-center text-blue-600 dark:text-blue-400 shrink-0">
                       <Users className="h-4 w-4" />
                     </div>
-                    <div className="text-sm">
+                    <div className="text-sm truncate">
                       {teamNames[teamId] || `Team: ${teamId}`}
                     </div>
                   </div>
-                  <button
-                    className="text-muted-foreground hover:text-destructive"
-                    onClick={() => {
-                      // TODO: Implement remove team access
-                      setSharedWithTeams(sharedWithTeams.filter(t => t !== teamId));
-                    }}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                  </button>
+                  <div className="flex items-center gap-1.5 shrink-0">
+                    <select
+                      value={teamPermissions[teamId] || 'view'}
+                      onChange={(e) => handlePermissionChange({ team_id: teamId }, e.target.value as SharePermission)}
+                      className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-muted-foreground hover:text-foreground cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/50"
+                    >
+                      <option value="view">Can view</option>
+                      <option value="comment">Can edit</option>
+                    </select>
+                    <button
+                      className="text-muted-foreground hover:text-destructive"
+                      onClick={() => {
+                        // TODO: Implement remove team access
+                        setSharedWithTeams(sharedWithTeams.filter(t => t !== teamId));
+                      }}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
                 </div>
               ))}
             </div>

--- a/ui/src/components/nps/NPSSurvey.tsx
+++ b/ui/src/components/nps/NPSSurvey.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { useSession } from "next-auth/react";
+import { motion, AnimatePresence } from "framer-motion";
+import { X, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { getConfig } from "@/lib/config";
+
+interface ActiveCampaign {
+  id: string;
+  name: string;
+  ends_at: string;
+}
+
+function getCampaignStorageKey(campaignId: string) {
+  return `caipe_nps_campaign_${campaignId}`;
+}
+
+export function NPSSurvey() {
+  const { data: session, status } = useSession();
+  const [visible, setVisible] = useState(false);
+  const [campaign, setCampaign] = useState<ActiveCampaign | null>(null);
+  const [selectedScore, setSelectedScore] = useState<number | null>(null);
+  const [comment, setComment] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+
+  useEffect(() => {
+    if (status !== "authenticated" || !getConfig("npsEnabled") || getConfig("storageMode") !== "mongodb") return;
+
+    let cancelled = false;
+
+    async function checkActiveCampaign() {
+      try {
+        const res = await fetch("/api/nps/active");
+        if (!res.ok) return;
+        const data = await res.json();
+
+        if (cancelled) return;
+
+        if (data.success && data.data?.active && data.data.campaign) {
+          const activeCampaign: ActiveCampaign = data.data.campaign;
+
+          const dismissed = localStorage.getItem(getCampaignStorageKey(activeCampaign.id));
+          if (dismissed) return;
+
+          setCampaign(activeCampaign);
+          const timer = setTimeout(() => {
+            if (!cancelled) setVisible(true);
+          }, 30000);
+          return () => clearTimeout(timer);
+        }
+      } catch (err) {
+        console.error("[NPS] Failed to check active campaign:", err);
+      }
+    }
+
+    checkActiveCampaign();
+    return () => { cancelled = true; };
+  }, [status]);
+
+  const dismiss = useCallback(() => {
+    setVisible(false);
+    if (campaign) {
+      localStorage.setItem(getCampaignStorageKey(campaign.id), "dismissed");
+    }
+  }, [campaign]);
+
+  const handleSubmit = useCallback(async () => {
+    if (selectedScore === null || !campaign) return;
+    setIsSubmitting(true);
+    try {
+      const res = await fetch("/api/nps", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          score: selectedScore,
+          comment: comment.trim() || undefined,
+          campaign_id: campaign.id,
+        }),
+      });
+      if (res.ok) {
+        setSubmitted(true);
+        localStorage.setItem(getCampaignStorageKey(campaign.id), "submitted");
+        setTimeout(() => setVisible(false), 2000);
+      }
+    } catch (err) {
+      console.error("[NPS] Failed to submit:", err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [selectedScore, comment, campaign]);
+
+  if (!visible) return null;
+
+  const getScoreColor = (score: number) => {
+    if (score <= 6) return "bg-red-500 hover:bg-red-600 text-white";
+    if (score <= 8) return "bg-amber-500 hover:bg-amber-600 text-white";
+    return "bg-green-500 hover:bg-green-600 text-white";
+  };
+
+  const getScoreLabel = (score: number) => {
+    if (score <= 6) return "Detractor";
+    if (score <= 8) return "Passive";
+    return "Promoter";
+  };
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        initial={{ opacity: 0, y: 80 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: 80 }}
+        className="fixed bottom-6 right-6 z-50 w-[420px] rounded-xl border bg-card shadow-2xl"
+      >
+        <div className="p-5">
+          {submitted ? (
+            <div className="text-center py-4">
+              <p className="text-lg font-semibold mb-1">Thank you!</p>
+              <p className="text-sm text-muted-foreground">Your feedback helps us improve.</p>
+            </div>
+          ) : (
+            <>
+              <div className="flex items-start justify-between mb-4">
+                <div>
+                  {campaign?.name && (
+                    <p className="text-xs font-medium text-primary mb-1.5">{campaign.name}</p>
+                  )}
+                  <p className="font-semibold text-sm">
+                    How well does {getConfig("appName")} help you get your work done?
+                  </p>
+                  <p className="text-xs text-muted-foreground mt-1">0 = Not helpful at all, 10 = Indispensable</p>
+                </div>
+                <button
+                  onClick={dismiss}
+                  className="text-muted-foreground hover:text-foreground -mt-1 -mr-1 p-1"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+
+              {/* Score buttons */}
+              <div className="flex gap-1 mb-3">
+                {Array.from({ length: 11 }, (_, i) => (
+                  <button
+                    key={i}
+                    onClick={() => setSelectedScore(i)}
+                    className={cn(
+                      "flex-1 h-9 rounded-md text-xs font-medium transition-all",
+                      selectedScore === i
+                        ? getScoreColor(i)
+                        : "bg-muted text-muted-foreground hover:bg-muted/80"
+                    )}
+                  >
+                    {i}
+                  </button>
+                ))}
+              </div>
+
+              {selectedScore !== null && (
+                <p className="text-xs text-center text-muted-foreground mb-3">
+                  Score: {selectedScore} ({getScoreLabel(selectedScore)})
+                </p>
+              )}
+
+              {/* Optional comment */}
+              <textarea
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+                placeholder="What could we do better? (optional)"
+                className="w-full h-16 px-3 py-2 text-sm bg-muted/50 border border-border rounded-lg resize-none focus:outline-none focus:ring-2 focus:ring-primary/50 mb-3"
+                maxLength={1000}
+              />
+
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  className="flex-1"
+                  onClick={dismiss}
+                >
+                  Maybe Later
+                </Button>
+                <Button
+                  size="sm"
+                  className="flex-1 gap-2"
+                  onClick={handleSubmit}
+                  disabled={selectedScore === null || isSubmitting}
+                >
+                  {isSubmitting && <Loader2 className="h-3 w-3 animate-spin" />}
+                  Submit
+                </Button>
+              </div>
+            </>
+          )}
+        </div>
+      </motion.div>
+    </AnimatePresence>
+  );
+}

--- a/ui/src/components/nps/NPSSurvey.tsx
+++ b/ui/src/components/nps/NPSSurvey.tsx
@@ -174,6 +174,10 @@ export function NPSSurvey() {
                 maxLength={1000}
               />
 
+              <p className="text-[10px] text-muted-foreground/50 mb-3 text-center">
+                Responses are tied to your account to help us follow up.
+              </p>
+
               <div className="flex gap-2">
                 <Button
                   variant="outline"

--- a/ui/src/lib/__tests__/config.test.ts
+++ b/ui/src/lib/__tests__/config.test.ts
@@ -123,7 +123,7 @@ describe('getServerConfig', () => {
         'gradientFrom', 'gradientTo', 'logoStyle', 'spinnerColor',
         'showPoweredBy', 'supportEmail', 'allowDevAdminWhenSsoDisabled',
         'storageMode', 'enabledIntegrationIcons', 'faviconUrl',
-        'docsUrl', 'sourceUrl', 'workflowRunnerEnabled',
+        'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'npsEnabled',
         'defaultFontSize', 'defaultFontFamily', 'defaultTheme', 'defaultGradientTheme',
       ];
       expect(Object.keys(cfg).sort()).toEqual(expectedKeys.sort());
@@ -672,7 +672,7 @@ describe('getClientConfigScript (XSS safety)', () => {
       'gradientFrom', 'gradientTo', 'logoStyle', 'spinnerColor',
       'showPoweredBy', 'supportEmail', 'allowDevAdminWhenSsoDisabled',
       'storageMode', 'enabledIntegrationIcons', 'faviconUrl',
-      'docsUrl', 'sourceUrl', 'workflowRunnerEnabled',
+      'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'npsEnabled',
       'defaultFontSize', 'defaultFontFamily', 'defaultTheme', 'defaultGradientTheme',
     ];
     expect(Object.keys(parsed).sort()).toEqual(expectedKeys.sort());

--- a/ui/src/lib/__tests__/config.test.ts
+++ b/ui/src/lib/__tests__/config.test.ts
@@ -88,6 +88,7 @@ describe('getServerConfig', () => {
       expect(cfg.isProd).toBe(false);
       expect(cfg.ssoEnabled).toBe(false);
       expect(cfg.ragEnabled).toBe(true); // default true
+      expect(cfg.feedbackEnabled).toBe(true); // default true
       expect(cfg.mongodbEnabled).toBe(false);
       expect(cfg.tagline).toBe('Multi-Agent Workflow Automation');
       expect(cfg.description).toBe(
@@ -123,7 +124,7 @@ describe('getServerConfig', () => {
         'gradientFrom', 'gradientTo', 'logoStyle', 'spinnerColor',
         'showPoweredBy', 'supportEmail', 'allowDevAdminWhenSsoDisabled',
         'storageMode', 'enabledIntegrationIcons', 'faviconUrl',
-        'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'npsEnabled',
+        'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'feedbackEnabled', 'npsEnabled',
         'defaultFontSize', 'defaultFontFamily', 'defaultTheme', 'defaultGradientTheme',
       ];
       expect(Object.keys(cfg).sort()).toEqual(expectedKeys.sort());
@@ -321,6 +322,31 @@ describe('getServerConfig', () => {
     it('should be true for RAG_ENABLED=anything (only "false" disables)', () => {
       process.env.RAG_ENABLED = 'banana';
       expect(getServerConfig().ragEnabled).toBe(true);
+    });
+  });
+
+  // ---------- feedbackEnabled ----------
+
+  describe('feedbackEnabled', () => {
+    beforeEach(() => clearEnv('FEEDBACK_ENABLED'));
+
+    it('should default to true (enabled)', () => {
+      expect(getServerConfig().feedbackEnabled).toBe(true);
+    });
+
+    it('should be false when FEEDBACK_ENABLED=false', () => {
+      process.env.FEEDBACK_ENABLED = 'false';
+      expect(getServerConfig().feedbackEnabled).toBe(false);
+    });
+
+    it('should be true when FEEDBACK_ENABLED=true', () => {
+      process.env.FEEDBACK_ENABLED = 'true';
+      expect(getServerConfig().feedbackEnabled).toBe(true);
+    });
+
+    it('should be true for any value other than "false"', () => {
+      process.env.FEEDBACK_ENABLED = 'banana';
+      expect(getServerConfig().feedbackEnabled).toBe(true);
     });
   });
 
@@ -672,7 +698,7 @@ describe('getClientConfigScript (XSS safety)', () => {
       'gradientFrom', 'gradientTo', 'logoStyle', 'spinnerColor',
       'showPoweredBy', 'supportEmail', 'allowDevAdminWhenSsoDisabled',
       'storageMode', 'enabledIntegrationIcons', 'faviconUrl',
-      'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'npsEnabled',
+      'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'feedbackEnabled', 'npsEnabled',
       'defaultFontSize', 'defaultFontFamily', 'defaultTheme', 'defaultGradientTheme',
     ];
     expect(Object.keys(parsed).sort()).toEqual(expectedKeys.sort());

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -328,7 +328,7 @@ export async function getUserTeamIds(userEmail: string): Promise<string[]> {
   }
 }
 
-export type ConversationAccessLevel = 'owner' | 'shared' | 'admin_audit';
+export type ConversationAccessLevel = 'owner' | 'shared' | 'shared_readonly' | 'admin_audit';
 
 interface ConversationAccessResult {
   conversation: any;
@@ -360,14 +360,26 @@ export async function requireConversationAccess(
     return { conversation, access_level: 'owner' };
   }
 
-  // Check if conversation is public (shared with everyone)
+  // Check if conversation is public (shared with everyone) — always read-only
   if (conversation.sharing?.is_public) {
-    return { conversation, access_level: 'shared' };
+    return { conversation, access_level: 'shared_readonly' };
   }
 
   // Check if conversation is shared with user directly
   if (conversation.sharing?.shared_with?.includes(userId)) {
-    return { conversation, access_level: 'shared' };
+    const sharingAccess = await getCollectionFn('sharing_access');
+    const accessRecord = await sharingAccess.findOne({
+      conversation_id: conversationId,
+      granted_to: userId,
+      revoked_at: null,
+    });
+    // Default to 'comment' (full access) for backward compatibility with
+    // shares created before permissions were introduced
+    const perm = accessRecord?.permission ?? 'comment';
+    return {
+      conversation,
+      access_level: perm === 'comment' ? 'shared' : 'shared_readonly',
+    };
   }
 
   // Check if conversation is shared with one of the user's teams
@@ -375,16 +387,21 @@ export async function requireConversationAccess(
   if (sharedTeams && sharedTeams.length > 0) {
     const userTeamIds = await getUserTeamIds(userId);
     if (userTeamIds.length > 0) {
-      const hasTeamAccess = sharedTeams.some((teamId: string) =>
+      const matchedTeamId = sharedTeams.find((teamId: string) =>
         userTeamIds.includes(teamId)
       );
-      if (hasTeamAccess) {
-        return { conversation, access_level: 'shared' };
+      if (matchedTeamId) {
+        const teamPerms = conversation.sharing?.team_permissions;
+        const perm = teamPerms?.[matchedTeamId] ?? 'comment';
+        return {
+          conversation,
+          access_level: perm === 'comment' ? 'shared' : 'shared_readonly',
+        };
       }
     }
   }
 
-  // Check sharing_access collection
+  // Check sharing_access collection (link-based or other grants)
   const sharingAccess = await getCollectionFn('sharing_access');
   const access = await sharingAccess.findOne({
     conversation_id: conversationId,
@@ -393,7 +410,11 @@ export async function requireConversationAccess(
   });
 
   if (access) {
-    return { conversation, access_level: 'shared' };
+    const perm = access.permission ?? 'comment';
+    return {
+      conversation,
+      access_level: perm === 'comment' ? 'shared' : 'shared_readonly',
+    };
   }
 
   // Admins get read-only audit access to any conversation

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -360,9 +360,13 @@ export async function requireConversationAccess(
     return { conversation, access_level: 'owner' };
   }
 
-  // Check if conversation is public (shared with everyone) — always read-only
+  // Check if conversation is public (shared with everyone)
   if (conversation.sharing?.is_public) {
-    return { conversation, access_level: 'shared_readonly' };
+    const perm = conversation.sharing?.public_permission ?? 'comment';
+    return {
+      conversation,
+      access_level: perm === 'comment' ? 'shared' : 'shared_readonly',
+    };
   }
 
   // Check if conversation is shared with user directly

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -328,15 +328,26 @@ export async function getUserTeamIds(userEmail: string): Promise<string[]> {
   }
 }
 
+export type ConversationAccessLevel = 'owner' | 'shared' | 'admin_audit';
+
+interface ConversationAccessResult {
+  conversation: any;
+  access_level: ConversationAccessLevel;
+}
+
 /**
  * Check if user has access to a conversation (owner, shared with directly,
- * shared with one of their teams, or via sharing_access records).
+ * shared with one of their teams, via sharing_access records, or admin audit).
+ *
+ * When `session` is provided and the user is an admin, they receive read-only
+ * audit access even if they are not the owner or a share recipient.
  */
 export async function requireConversationAccess(
   conversationId: string,
   userId: string,
-  getCollectionFn: (name: string) => Promise<any>
-) {
+  getCollectionFn: (name: string) => Promise<any>,
+  session?: { role?: string; canViewAdmin?: boolean }
+): Promise<ConversationAccessResult> {
   const conversations = await getCollectionFn('conversations');
   const conversation = await conversations.findOne({ _id: conversationId });
 
@@ -346,7 +357,7 @@ export async function requireConversationAccess(
 
   // Check if user is owner
   if (conversation.owner_id === userId) {
-    return conversation;
+    return { conversation, access_level: 'owner' };
   }
 
   // Check if conversation is public (shared with everyone)
@@ -356,7 +367,7 @@ export async function requireConversationAccess(
 
   // Check if conversation is shared with user directly
   if (conversation.sharing?.shared_with?.includes(userId)) {
-    return conversation;
+    return { conversation, access_level: 'shared' };
   }
 
   // Check if conversation is shared with one of the user's teams
@@ -368,7 +379,7 @@ export async function requireConversationAccess(
         userTeamIds.includes(teamId)
       );
       if (hasTeamAccess) {
-        return conversation;
+        return { conversation, access_level: 'shared' };
       }
     }
   }
@@ -382,7 +393,12 @@ export async function requireConversationAccess(
   });
 
   if (access) {
-    return conversation;
+    return { conversation, access_level: 'shared' };
+  }
+
+  // Admins get read-only audit access to any conversation
+  if (session?.role === 'admin' || session?.canViewAdmin === true) {
+    return { conversation, access_level: 'admin_audit' };
   }
 
   throw new ApiError('Forbidden: You do not have access to this conversation', 403, 'FORBIDDEN');

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -362,7 +362,7 @@ export async function requireConversationAccess(
 
   // Check if conversation is public (shared with everyone)
   if (conversation.sharing?.is_public) {
-    return conversation;
+    return { conversation, access_level: 'shared' };
   }
 
   // Check if conversation is shared with user directly

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -90,6 +90,12 @@ export interface Config {
    * Set WORKFLOW_RUNNER_ENABLED=true to enable.
    */
   workflowRunnerEnabled: boolean;
+  /**
+   * Whether the NPS (Net Promoter Score) feature is enabled.
+   * When false (default), the NPS survey popup, admin NPS tab, and NPS API
+   * endpoints are all disabled. Set NPS_ENABLED=true to enable.
+   */
+  npsEnabled: boolean;
   /** Default font size for new users: "small" | "medium" | "large" | "x-large" */
   defaultFontSize: string;
   /** Default font family for new users: "inter" | "source-sans" | "ibm-plex" | "system" */
@@ -148,6 +154,7 @@ const DEFAULT_CONFIG: Config = {
   docsUrl: null,
   sourceUrl: null,
   workflowRunnerEnabled: false,
+  npsEnabled: false,
   defaultFontSize: DEFAULT_FONT_SIZE,
   defaultFontFamily: DEFAULT_FONT_FAMILY,
   defaultTheme: DEFAULT_THEME,
@@ -213,6 +220,7 @@ export function getServerConfig(): Config {
     || (env('PREVIEW_MODE') === 'true' ? 'Preview' : '');
   const allowDevAdminWhenSsoDisabled = env('ALLOW_DEV_ADMIN_WHEN_SSO_DISABLED') === 'true';
   const workflowRunnerEnabled = env('WORKFLOW_RUNNER_ENABLED') === 'true';
+  const npsEnabled = env('NPS_ENABLED') === 'true';
 
   const showPoweredByEnv = env('SHOW_POWERED_BY');
   const showPoweredBy = showPoweredByEnv !== undefined ? showPoweredByEnv !== 'false' : true;
@@ -252,6 +260,7 @@ export function getServerConfig(): Config {
     docsUrl: env('DOCS_URL') || null,
     sourceUrl: env('SOURCE_URL') || null,
     workflowRunnerEnabled,
+    npsEnabled,
     defaultFontSize: validated(env('DEFAULT_FONT_SIZE'), VALID_FONT_SIZES, DEFAULT_FONT_SIZE),
     defaultFontFamily: validated(env('DEFAULT_FONT_FAMILY'), VALID_FONT_FAMILIES, DEFAULT_FONT_FAMILY),
     defaultTheme: validated(env('DEFAULT_THEME'), VALID_THEMES, DEFAULT_THEME),

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -91,6 +91,11 @@ export interface Config {
    */
   workflowRunnerEnabled: boolean;
   /**
+   * Whether the admin Feedback tab and feedback API are enabled.
+   * Enabled by default. Set FEEDBACK_ENABLED=false to disable.
+   */
+  feedbackEnabled: boolean;
+  /**
    * Whether the NPS (Net Promoter Score) feature is enabled.
    * When false (default), the NPS survey popup, admin NPS tab, and NPS API
    * endpoints are all disabled. Set NPS_ENABLED=true to enable.
@@ -154,6 +159,7 @@ const DEFAULT_CONFIG: Config = {
   docsUrl: null,
   sourceUrl: null,
   workflowRunnerEnabled: false,
+  feedbackEnabled: true,
   npsEnabled: false,
   defaultFontSize: DEFAULT_FONT_SIZE,
   defaultFontFamily: DEFAULT_FONT_FAMILY,
@@ -220,6 +226,7 @@ export function getServerConfig(): Config {
     || (env('PREVIEW_MODE') === 'true' ? 'Preview' : '');
   const allowDevAdminWhenSsoDisabled = env('ALLOW_DEV_ADMIN_WHEN_SSO_DISABLED') === 'true';
   const workflowRunnerEnabled = env('WORKFLOW_RUNNER_ENABLED') === 'true';
+  const feedbackEnabled = env('FEEDBACK_ENABLED') !== 'false';
   const npsEnabled = env('NPS_ENABLED') === 'true';
 
   const showPoweredByEnv = env('SHOW_POWERED_BY');
@@ -260,6 +267,7 @@ export function getServerConfig(): Config {
     docsUrl: env('DOCS_URL') || null,
     sourceUrl: env('SOURCE_URL') || null,
     workflowRunnerEnabled,
+    feedbackEnabled,
     npsEnabled,
     defaultFontSize: validated(env('DEFAULT_FONT_SIZE'), VALID_FONT_SIZES, DEFAULT_FONT_SIZE),
     defaultFontFamily: validated(env('DEFAULT_FONT_FAMILY'), VALID_FONT_FAMILIES, DEFAULT_FONT_FAMILY),

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -46,6 +46,7 @@ export interface Conversation {
   };
   sharing: {
     is_public: boolean;
+    public_permission?: 'view' | 'comment'; // Permission for public shares (default: comment)
     shared_with: string[]; // Array of user emails
     shared_with_teams: string[]; // Array of team IDs
     team_permissions?: Record<string, 'view' | 'comment'>; // Per-team permission
@@ -221,6 +222,7 @@ export interface ShareConversationRequest {
   enable_link?: boolean;
   link_expires?: string; // ISO date string
   is_public?: boolean;
+  public_permission?: 'view' | 'comment'; // Permission when is_public is true
 }
 
 // Message API

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -48,6 +48,7 @@ export interface Conversation {
     is_public: boolean;
     shared_with: string[]; // Array of user emails
     shared_with_teams: string[]; // Array of team IDs
+    team_permissions?: Record<string, 'view' | 'comment'>; // Per-team permission
     share_link_enabled: boolean;
     share_link_expires?: Date;
   };


### PR DESCRIPTION
## Summary

- **Feedback tab**: Persists user feedback to MongoDB and adds admin dashboard tab with filterable feedback list, chat links, and read-only audit mode
- **NPS tab**: Admin-controlled campaign-based NPS surveys with score analytics, trend charts, campaign management (create/stop), and per-campaign filtering
- **Read-only sharing permissions**: Owners can share conversations as "Can view" (read-only) or "Can edit" (full access) per user, team, and everyone — with a permission dropdown in the share dialog (defaults to "Can edit")
- **Feature flags**: Feedback (`FEEDBACK_ENABLED`, default on) and NPS (`NPS_ENABLED`, default off) are independently toggleable
- **Transparency disclaimers**: Subtle notes in feedback popover and NPS survey inform users their responses are visible to admins
- **Deep-linkable admin tabs**: `?tab=` query param support for direct tab navigation

## Key Changes

### Read-Only Sharing
- New `shared_readonly` access level in `requireConversationAccess`
- Permission dropdown ("Can view" / "Can edit") in ShareDialog per user, team, and "everyone"
- `PATCH /api/chat/conversations/[id]/share` for changing permissions after sharing
- Public shares default to read/write; owner can switch to read-only via dropdown
- Per-team permissions stored in `sharing.team_permissions`; public permission in `sharing.public_permission`
- Legacy shares (without permission records) default to full access for backward compatibility
- Contextual read-only banners in ChatPanel ("Read-Only Audit Mode" vs "View Only")

### Feedback & NPS
- Dual-write feedback to MongoDB and Langfuse
- Admin-controlled NPS campaigns with overlap prevention
- Campaign-specific NPS analytics filtering

## Test plan

- [x] 2026 tests pass across 83 suites
- [x] 20 new tests for read-only sharing permissions (access levels, PATCH, public permission, backward compat, message blocking)
- [x] Existing sharing tests updated for new access level defaults
- [x] Spec and ADR updated