### PR TITLE
feat(ui): add admin audit logs with export, owner search, and CSV download

### DIFF
--- a/.specify/specs/admin-audit-logs.md
+++ b/.specify/specs/admin-audit-logs.md
@@ -1,0 +1,132 @@
+# Spec: Admin Audit Logs
+
+## Overview
+
+Admin-only feature that allows administrators to browse, search, and export all conversations and full message content across all users, gated by the `AUDIT_LOGS_ENABLED` environment variable (disabled by default).
+
+## Motivation
+
+Platform administrators need visibility into all chat conversations for compliance, auditing, and support purposes. Without this, there is no way for admins to review what users are discussing with the AI agents, investigate issues reported by users, or audit platform usage at the conversation level.
+
+## Scope
+
+### In Scope
+- Environment variable toggle (`AUDIT_LOGS_ENABLED=true`) to enable the feature
+- Admin API endpoints for listing conversations, reading messages, exporting to CSV, and searching owners
+- Admin UI tab with search, filtering, and pagination
+- Searchable owner email dropdown with typeahead autocomplete
+- Conversation detail dialog showing full message content with scrollable layout
+- Conversation UUID display with direct chat link and copy-to-clipboard
+- CSV export of audit logs (respects active filters, up to 10,000 rows)
+- Server-side enforcement of the feature flag (API returns 403 when disabled)
+
+### Out of Scope
+- Exporting to external SIEM systems
+- Real-time streaming of new conversations/messages
+- Editing or deleting conversations from the audit view
+- Per-message audit trail (who viewed what)
+- Retention policies for audit data
+
+## Design
+
+### Architecture
+
+The feature adds a new "Audit Logs" tab to the existing admin dashboard, backed by four API endpoints that query the existing MongoDB `conversations` and `messages` collections. No new collections or data models are introduced — the feature provides a read-only cross-user view over existing data.
+
+The feature is double-gated:
+1. `AUDIT_LOGS_ENABLED=true` env var must be set (disabled by default)
+2. User must be a full admin (`requireAdmin`) — read-only admin viewers cannot access audit logs
+
+### Components Affected
+- [ ] Agents (`ai_platform_engineering/agents/`)
+- [ ] Multi-Agents (`ai_platform_engineering/multi_agents/`)
+- [ ] MCP Servers
+- [ ] Knowledge Bases (`ai_platform_engineering/knowledge_bases/`)
+- [x] UI (`ui/`)
+  - `ui/src/lib/config.ts` — `auditLogsEnabled` config flag
+  - `ui/src/types/mongodb.ts` — `AuditConversation`, `AuditLogFilters` types
+  - `ui/src/app/api/admin/audit-logs/route.ts` — list conversations endpoint
+  - `ui/src/app/api/admin/audit-logs/[id]/messages/route.ts` — conversation messages endpoint
+  - `ui/src/app/api/admin/audit-logs/export/route.ts` — CSV export endpoint
+  - `ui/src/app/api/admin/audit-logs/owners/route.ts` — searchable owners endpoint
+  - `ui/src/app/(app)/admin/page.tsx` — conditional Audit Logs tab
+  - `ui/src/components/admin/AuditLogsTab.tsx` — filter/search/table component with export and owner search
+  - `ui/src/components/admin/ConversationDetailDialog.tsx` — message viewer dialog with scrolling
+- [x] Documentation (`docs/`)
+  - ADR: `docs/docs/changes/2026-03-03-admin-audit-logs.md`
+- [x] Tests (`ui/src/app/api/__tests__/`)
+  - `admin-audit-logs.test.ts` — 40 tests covering all 4 endpoints
+- [ ] Helm Charts (`charts/`)
+
+## Acceptance Criteria
+
+- [x] Feature is disabled by default (no env var = tab hidden, API returns 403)
+- [x] Setting `AUDIT_LOGS_ENABLED=true` shows the Audit Logs tab in admin dashboard
+- [x] Admins can search conversations by owner email, title, date range, and status
+- [x] Owner email field provides searchable autocomplete with typeahead
+- [x] Admins can view full message content for any conversation
+- [x] Conversation detail dialog has proper scrolling for long conversations
+- [x] Conversation UUID is visible with copy-to-clipboard and direct chat link
+- [x] Admins can download filtered audit logs as CSV
+- [x] API enforces `requireAdmin` authorization on all endpoints (full admin only, not read-only viewers)
+- [x] API enforces feature flag server-side (not just UI hiding)
+- [x] Pagination works for both conversation list and message detail
+- [x] No write operations are exposed (read-only audit view)
+- [x] CSV export includes proper headers, escaping, and `Cache-Control: no-store`
+- [x] All 40 unit tests pass
+- [x] Documentation updated (spec + ADR)
+
+## Implementation Plan
+
+### Phase 1: Core Feature
+- [x] Add `auditLogsEnabled` to Config interface, DEFAULT_CONFIG, and getServerConfig()
+- [x] Add `AuditConversation` and `AuditLogFilters` types
+- [x] Create `GET /api/admin/audit-logs` with aggregation pipeline
+- [x] Create `GET /api/admin/audit-logs/[id]/messages` for conversation detail
+- [x] Create `AuditLogsTab` component with filters and results table
+- [x] Create `ConversationDetailDialog` component for message viewing
+- [x] Add conditional tab to admin page
+
+### Phase 2: Enhancements
+- [x] Add CSV export endpoint (`GET /api/admin/audit-logs/export`)
+- [x] Add Download CSV button to AuditLogsTab UI
+- [x] Add searchable owner email dropdown with `GET /api/admin/audit-logs/owners`
+- [x] Add conversation UUID display, copy-to-clipboard, and direct chat link
+- [x] Implement scrollable message content in ConversationDetailDialog
+
+### Phase 3: Quality & Documentation
+- [x] Create comprehensive test suite (40 tests across all 4 endpoints)
+- [x] Create spec in `.specify/specs/`
+- [x] Create ADR in `docs/docs/changes/`
+
+## Testing Strategy
+
+- Unit tests (40 tests in `admin-audit-logs.test.ts`):
+  - Auth: 401 unauthenticated, 403 non-admin, 403 readonly admin, 503 MongoDB not configured
+  - Feature flag: 403 when `auditLogsEnabled` is false (all 4 endpoints)
+  - List: filter propagation (owner, search, date range, status), pagination, aggregation pipeline
+  - Messages: 404 not found, conversation metadata, paginated messages, empty conversations
+  - Export: CSV headers, Content-Type/Content-Disposition, data rows, CSV escaping, filter propagation
+  - Owners: distinct owners, search query, `$group` aggregation, result limit, null filtering
+- Manual verification:
+  - Set `AUDIT_LOGS_ENABLED=true`, verify tab appears
+  - Unset env var, verify tab is hidden and API returns 403
+  - Search by owner email using autocomplete dropdown
+  - Click conversation to view full messages with scrolling
+  - Download CSV and verify contents
+  - Copy conversation UUID and open direct chat link
+
+## Rollout Plan
+
+1. Merge PR to main
+2. Feature is off by default — no impact on existing deployments
+3. Operators enable via `AUDIT_LOGS_ENABLED=true` in their environment
+4. Document env var in deployment guides
+
+## Related
+
+- ADR: `docs/docs/changes/2026-03-03-admin-audit-logs.md`
+- PR: [#894](https://github.com/cnoe-io/ai-platform-engineering/pull/894)
+- Tests: `ui/src/app/api/__tests__/admin-audit-logs.test.ts`
+- Existing admin dashboard: `ui/src/app/(app)/admin/page.tsx`
+- Config system: `ui/src/lib/config.ts`

--- a/docs/docs/changes/2026-03-03-admin-audit-logs.md
+++ b/docs/docs/changes/2026-03-03-admin-audit-logs.md
@@ -1,0 +1,132 @@
+---
+title: "2026-03-03: Admin Audit Logs — All-Chats Compliance View"
+---
+
+# Admin Audit Logs — All-Chats Compliance View
+
+**Date**: 2026-03-03
+**Status**: Implemented
+**Type**: Feature Addition
+
+## Overview
+
+Added an optional admin-only feature that allows platform administrators to browse, search, and export all conversations and full message content across all users. The feature is gated by the `AUDIT_LOGS_ENABLED` environment variable and disabled by default.
+
+## Problem Statement
+
+Administrators had no way to review user conversations with AI agents for compliance, auditing, or support purposes. The existing admin dashboard provided aggregate statistics (total conversations, message counts, top users) but no ability to inspect individual conversation content across users.
+
+## Decision
+
+| Alternative | Pros | Cons | Decision |
+|---|---|---|---|
+| **New admin tab with env-var gate (chosen)** | Opt-in, no impact on existing deployments, reuses existing MongoDB collections | Requires env var configuration to enable | Selected |
+| Always-on audit view | No configuration needed | Privacy concern; exposes all chats by default | Rejected |
+| Separate audit service | Decoupled, scalable | Over-engineered for current needs; new infrastructure | Rejected |
+| Database-level audit logs | Captures all mutations | Does not provide user-friendly browsing UI | Rejected — complementary, not replacement |
+
+## Solution Architecture
+
+### Feature Gate
+
+The feature follows the same pattern as `workflowRunnerEnabled`:
+
+```bash
+AUDIT_LOGS_ENABLED=true  # Set to enable; omit or set false to disable
+```
+
+The gate is enforced at three levels:
+1. **Env var**: `AUDIT_LOGS_ENABLED=true` must be set (disabled by default)
+2. **UI**: The Audit Logs tab is only rendered when `auditLogsEnabled` is true AND the user is a full admin (`isAdmin`) — read-only admin viewers do not see the tab
+3. **API**: All endpoints return HTTP 403 if the feature is disabled OR if the user is not a full admin (`requireAdmin`, not `requireAdminView`)
+
+### API Endpoints
+
+| Endpoint | Method | Auth | Description |
+|---|---|---|---|
+| `/api/admin/audit-logs` | GET | `requireAdmin` | List all conversations with filters and pagination |
+| `/api/admin/audit-logs/[id]/messages` | GET | `requireAdmin` | Get paginated messages for a specific conversation |
+| `/api/admin/audit-logs/export` | GET | `requireAdmin` | Download filtered conversations as CSV (up to 10,000 rows) |
+| `/api/admin/audit-logs/owners` | GET | `requireAdmin` | Search distinct conversation owner emails (typeahead) |
+
+### List Endpoint Filters
+
+| Parameter | Type | Description |
+|---|---|---|
+| `owner_email` | string | Filter by conversation owner (case-insensitive substring) |
+| `search` | string | Search in conversation titles (case-insensitive substring) |
+| `date_from` | ISO date | Conversations created on or after this date |
+| `date_to` | ISO date | Conversations created on or before this date |
+| `status` | enum | `active`, `archived`, or `deleted` |
+| `include_deleted` | boolean | Include soft-deleted conversations (default: false) |
+| `page` | number | Page number (default: 1) |
+| `page_size` | number | Items per page (default: 20, max: 100) |
+
+### Export Endpoint
+
+The export endpoint accepts the same filter parameters as the list endpoint but returns a CSV file instead of JSON. The response includes:
+- `Content-Type: text/csv; charset=utf-8`
+- `Content-Disposition: attachment; filename="audit-logs-&#123;timestamp&#125;.csv"`
+- `Cache-Control: no-store`
+- CSV columns: Conversation ID, Owner, Title, Status, Messages, Created, Updated, Last Message, Tags, Shared With, Shared With Teams, Is Public
+- Maximum 10,000 rows per export
+
+### Owners Endpoint
+
+| Parameter | Type | Description |
+|---|---|---|
+| `q` | string | Case-insensitive substring search on owner_id (optional) |
+
+Returns up to 50 distinct owner emails sorted alphabetically. Used by the searchable owner dropdown in the UI.
+
+### Data Flow
+
+The feature queries existing MongoDB collections (`conversations` and `messages`) with no schema changes. The list and export endpoints use a `$lookup` aggregation to fetch the last message timestamp and derive conversation status from `deleted_at` and `is_archived` fields. The owners endpoint uses `$group` to extract distinct `owner_id` values.
+
+### Configuration
+
+```bash
+# Enable audit logs (disabled by default)
+AUDIT_LOGS_ENABLED=true
+```
+
+No additional configuration is required. The feature inherits MongoDB connection settings and admin authorization from the existing platform configuration.
+
+## Components Changed
+
+### Config
+- `ui/src/lib/config.ts` — Added `auditLogsEnabled: boolean` to Config interface, DEFAULT_CONFIG (false), and getServerConfig()
+
+### Types
+- `ui/src/types/mongodb.ts` — Added `AuditConversation` (extends Conversation with `message_count`, `last_message_at`, `status`) and `AuditLogFilters`
+
+### API Routes
+- `ui/src/app/api/admin/audit-logs/route.ts` (new) — GET handler with feature-flag check, admin auth, MongoDB aggregation pipeline with filters and pagination
+- `ui/src/app/api/admin/audit-logs/[id]/messages/route.ts` (new) — GET handler returning paginated messages with conversation metadata
+- `ui/src/app/api/admin/audit-logs/export/route.ts` (new) — GET handler generating CSV export with filters, proper escaping, and security headers
+- `ui/src/app/api/admin/audit-logs/owners/route.ts` (new) — GET handler returning distinct owner emails with optional search filter
+
+### UI Components
+- `ui/src/app/(app)/admin/page.tsx` — Conditionally renders Audit Logs tab when `auditLogsEnabled` is true and user is full admin
+- `ui/src/components/admin/AuditLogsTab.tsx` (new) — Filter bar with searchable owner dropdown, results table, CSV download button, pagination, conversation UUID display with copy and chat link
+- `ui/src/components/admin/ConversationDetailDialog.tsx` (new) — Dialog for viewing full conversation messages with scrollable layout, UUID display, copy-to-clipboard, and direct chat link
+
+### Tests
+- `ui/src/app/api/__tests__/admin-audit-logs.test.ts` (new) — 40 tests covering authentication, authorization, feature flag enforcement, filtering, pagination, CSV export, and owner search across all 4 endpoints
+
+## Security
+
+- Triple-gated: env var + full admin role (`requireAdmin`) + UI visibility check
+- Read-only admin viewers (`canViewAdmin`) cannot access audit logs — only full admins (`session.role === 'admin'`) can
+- Server-side enforcement: all 4 API endpoints reject with 403 when feature is disabled or user is not a full admin
+- Read-only: no mutation endpoints exposed
+- MongoDB queries use parameterized aggregation pipelines
+- CSV export response includes `Cache-Control: no-store` to prevent caching of sensitive data
+
+## Related
+
+- Spec: `.specify/specs/admin-audit-logs.md`
+- PR: [#894](https://github.com/cnoe-io/ai-platform-engineering/pull/894)
+- Tests: `ui/src/app/api/__tests__/admin-audit-logs.test.ts`
+- Admin dashboard: `ui/src/app/(app)/admin/page.tsx`
+- Config system: `ui/src/lib/config.ts`

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -4,7 +4,7 @@ import React, { useState, useEffect } from "react";
 import { useSearchParams } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { motion } from "framer-motion";
-import { Users, MessageSquare, TrendingUp, Activity, Database, Share2, ShieldCheck, ShieldOff, UserPlus, Trash2, UsersIcon, Loader2, Bot, ThumbsUp, ThumbsDown, Clock, Zap, CheckCircle2, AlertCircle, Layers, Eye, Star, Filter, ExternalLink, Plus, Calendar, X } from "lucide-react";
+import { Users, MessageSquare, TrendingUp, Activity, Database, Share2, ShieldCheck, ShieldOff, UserPlus, Trash2, UsersIcon, Loader2, Bot, ThumbsUp, ThumbsDown, Clock, Zap, CheckCircle2, AlertCircle, Layers, Eye, Star, Filter, ExternalLink, Plus, Calendar, X, FileText } from "lucide-react";
 import { AuthGuard } from "@/components/auth-guard";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -23,9 +23,10 @@ import {
 } from "@/components/admin/SkillMetricsCards";
 import { CreateTeamDialog } from "@/components/admin/CreateTeamDialog";
 import { TeamDetailsDialog } from "@/components/admin/TeamDetailsDialog";
+import { AuditLogsTab } from "@/components/admin/AuditLogsTab";
 import { useAdminRole } from "@/hooks/use-admin-role";
-import { apiClient } from "@/lib/api-client";
 import { getConfig } from "@/lib/config";
+import { apiClient } from "@/lib/api-client";
 import type { Team as TeamType } from "@/types/teams";
 import type { SkillMetricsAdmin } from "@/types/agent-config";
 
@@ -164,6 +165,7 @@ function AdminPage() {
   const { status } = useSession();
   const searchParams = useSearchParams();
   const { isAdmin } = useAdminRole();
+  const auditLogsEnabled = getConfig('auditLogsEnabled');
   const [stats, setStats] = useState<AdminStats | null>(null);
   const [skillStats, setSkillStats] = useState<SkillMetricsAdmin | null>(null);
   const [users, setUsers] = useState<UserInfo[]>([]);
@@ -548,11 +550,14 @@ function AdminPage() {
 
             {/* Tabbed Content */}
             <Tabs value={activeTab} onValueChange={setActiveTab} className="space-y-4">
-              <TabsList className={`grid w-full ${
-                getConfig('feedbackEnabled') && getConfig('npsEnabled') ? 'grid-cols-8' :
-                getConfig('feedbackEnabled') || getConfig('npsEnabled') ? 'grid-cols-7' :
-                'grid-cols-6'
-              }`}>
+              <TabsList className={`grid w-full ${(() => {
+                const n = 6
+                  + (getConfig('feedbackEnabled') ? 1 : 0)
+                  + (getConfig('npsEnabled') ? 1 : 0)
+                  + (auditLogsEnabled && isAdmin ? 1 : 0);
+                const cols: Record<number, string> = { 6: 'grid-cols-6', 7: 'grid-cols-7', 8: 'grid-cols-8', 9: 'grid-cols-9' };
+                return cols[n] ?? 'grid-cols-6';
+              })()}`}>
                 <TabsTrigger value="users" className="gap-2">
                   <Users className="h-4 w-4" />
                   Users
@@ -589,6 +594,12 @@ function AdminPage() {
                   <Database className="h-4 w-4" />
                   Health
                 </TabsTrigger>
+                {auditLogsEnabled && isAdmin && (
+                  <TabsTrigger value="audit-logs" className="gap-2">
+                    <FileText className="h-4 w-4" />
+                    Audit Logs
+                  </TabsTrigger>
+                )}
               </TabsList>
 
               {/* User Management Tab */}
@@ -1828,6 +1839,13 @@ function AdminPage() {
               <TabsContent value="health" className="space-y-4">
                 <HealthTab />
               </TabsContent>
+
+              {/* Audit Logs Tab (optional, gated by AUDIT_LOGS_ENABLED + full admin role) */}
+              {auditLogsEnabled && isAdmin && (
+                <TabsContent value="audit-logs" className="space-y-4">
+                  <AuditLogsTab isAdmin={isAdmin} />
+                </TabsContent>
+              )}
             </Tabs>
           </div>
         </ScrollArea>

--- a/ui/src/app/api/__tests__/admin-audit-logs.test.ts
+++ b/ui/src/app/api/__tests__/admin-audit-logs.test.ts
@@ -1,0 +1,825 @@
+/**
+ * @jest-environment node
+ */
+/**
+ * Tests for Admin Audit Logs API Routes
+ *
+ * Covers:
+ * - GET /api/admin/audit-logs — list all conversations with filters and pagination
+ * - GET /api/admin/audit-logs/[id]/messages — get paginated messages for a conversation
+ * - GET /api/admin/audit-logs/export — download conversations as CSV
+ * - GET /api/admin/audit-logs/owners — search distinct conversation owners
+ *
+ * Features tested:
+ * - Authentication: 401 when unauthenticated
+ * - Authorization: 403 when non-admin (full admin required, not readonly)
+ * - Feature flag: 403 when AUDIT_LOGS_ENABLED is false
+ * - MongoDB guard: 503 when MongoDB is not configured
+ * - List endpoint: filters (owner, search, date, status), pagination, aggregation pipeline
+ * - Messages endpoint: conversation lookup, paginated messages, 404 handling
+ * - Export endpoint: CSV generation with headers, proper Content-Type and Content-Disposition
+ * - Owners endpoint: distinct owner_id aggregation with search filter
+ * - Edge cases: empty results, readonly admin rejection
+ */
+
+import { NextRequest } from 'next/server';
+import { ObjectId } from 'mongodb';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetServerSession = jest.fn();
+jest.mock('next-auth', () => ({
+  getServerSession: (...args: any[]) => mockGetServerSession(...args),
+}));
+
+jest.mock('@/lib/auth-config', () => ({
+  authOptions: {},
+}));
+
+jest.mock('@/lib/config', () => ({
+  getConfig: (key: string) => key === 'ssoEnabled',
+  getServerConfig: () => mockServerConfig,
+}));
+
+let mockServerConfig: Record<string, any> = { auditLogsEnabled: true };
+
+const mockCollections: Record<string, any> = {};
+const mockGetCollection = jest.fn((name: string) => {
+  if (!mockCollections[name]) {
+    mockCollections[name] = createMockCollection();
+  }
+  return Promise.resolve(mockCollections[name]);
+});
+
+let mockIsMongoDBConfigured = true;
+jest.mock('@/lib/mongodb', () => ({
+  getCollection: (...args: any[]) => mockGetCollection(...args),
+  get isMongoDBConfigured() {
+    return mockIsMongoDBConfigured;
+  },
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createMockCollection() {
+  return {
+    find: jest.fn().mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    }),
+    findOne: jest.fn().mockResolvedValue(null),
+    insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
+    updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    countDocuments: jest.fn().mockResolvedValue(0),
+    aggregate: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    }),
+  };
+}
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost:3000'));
+}
+
+function adminSession() {
+  return {
+    user: { email: 'admin@example.com', name: 'Admin User' },
+    role: 'admin',
+  };
+}
+
+function userSession() {
+  return {
+    user: { email: 'user@example.com', name: 'Regular User' },
+    role: 'user',
+  };
+}
+
+function readonlyAdminSession() {
+  return {
+    user: { email: 'viewer@example.com', name: 'Viewer User' },
+    role: 'user',
+    canViewAdmin: true,
+  };
+}
+
+function resetMocks() {
+  mockGetServerSession.mockReset();
+  mockGetCollection.mockClear();
+  mockIsMongoDBConfigured = true;
+  mockServerConfig = { auditLogsEnabled: true };
+  Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
+}
+
+function setupAdminWithConversations(convData: any[] = []) {
+  mockGetServerSession.mockResolvedValue(adminSession());
+
+  const convCol = createMockCollection();
+  convCol.aggregate.mockReturnValue({
+    toArray: jest.fn().mockResolvedValue([
+      {
+        items: convData,
+        totalCount: [{ count: convData.length }],
+      },
+    ]),
+  });
+  mockCollections['conversations'] = convCol;
+
+  return { convCol };
+}
+
+// ============================================================================
+// Test imports (after mocks)
+// ============================================================================
+
+import { GET as listGET } from '../admin/audit-logs/route';
+import { GET as messagesGET } from '../admin/audit-logs/[id]/messages/route';
+import { GET as exportGET } from '../admin/audit-logs/export/route';
+import { GET as ownersGET } from '../admin/audit-logs/owners/route';
+
+// ============================================================================
+// Tests: GET /api/admin/audit-logs — Auth & Feature Flag
+// ============================================================================
+
+describe('GET /api/admin/audit-logs — Auth & Feature Flag', () => {
+  beforeEach(resetMocks);
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const req = makeRequest('/api/admin/audit-logs');
+    const res = await listGET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 when user is not a full admin', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const req = makeRequest('/api/admin/audit-logs');
+    const res = await listGET(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 for readonly admin viewers (canViewAdmin)', async () => {
+    mockGetServerSession.mockResolvedValue(readonlyAdminSession());
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const req = makeRequest('/api/admin/audit-logs');
+    const res = await listGET(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toContain('Admin access required');
+  });
+
+  it('returns 403 when auditLogsEnabled is false', async () => {
+    mockServerConfig = { auditLogsEnabled: false };
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const req = makeRequest('/api/admin/audit-logs');
+    const res = await listGET(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe('FEATURE_DISABLED');
+  });
+
+  it('returns 503 when MongoDB is not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    const req = makeRequest('/api/admin/audit-logs');
+    const res = await listGET(req);
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.code).toBe('MONGODB_NOT_CONFIGURED');
+  });
+});
+
+// ============================================================================
+// Tests: GET /api/admin/audit-logs — Listing & Filters
+// ============================================================================
+
+describe('GET /api/admin/audit-logs — Listing', () => {
+  beforeEach(resetMocks);
+
+  it('returns paginated conversations on success', async () => {
+    const convData = [
+      {
+        _id: 'conv-1',
+        owner_id: 'alice@example.com',
+        title: 'Test Chat',
+        created_at: new Date(),
+        updated_at: new Date(),
+        message_count: 5,
+        status: 'active',
+      },
+    ];
+    setupAdminWithConversations(convData);
+
+    const req = makeRequest('/api/admin/audit-logs');
+    const res = await listGET(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.items).toHaveLength(1);
+    expect(body.data.items[0]._id).toBe('conv-1');
+    expect(body.data.total).toBe(1);
+  });
+
+  it('returns empty list when no conversations match', async () => {
+    setupAdminWithConversations([]);
+
+    const req = makeRequest('/api/admin/audit-logs');
+    const res = await listGET(req);
+    const body = await res.json();
+
+    expect(body.data.items).toEqual([]);
+    expect(body.data.total).toBe(0);
+  });
+
+  it('passes owner_email filter to aggregation pipeline', async () => {
+    const { convCol } = setupAdminWithConversations([]);
+
+    const req = makeRequest('/api/admin/audit-logs?owner_email=alice');
+    await listGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const matchStage = pipeline.find((s: any) => s.$match);
+    expect(matchStage.$match.owner_id).toEqual({ $regex: 'alice', $options: 'i' });
+  });
+
+  it('passes search filter to aggregation pipeline', async () => {
+    const { convCol } = setupAdminWithConversations([]);
+
+    const req = makeRequest('/api/admin/audit-logs?search=kubernetes');
+    await listGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const matchStage = pipeline.find((s: any) => s.$match);
+    expect(matchStage.$match.title).toEqual({ $regex: 'kubernetes', $options: 'i' });
+  });
+
+  it('passes date range filters to aggregation pipeline', async () => {
+    const { convCol } = setupAdminWithConversations([]);
+
+    const req = makeRequest(
+      '/api/admin/audit-logs?date_from=2026-01-01&date_to=2026-03-01'
+    );
+    await listGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const matchStage = pipeline.find((s: any) => s.$match);
+    expect(matchStage.$match.created_at.$gte).toEqual(new Date('2026-01-01'));
+    expect(matchStage.$match.created_at.$lte).toEqual(new Date('2026-03-01'));
+  });
+
+  it('filters by status=active', async () => {
+    const { convCol } = setupAdminWithConversations([]);
+
+    const req = makeRequest('/api/admin/audit-logs?status=active');
+    await listGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const matchStage = pipeline.find((s: any) => s.$match);
+    expect(matchStage.$match.is_archived).toEqual({ $ne: true });
+  });
+
+  it('filters by status=deleted', async () => {
+    const { convCol } = setupAdminWithConversations([]);
+
+    const req = makeRequest('/api/admin/audit-logs?status=deleted');
+    await listGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const matchStage = pipeline.find((s: any) => s.$match);
+    expect(matchStage.$match.deleted_at).toEqual({ $ne: null, $exists: true });
+  });
+
+  it('uses $lookup to get last message timestamp', async () => {
+    const { convCol } = setupAdminWithConversations([]);
+
+    const req = makeRequest('/api/admin/audit-logs');
+    await listGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const lookupStage = pipeline.find((s: any) => s.$lookup);
+    expect(lookupStage).toBeDefined();
+    expect(lookupStage.$lookup.from).toBe('messages');
+    expect(lookupStage.$lookup.localField).toBe('_id');
+    expect(lookupStage.$lookup.foreignField).toBe('conversation_id');
+  });
+
+  it('uses $facet for pagination', async () => {
+    const { convCol } = setupAdminWithConversations([]);
+
+    const req = makeRequest('/api/admin/audit-logs?page=2&page_size=10');
+    await listGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const facetStage = pipeline.find((s: any) => s.$facet);
+    expect(facetStage).toBeDefined();
+    expect(facetStage.$facet.items).toBeDefined();
+    expect(facetStage.$facet.totalCount).toBeDefined();
+  });
+});
+
+// ============================================================================
+// Tests: GET /api/admin/audit-logs/[id]/messages — Auth & Feature Flag
+// ============================================================================
+
+describe('GET /api/admin/audit-logs/[id]/messages — Auth & Feature Flag', () => {
+  beforeEach(resetMocks);
+
+  const callMessages = (url: string, id: string = 'conv-123') => {
+    const req = makeRequest(url);
+    return messagesGET(req, { params: Promise.resolve({ id }) });
+  };
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const res = await callMessages('/api/admin/audit-logs/conv-123/messages');
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for readonly admin viewers', async () => {
+    mockGetServerSession.mockResolvedValue(readonlyAdminSession());
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const res = await callMessages('/api/admin/audit-logs/conv-123/messages');
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when auditLogsEnabled is false', async () => {
+    mockServerConfig = { auditLogsEnabled: false };
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const res = await callMessages('/api/admin/audit-logs/conv-123/messages');
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe('FEATURE_DISABLED');
+  });
+
+  it('returns 503 when MongoDB is not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    const res = await callMessages('/api/admin/audit-logs/conv-123/messages');
+    expect(res.status).toBe(503);
+  });
+});
+
+// ============================================================================
+// Tests: GET /api/admin/audit-logs/[id]/messages — Conversation Messages
+// ============================================================================
+
+describe('GET /api/admin/audit-logs/[id]/messages — Messages', () => {
+  beforeEach(resetMocks);
+
+  const callMessages = (url: string, id: string = 'conv-123') => {
+    const req = makeRequest(url);
+    return messagesGET(req, { params: Promise.resolve({ id }) });
+  };
+
+  it('returns 404 when conversation does not exist', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.findOne.mockResolvedValue(null);
+    mockCollections['conversations'] = convCol;
+
+    const res = await callMessages('/api/admin/audit-logs/nonexistent/messages', 'nonexistent');
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.code).toBe('NOT_FOUND');
+  });
+
+  it('returns conversation metadata and paginated messages', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const now = new Date();
+    const convCol = createMockCollection();
+    convCol.findOne.mockResolvedValue({
+      _id: 'conv-123',
+      title: 'Test Conversation',
+      owner_id: 'alice@example.com',
+      created_at: now,
+      updated_at: now,
+      tags: ['test'],
+      sharing: { is_public: false },
+      is_archived: false,
+      deleted_at: null,
+    });
+    mockCollections['conversations'] = convCol;
+
+    const msgCol = createMockCollection();
+    msgCol.countDocuments.mockResolvedValue(2);
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([
+              { _id: 'msg-1', role: 'user', content: 'Hello', created_at: now },
+              { _id: 'msg-2', role: 'assistant', content: 'Hi there', created_at: now },
+            ]),
+          }),
+        }),
+      }),
+    });
+    mockCollections['messages'] = msgCol;
+
+    const res = await callMessages('/api/admin/audit-logs/conv-123/messages');
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.conversation._id).toBe('conv-123');
+    expect(body.data.conversation.title).toBe('Test Conversation');
+    expect(body.data.conversation.owner_id).toBe('alice@example.com');
+    expect(body.data.messages.items).toHaveLength(2);
+    expect(body.data.messages.total).toBe(2);
+    expect(body.data.messages.page).toBe(1);
+  });
+
+  it('returns empty messages for conversation with no messages', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.findOne.mockResolvedValue({
+      _id: 'conv-empty',
+      title: 'Empty Conv',
+      owner_id: 'bob@example.com',
+      created_at: new Date(),
+      updated_at: new Date(),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const msgCol = createMockCollection();
+    msgCol.countDocuments.mockResolvedValue(0);
+    msgCol.find.mockReturnValue({
+      sort: jest.fn().mockReturnValue({
+        skip: jest.fn().mockReturnValue({
+          limit: jest.fn().mockReturnValue({
+            toArray: jest.fn().mockResolvedValue([]),
+          }),
+        }),
+      }),
+    });
+    mockCollections['messages'] = msgCol;
+
+    const res = await callMessages('/api/admin/audit-logs/conv-empty/messages', 'conv-empty');
+    const body = await res.json();
+
+    expect(body.data.messages.items).toEqual([]);
+    expect(body.data.messages.total).toBe(0);
+    expect(body.data.messages.has_more).toBe(false);
+  });
+});
+
+// ============================================================================
+// Tests: GET /api/admin/audit-logs/export — Auth & Feature Flag
+// ============================================================================
+
+describe('GET /api/admin/audit-logs/export — Auth & Feature Flag', () => {
+  beforeEach(resetMocks);
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const req = makeRequest('/api/admin/audit-logs/export');
+    const res = await exportGET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for readonly admin viewers', async () => {
+    mockGetServerSession.mockResolvedValue(readonlyAdminSession());
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const req = makeRequest('/api/admin/audit-logs/export');
+    const res = await exportGET(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when auditLogsEnabled is false', async () => {
+    mockServerConfig = { auditLogsEnabled: false };
+    const req = makeRequest('/api/admin/audit-logs/export');
+    const res = await exportGET(req);
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.code).toBe('FEATURE_DISABLED');
+  });
+
+  it('returns 503 when MongoDB is not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    const req = makeRequest('/api/admin/audit-logs/export');
+    const res = await exportGET(req);
+    expect(res.status).toBe(503);
+  });
+});
+
+// ============================================================================
+// Tests: GET /api/admin/audit-logs/export — CSV Export
+// ============================================================================
+
+describe('GET /api/admin/audit-logs/export — CSV', () => {
+  beforeEach(resetMocks);
+
+  it('returns CSV with correct Content-Type and Content-Disposition', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/export');
+    const res = await exportGET(req);
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get('Content-Type')).toBe('text/csv; charset=utf-8');
+    expect(res.headers.get('Content-Disposition')).toMatch(/^attachment; filename="audit-logs-/);
+    expect(res.headers.get('Cache-Control')).toBe('no-store');
+  });
+
+  it('includes CSV header row', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/export');
+    const res = await exportGET(req);
+    const csv = await res.text();
+
+    const headerLine = csv.split('\n')[0];
+    expect(headerLine).toContain('Conversation ID');
+    expect(headerLine).toContain('Owner');
+    expect(headerLine).toContain('Title');
+    expect(headerLine).toContain('Status');
+    expect(headerLine).toContain('Messages');
+  });
+
+  it('includes conversation data rows in CSV', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+    const now = new Date('2026-03-01T12:00:00Z');
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([
+        {
+          _id: 'conv-1',
+          owner_id: 'alice@example.com',
+          title: 'Test Chat',
+          status: 'active',
+          message_count: 5,
+          created_at: now,
+          updated_at: now,
+          last_message_at: now,
+          tags: ['prod', 'k8s'],
+          sharing: { shared_with: [], shared_with_teams: [], is_public: false },
+        },
+      ]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/export');
+    const res = await exportGET(req);
+    const csv = await res.text();
+    const lines = csv.split('\n');
+
+    expect(lines).toHaveLength(2);
+    expect(lines[1]).toContain('conv-1');
+    expect(lines[1]).toContain('alice@example.com');
+    expect(lines[1]).toContain('Test Chat');
+    expect(lines[1]).toContain('active');
+    expect(lines[1]).toContain('5');
+    expect(lines[1]).toContain('prod; k8s');
+  });
+
+  it('escapes CSV values containing commas and quotes', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([
+        {
+          _id: 'conv-2',
+          owner_id: 'bob@example.com',
+          title: 'Chat about "Kubernetes, Helm"',
+          status: 'active',
+          message_count: 1,
+          created_at: new Date(),
+          updated_at: new Date(),
+          tags: [],
+        },
+      ]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/export');
+    const res = await exportGET(req);
+    const csv = await res.text();
+
+    expect(csv).toContain('"Chat about ""Kubernetes, Helm"""');
+  });
+
+  it('passes filters to export aggregation pipeline', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/export?owner_email=alice&status=archived');
+    await exportGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const matchStage = pipeline.find((s: any) => s.$match);
+    expect(matchStage.$match.owner_id).toEqual({ $regex: 'alice', $options: 'i' });
+    expect(matchStage.$match.is_archived).toBe(true);
+  });
+});
+
+// ============================================================================
+// Tests: GET /api/admin/audit-logs/owners — Auth & Feature Flag
+// ============================================================================
+
+describe('GET /api/admin/audit-logs/owners — Auth & Feature Flag', () => {
+  beforeEach(resetMocks);
+
+  it('returns 401 when not authenticated', async () => {
+    mockGetServerSession.mockResolvedValue(null);
+    const req = makeRequest('/api/admin/audit-logs/owners');
+    const res = await ownersGET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for readonly admin viewers', async () => {
+    mockGetServerSession.mockResolvedValue(readonlyAdminSession());
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const req = makeRequest('/api/admin/audit-logs/owners');
+    const res = await ownersGET(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 403 when auditLogsEnabled is false', async () => {
+    mockServerConfig = { auditLogsEnabled: false };
+    const req = makeRequest('/api/admin/audit-logs/owners');
+    const res = await ownersGET(req);
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 503 when MongoDB is not configured', async () => {
+    mockIsMongoDBConfigured = false;
+    const req = makeRequest('/api/admin/audit-logs/owners');
+    const res = await ownersGET(req);
+    expect(res.status).toBe(503);
+  });
+});
+
+// ============================================================================
+// Tests: GET /api/admin/audit-logs/owners — Owner Search
+// ============================================================================
+
+describe('GET /api/admin/audit-logs/owners — Search', () => {
+  beforeEach(resetMocks);
+
+  it('returns distinct owner emails', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([
+        { owner_id: 'alice@example.com' },
+        { owner_id: 'bob@example.com' },
+      ]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/owners');
+    const res = await ownersGET(req);
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.data.owners).toEqual(['alice@example.com', 'bob@example.com']);
+  });
+
+  it('passes search query to aggregation pipeline', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([
+        { owner_id: 'alice@example.com' },
+      ]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/owners?q=alice');
+    await ownersGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const matchStage = pipeline.find((s: any) => s.$match);
+    expect(matchStage).toBeDefined();
+    expect(matchStage.$match.owner_id).toEqual({ $regex: 'alice', $options: 'i' });
+  });
+
+  it('uses $group for distinct owners', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/owners');
+    await ownersGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const groupStage = pipeline.find((s: any) => s.$group);
+    expect(groupStage).toBeDefined();
+    expect(groupStage.$group._id).toBe('$owner_id');
+  });
+
+  it('limits results to 50', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/owners');
+    await ownersGET(req);
+
+    const pipeline = convCol.aggregate.mock.calls[0][0];
+    const limitStage = pipeline.find((s: any) => s.$limit);
+    expect(limitStage).toBeDefined();
+    expect(limitStage.$limit).toBe(50);
+  });
+
+  it('returns empty array when no owners found', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/owners?q=nonexistent');
+    const res = await ownersGET(req);
+    const body = await res.json();
+
+    expect(body.data.owners).toEqual([]);
+  });
+
+  it('omits null/empty owner_id values', async () => {
+    mockGetServerSession.mockResolvedValue(adminSession());
+
+    const convCol = createMockCollection();
+    convCol.aggregate.mockReturnValue({
+      toArray: jest.fn().mockResolvedValue([
+        { owner_id: 'alice@example.com' },
+        { owner_id: null },
+        { owner_id: '' },
+      ]),
+    });
+    mockCollections['conversations'] = convCol;
+
+    const req = makeRequest('/api/admin/audit-logs/owners');
+    const res = await ownersGET(req);
+    const body = await res.json();
+
+    expect(body.data.owners).toEqual(['alice@example.com']);
+  });
+});

--- a/ui/src/app/api/admin/audit-logs/[id]/messages/route.ts
+++ b/ui/src/app/api/admin/audit-logs/[id]/messages/route.ts
@@ -1,0 +1,80 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  withAuth,
+  withErrorHandler,
+  requireAdmin,
+  getPaginationParams,
+  ApiError,
+  successResponse,
+} from '@/lib/api-middleware';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getServerConfig } from '@/lib/config';
+import type { Message, Conversation } from '@/types/mongodb';
+
+export const GET = withErrorHandler(
+  async (request: NextRequest, { params }: { params: Promise<{ id: string }> }) => {
+    if (!isMongoDBConfigured) {
+      return NextResponse.json(
+        { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+        { status: 503 },
+      );
+    }
+
+    if (!getServerConfig().auditLogsEnabled) {
+      return NextResponse.json(
+        { success: false, error: 'Audit logs feature is not enabled', code: 'FEATURE_DISABLED' },
+        { status: 403 },
+      );
+    }
+
+    return withAuth(request, async (req, _user, session) => {
+      requireAdmin(session);
+
+      const { id: conversationId } = await params;
+
+      if (!conversationId) {
+        throw new ApiError('Conversation ID is required', 400);
+      }
+
+      const conversations = await getCollection<Conversation>('conversations');
+      const conversation = await conversations.findOne({ _id: conversationId });
+
+      if (!conversation) {
+        throw new ApiError('Conversation not found', 404, 'NOT_FOUND');
+      }
+
+      const { page, pageSize, skip } = getPaginationParams(req);
+      const messages = await getCollection<Message>('messages');
+
+      const query = { conversation_id: conversationId };
+      const total = await messages.countDocuments(query);
+      const items = await messages
+        .find(query)
+        .sort({ created_at: 1 })
+        .skip(skip)
+        .limit(pageSize)
+        .toArray();
+
+      return successResponse({
+        conversation: {
+          _id: conversation._id,
+          title: conversation.title,
+          owner_id: conversation.owner_id,
+          created_at: conversation.created_at,
+          updated_at: conversation.updated_at,
+          tags: conversation.tags,
+          sharing: conversation.sharing,
+          is_archived: conversation.is_archived,
+          deleted_at: conversation.deleted_at,
+        },
+        messages: {
+          items,
+          total,
+          page,
+          page_size: pageSize,
+          has_more: page * pageSize < total,
+        },
+      });
+    });
+  },
+);

--- a/ui/src/app/api/admin/audit-logs/export/route.ts
+++ b/ui/src/app/api/admin/audit-logs/export/route.ts
@@ -1,0 +1,177 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  withAuth,
+  withErrorHandler,
+  requireAdmin,
+} from '@/lib/api-middleware';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getServerConfig } from '@/lib/config';
+import type { Conversation } from '@/types/mongodb';
+
+const MAX_EXPORT_ROWS = 10000;
+
+function escapeCSV(value: string): string {
+  if (value.includes(',') || value.includes('"') || value.includes('\n') || value.includes('\r')) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}
+
+function toISOSafe(date: any): string {
+  if (!date) return '';
+  try {
+    return new Date(date).toISOString();
+  } catch {
+    return '';
+  }
+}
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+      { status: 503 },
+    );
+  }
+
+  if (!getServerConfig().auditLogsEnabled) {
+    return NextResponse.json(
+      { success: false, error: 'Audit logs feature is not enabled', code: 'FEATURE_DISABLED' },
+      { status: 403 },
+    );
+  }
+
+  return withAuth(request, async (req, _user, session) => {
+    requireAdmin(session);
+
+    const url = new URL(req.url);
+    const ownerEmail = url.searchParams.get('owner_email')?.trim();
+    const search = url.searchParams.get('search')?.trim();
+    const dateFrom = url.searchParams.get('date_from');
+    const dateTo = url.searchParams.get('date_to');
+    const includeDeleted = url.searchParams.get('include_deleted') === 'true';
+    const status = url.searchParams.get('status') as 'active' | 'archived' | 'deleted' | null;
+
+    const matchStage: Record<string, any> = {};
+
+    if (ownerEmail) {
+      matchStage.owner_id = { $regex: ownerEmail, $options: 'i' };
+    }
+
+    if (search) {
+      matchStage.title = { $regex: search, $options: 'i' };
+    }
+
+    if (dateFrom || dateTo) {
+      matchStage.created_at = {};
+      if (dateFrom) matchStage.created_at.$gte = new Date(dateFrom);
+      if (dateTo) matchStage.created_at.$lte = new Date(dateTo);
+    }
+
+    if (status === 'deleted') {
+      matchStage.deleted_at = { $ne: null, $exists: true };
+    } else if (status === 'archived') {
+      matchStage.is_archived = true;
+      if (!includeDeleted) {
+        matchStage.$or = [{ deleted_at: null }, { deleted_at: { $exists: false } }];
+      }
+    } else if (status === 'active') {
+      matchStage.is_archived = { $ne: true };
+      matchStage.$or = [{ deleted_at: null }, { deleted_at: { $exists: false } }];
+    } else if (!includeDeleted) {
+      matchStage.$or = [{ deleted_at: null }, { deleted_at: { $exists: false } }];
+    }
+
+    const conversations = await getCollection<Conversation>('conversations');
+
+    const pipeline: any[] = [
+      { $match: matchStage },
+      {
+        $lookup: {
+          from: 'messages',
+          localField: '_id',
+          foreignField: 'conversation_id',
+          pipeline: [
+            { $sort: { created_at: -1 as const } },
+            { $limit: 1 },
+            { $project: { created_at: 1 } },
+          ],
+          as: '_last_msg',
+        },
+      },
+      {
+        $addFields: {
+          message_count: { $ifNull: ['$metadata.total_messages', 0] },
+          last_message_at: { $arrayElemAt: ['$_last_msg.created_at', 0] },
+          status: {
+            $cond: {
+              if: {
+                $and: [
+                  { $ne: ['$deleted_at', null] },
+                  { $ifNull: ['$deleted_at', false] },
+                ],
+              },
+              then: 'deleted',
+              else: {
+                $cond: {
+                  if: { $eq: ['$is_archived', true] },
+                  then: 'archived',
+                  else: 'active',
+                },
+              },
+            },
+          },
+        },
+      },
+      { $project: { _last_msg: 0 } },
+      { $sort: { updated_at: -1 as const } },
+      { $limit: MAX_EXPORT_ROWS },
+    ];
+
+    const items = await conversations.aggregate(pipeline).toArray();
+
+    const header = [
+      'Conversation ID',
+      'Owner',
+      'Title',
+      'Status',
+      'Messages',
+      'Created',
+      'Updated',
+      'Last Message',
+      'Tags',
+      'Shared With',
+      'Shared With Teams',
+      'Is Public',
+    ];
+
+    const rows = items.map((conv: any) => [
+      escapeCSV(conv._id || ''),
+      escapeCSV(conv.owner_id || ''),
+      escapeCSV(conv.title || ''),
+      escapeCSV(conv.status || ''),
+      String(conv.message_count || 0),
+      toISOSafe(conv.created_at),
+      toISOSafe(conv.updated_at),
+      toISOSafe(conv.last_message_at),
+      escapeCSV((conv.tags || []).join('; ')),
+      escapeCSV((conv.sharing?.shared_with || []).join('; ')),
+      escapeCSV((conv.sharing?.shared_with_teams || []).join('; ')),
+      String(conv.sharing?.is_public || false),
+    ]);
+
+    const csv = [header.join(','), ...rows.map((r: string[]) => r.join(','))].join('\n');
+
+    const timestamp = new Date().toISOString().replace(/[:.]/g, '-').slice(0, 19);
+    const filename = `audit-logs-${timestamp}.csv`;
+
+    return new NextResponse(csv, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv; charset=utf-8',
+        'Content-Disposition': `attachment; filename="${filename}"`,
+        'Cache-Control': 'no-store',
+      },
+    });
+  });
+});

--- a/ui/src/app/api/admin/audit-logs/owners/route.ts
+++ b/ui/src/app/api/admin/audit-logs/owners/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  withAuth,
+  withErrorHandler,
+  requireAdmin,
+  successResponse,
+} from '@/lib/api-middleware';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getServerConfig } from '@/lib/config';
+import type { Conversation } from '@/types/mongodb';
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+      { status: 503 },
+    );
+  }
+
+  if (!getServerConfig().auditLogsEnabled) {
+    return NextResponse.json(
+      { success: false, error: 'Audit logs feature is not enabled', code: 'FEATURE_DISABLED' },
+      { status: 403 },
+    );
+  }
+
+  return withAuth(request, async (req, _user, session) => {
+    requireAdmin(session);
+
+    const url = new URL(req.url);
+    const q = url.searchParams.get('q')?.trim() || '';
+
+    const conversations = await getCollection<Conversation>('conversations');
+
+    const matchStage: Record<string, any> = {};
+    if (q) {
+      matchStage.owner_id = { $regex: q, $options: 'i' };
+    }
+
+    const pipeline: any[] = [
+      ...(Object.keys(matchStage).length > 0 ? [{ $match: matchStage }] : []),
+      { $group: { _id: '$owner_id' } },
+      { $sort: { _id: 1 as const } },
+      { $limit: 50 },
+      { $project: { _id: 0, owner_id: '$_id' } },
+    ];
+
+    const results = await conversations.aggregate(pipeline).toArray();
+    const owners: string[] = results.map((r: any) => r.owner_id).filter(Boolean);
+
+    return successResponse({ owners });
+  });
+});

--- a/ui/src/app/api/admin/audit-logs/route.ts
+++ b/ui/src/app/api/admin/audit-logs/route.ts
@@ -1,0 +1,132 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  withAuth,
+  withErrorHandler,
+  requireAdmin,
+  getPaginationParams,
+  paginatedResponse,
+  ApiError,
+} from '@/lib/api-middleware';
+import { getCollection, isMongoDBConfigured } from '@/lib/mongodb';
+import { getServerConfig } from '@/lib/config';
+import type { Conversation } from '@/types/mongodb';
+
+export const GET = withErrorHandler(async (request: NextRequest) => {
+  if (!isMongoDBConfigured) {
+    return NextResponse.json(
+      { success: false, error: 'MongoDB not configured', code: 'MONGODB_NOT_CONFIGURED' },
+      { status: 503 },
+    );
+  }
+
+  if (!getServerConfig().auditLogsEnabled) {
+    return NextResponse.json(
+      { success: false, error: 'Audit logs feature is not enabled', code: 'FEATURE_DISABLED' },
+      { status: 403 },
+    );
+  }
+
+  return withAuth(request, async (req, _user, session) => {
+    requireAdmin(session);
+
+    const { page, pageSize, skip } = getPaginationParams(req);
+    const url = new URL(req.url);
+
+    const ownerEmail = url.searchParams.get('owner_email')?.trim();
+    const search = url.searchParams.get('search')?.trim();
+    const dateFrom = url.searchParams.get('date_from');
+    const dateTo = url.searchParams.get('date_to');
+    const includeDeleted = url.searchParams.get('include_deleted') === 'true';
+    const status = url.searchParams.get('status') as 'active' | 'archived' | 'deleted' | null;
+
+    const matchStage: Record<string, any> = {};
+
+    if (ownerEmail) {
+      matchStage.owner_id = { $regex: ownerEmail, $options: 'i' };
+    }
+
+    if (search) {
+      matchStage.title = { $regex: search, $options: 'i' };
+    }
+
+    if (dateFrom || dateTo) {
+      matchStage.created_at = {};
+      if (dateFrom) matchStage.created_at.$gte = new Date(dateFrom);
+      if (dateTo) matchStage.created_at.$lte = new Date(dateTo);
+    }
+
+    if (status === 'deleted') {
+      matchStage.deleted_at = { $ne: null, $exists: true };
+    } else if (status === 'archived') {
+      matchStage.is_archived = true;
+      if (!includeDeleted) {
+        matchStage.$or = [{ deleted_at: null }, { deleted_at: { $exists: false } }];
+      }
+    } else if (status === 'active') {
+      matchStage.is_archived = { $ne: true };
+      matchStage.$or = [{ deleted_at: null }, { deleted_at: { $exists: false } }];
+    } else if (!includeDeleted) {
+      matchStage.$or = [{ deleted_at: null }, { deleted_at: { $exists: false } }];
+    }
+
+    const conversations = await getCollection<Conversation>('conversations');
+
+    const pipeline: any[] = [
+      { $match: matchStage },
+      {
+        $lookup: {
+          from: 'messages',
+          localField: '_id',
+          foreignField: 'conversation_id',
+          pipeline: [
+            { $sort: { created_at: -1 as const } },
+            { $limit: 1 },
+            { $project: { created_at: 1 } },
+          ],
+          as: '_last_msg',
+        },
+      },
+      {
+        $addFields: {
+          message_count: { $ifNull: ['$metadata.total_messages', 0] },
+          last_message_at: { $arrayElemAt: ['$_last_msg.created_at', 0] },
+          status: {
+            $cond: {
+              if: {
+                $and: [
+                  { $ne: ['$deleted_at', null] },
+                  { $ifNull: ['$deleted_at', false] },
+                ],
+              },
+              then: 'deleted',
+              else: {
+                $cond: {
+                  if: { $eq: ['$is_archived', true] },
+                  then: 'archived',
+                  else: 'active',
+                },
+              },
+            },
+          },
+        },
+      },
+      { $project: { _last_msg: 0 } },
+      {
+        $facet: {
+          items: [
+            { $sort: { updated_at: -1 as const } },
+            { $skip: skip },
+            { $limit: pageSize },
+          ],
+          totalCount: [{ $count: 'count' }],
+        },
+      },
+    ];
+
+    const [result] = await conversations.aggregate(pipeline).toArray();
+    const items = result?.items || [];
+    const total = result?.totalCount?.[0]?.count || 0;
+
+    return paginatedResponse(items, total, page, pageSize);
+  });
+});

--- a/ui/src/components/admin/AuditLogsTab.tsx
+++ b/ui/src/components/admin/AuditLogsTab.tsx
@@ -1,0 +1,521 @@
+"use client";
+
+import React, { useState, useCallback, useEffect, useRef } from "react";
+import {
+  Search,
+  Loader2,
+  ChevronLeft,
+  ChevronRight,
+  FileText,
+  RotateCcw,
+  ExternalLink,
+  Copy,
+  Check,
+  Download,
+  ChevronsUpDown,
+  X,
+} from "lucide-react";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Badge } from "@/components/ui/badge";
+import { ConversationDetailDialog } from "@/components/admin/ConversationDetailDialog";
+import type { AuditConversation } from "@/types/mongodb";
+
+interface AuditLogsTabProps {
+  isAdmin: boolean;
+}
+
+interface PaginatedResult {
+  items: AuditConversation[];
+  total: number;
+  page: number;
+  page_size: number;
+  has_more: boolean;
+}
+
+const STATUS_OPTIONS = [
+  { value: "", label: "All statuses" },
+  { value: "active", label: "Active" },
+  { value: "archived", label: "Archived" },
+  { value: "deleted", label: "Deleted" },
+];
+
+export function AuditLogsTab({ isAdmin }: AuditLogsTabProps) {
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [ownerEmail, setOwnerEmail] = useState("");
+  const [searchTitle, setSearchTitle] = useState("");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+  const [status, setStatus] = useState("");
+  const [includeDeleted, setIncludeDeleted] = useState(false);
+
+  const [result, setResult] = useState<PaginatedResult | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [searched, setSearched] = useState(false);
+
+  const [selectedConversationId, setSelectedConversationId] = useState<string | null>(null);
+  const [detailOpen, setDetailOpen] = useState(false);
+  const [exporting, setExporting] = useState(false);
+
+  const [ownerQuery, setOwnerQuery] = useState("");
+  const [ownerSuggestions, setOwnerSuggestions] = useState<string[]>([]);
+  const [ownerDropdownOpen, setOwnerDropdownOpen] = useState(false);
+  const [ownerLoading, setOwnerLoading] = useState(false);
+  const ownerRef = useRef<HTMLDivElement>(null);
+  const ownerDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (ownerDebounceRef.current) clearTimeout(ownerDebounceRef.current);
+    ownerDebounceRef.current = setTimeout(async () => {
+      setOwnerLoading(true);
+      try {
+        const params = new URLSearchParams();
+        if (ownerQuery.trim()) params.set("q", ownerQuery.trim());
+        const res = await fetch(`/api/admin/audit-logs/owners?${params.toString()}`);
+        const json = await res.json();
+        if (json.success) setOwnerSuggestions(json.data.owners || []);
+      } catch {
+        /* swallow */
+      } finally {
+        setOwnerLoading(false);
+      }
+    }, 250);
+    return () => {
+      if (ownerDebounceRef.current) clearTimeout(ownerDebounceRef.current);
+    };
+  }, [ownerQuery]);
+
+  useEffect(() => {
+    if (!ownerDropdownOpen) return;
+    const handleClick = (e: MouseEvent) => {
+      if (ownerRef.current && !ownerRef.current.contains(e.target as Node)) {
+        setOwnerDropdownOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClick);
+    return () => document.removeEventListener("mousedown", handleClick);
+  }, [ownerDropdownOpen]);
+
+  const selectOwner = (owner: string) => {
+    setOwnerEmail(owner);
+    setOwnerQuery(owner);
+    setOwnerDropdownOpen(false);
+  };
+
+  const clearOwner = () => {
+    setOwnerEmail("");
+    setOwnerQuery("");
+    setOwnerSuggestions([]);
+  };
+
+  const fetchAuditLogs = useCallback(async (p: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams();
+      params.set("page", String(p));
+      params.set("page_size", "20");
+      if (ownerEmail.trim()) params.set("owner_email", ownerEmail.trim());
+      if (searchTitle.trim()) params.set("search", searchTitle.trim());
+      if (dateFrom) params.set("date_from", dateFrom);
+      if (dateTo) params.set("date_to", dateTo);
+      if (status) params.set("status", status);
+      if (includeDeleted) params.set("include_deleted", "true");
+
+      const res = await fetch(`/api/admin/audit-logs?${params.toString()}`);
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error || "Failed to load audit logs");
+      setResult(json.data);
+      setSearched(true);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, [ownerEmail, searchTitle, dateFrom, dateTo, status, includeDeleted]);
+
+  const handleSearch = (e?: React.FormEvent) => {
+    e?.preventDefault();
+    setPage(1);
+    fetchAuditLogs(1);
+  };
+
+  const handleReset = () => {
+    setOwnerEmail("");
+    setOwnerQuery("");
+    setSearchTitle("");
+    setDateFrom("");
+    setDateTo("");
+    setStatus("");
+    setIncludeDeleted(false);
+    setResult(null);
+    setSearched(false);
+    setError(null);
+    setPage(1);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+    fetchAuditLogs(newPage);
+  };
+
+  const openDetail = (id: string) => {
+    setSelectedConversationId(id);
+    setDetailOpen(true);
+  };
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const params = new URLSearchParams();
+      if (ownerEmail.trim()) params.set("owner_email", ownerEmail.trim());
+      if (searchTitle.trim()) params.set("search", searchTitle.trim());
+      if (dateFrom) params.set("date_from", dateFrom);
+      if (dateTo) params.set("date_to", dateTo);
+      if (status) params.set("status", status);
+      if (includeDeleted) params.set("include_deleted", "true");
+
+      const res = await fetch(`/api/admin/audit-logs/export?${params.toString()}`);
+      if (!res.ok) {
+        const json = await res.json().catch(() => null);
+        throw new Error(json?.error || `Export failed (${res.status})`);
+      }
+
+      const blob = await res.blob();
+      const disposition = res.headers.get("Content-Disposition") || "";
+      const filenameMatch = disposition.match(/filename="?([^"]+)"?/);
+      const filename = filenameMatch?.[1] || "audit-logs.csv";
+
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const copyId = (e: React.MouseEvent, id: string) => {
+    e.stopPropagation();
+    navigator.clipboard.writeText(id);
+    setCopiedId(id);
+    setTimeout(() => setCopiedId(null), 1500);
+  };
+
+  const statusBadge = (s: string) => {
+    switch (s) {
+      case "active":
+        return <Badge className="bg-green-500/15 text-green-600 dark:text-green-400 border-green-500/30 text-[10px] px-1.5 py-0">Active</Badge>;
+      case "archived":
+        return <Badge className="bg-amber-500/15 text-amber-600 dark:text-amber-400 border-amber-500/30 text-[10px] px-1.5 py-0">Archived</Badge>;
+      case "deleted":
+        return <Badge variant="destructive" className="text-[10px] px-1.5 py-0">Deleted</Badge>;
+      default:
+        return <Badge variant="outline" className="text-[10px] px-1.5 py-0">{s}</Badge>;
+    }
+  };
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <FileText className="h-5 w-5" />
+            Audit Logs
+          </CardTitle>
+          <CardDescription>
+            Browse all conversations and messages across all users for compliance and auditing.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Filters */}
+          <form onSubmit={handleSearch} className="space-y-3">
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
+              <div ref={ownerRef} className="relative">
+                <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  Owner Email
+                </label>
+                <div className="relative">
+                  <Input
+                    placeholder="Search owners..."
+                    value={ownerQuery}
+                    onChange={(e) => {
+                      setOwnerQuery(e.target.value);
+                      setOwnerEmail(e.target.value);
+                      setOwnerDropdownOpen(true);
+                    }}
+                    onFocus={() => setOwnerDropdownOpen(true)}
+                    className="h-8 text-sm pr-14"
+                    autoComplete="off"
+                  />
+                  <div className="absolute right-1 top-1/2 -translate-y-1/2 flex items-center gap-0.5">
+                    {ownerQuery && (
+                      <button
+                        type="button"
+                        onClick={clearOwner}
+                        className="p-0.5 rounded hover:bg-muted"
+                      >
+                        <X className="h-3.5 w-3.5 text-muted-foreground" />
+                      </button>
+                    )}
+                    <button
+                      type="button"
+                      onClick={() => setOwnerDropdownOpen(!ownerDropdownOpen)}
+                      className="p-0.5 rounded hover:bg-muted"
+                    >
+                      <ChevronsUpDown className="h-3.5 w-3.5 text-muted-foreground" />
+                    </button>
+                  </div>
+                </div>
+                {ownerDropdownOpen && (
+                  <div className="absolute z-50 mt-1 w-full rounded-md border border-border bg-popover shadow-lg max-h-48 overflow-y-auto">
+                    {ownerLoading ? (
+                      <div className="flex items-center justify-center py-3">
+                        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+                      </div>
+                    ) : ownerSuggestions.length === 0 ? (
+                      <div className="py-2 px-3 text-xs text-muted-foreground">
+                        No owners found
+                      </div>
+                    ) : (
+                      ownerSuggestions.map((owner) => (
+                        <button
+                          key={owner}
+                          type="button"
+                          onClick={() => selectOwner(owner)}
+                          className={`w-full text-left px-3 py-1.5 text-sm hover:bg-muted/60 truncate ${
+                            ownerEmail === owner ? "bg-muted font-medium" : ""
+                          }`}
+                        >
+                          {owner}
+                        </button>
+                      ))
+                    )}
+                  </div>
+                )}
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  Title Search
+                </label>
+                <Input
+                  placeholder="Search conversation titles..."
+                  value={searchTitle}
+                  onChange={(e) => setSearchTitle(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  From Date
+                </label>
+                <Input
+                  type="date"
+                  value={dateFrom}
+                  onChange={(e) => setDateFrom(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+              <div>
+                <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  To Date
+                </label>
+                <Input
+                  type="date"
+                  value={dateTo}
+                  onChange={(e) => setDateTo(e.target.value)}
+                  className="h-8 text-sm"
+                />
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <div>
+                <select
+                  value={status}
+                  onChange={(e) => setStatus(e.target.value)}
+                  className="h-8 text-sm rounded-md border border-input bg-background px-3 py-1 text-foreground"
+                >
+                  {STATUS_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <label className="flex items-center gap-1.5 text-sm cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={includeDeleted}
+                  onChange={(e) => setIncludeDeleted(e.target.checked)}
+                  className="rounded border-input"
+                />
+                Include deleted
+              </label>
+              <div className="flex-1" />
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleReset}
+                className="gap-1.5"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                Reset
+              </Button>
+              <Button type="submit" size="sm" disabled={loading} className="gap-1.5">
+                {loading ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Search className="h-3.5 w-3.5" />
+                )}
+                Search
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleExport}
+                disabled={exporting}
+                className="gap-1.5"
+                title="Download matching conversations as CSV"
+              >
+                {exporting ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Download className="h-3.5 w-3.5" />
+                )}
+                Download CSV
+              </Button>
+            </div>
+          </form>
+
+          {/* Error */}
+          {error && (
+            <div className="text-sm text-destructive text-center py-4">{error}</div>
+          )}
+
+          {/* Empty state before search */}
+          {!searched && !loading && !error && (
+            <div className="text-center py-12 text-muted-foreground">
+              <FileText className="h-12 w-12 mx-auto mb-4 opacity-50" />
+              <p className="text-sm">Use the filters above and click Search to browse conversations.</p>
+            </div>
+          )}
+
+          {/* Results table */}
+          {result && (
+            <>
+              <div className="text-xs text-muted-foreground">
+                {result.total} conversation{result.total !== 1 ? "s" : ""} found
+              </div>
+              {result.items.length === 0 ? (
+                <div className="text-center py-8 text-muted-foreground text-sm">
+                  No conversations match your filters.
+                </div>
+              ) : (
+                <div className="space-y-1">
+                  <div className="grid grid-cols-[2fr_2fr_minmax(0,1fr)_auto_1fr_1fr_auto] gap-2 pb-2 border-b text-xs font-medium text-muted-foreground">
+                    <div>Owner</div>
+                    <div>Title</div>
+                    <div>ID</div>
+                    <div className="text-center">Msgs</div>
+                    <div>Created</div>
+                    <div>Updated</div>
+                    <div className="text-center">Status</div>
+                  </div>
+                  {result.items.map((conv) => (
+                    <div
+                      key={conv._id}
+                      onClick={() => openDetail(conv._id)}
+                      className="grid grid-cols-[2fr_2fr_minmax(0,1fr)_auto_1fr_1fr_auto] gap-2 py-2 text-sm hover:bg-muted/50 rounded px-1 cursor-pointer items-center"
+                    >
+                      <div className="truncate">{conv.owner_id}</div>
+                      <div className="truncate font-medium">{conv.title}</div>
+                      <div className="flex items-center gap-1 min-w-0">
+                        <a
+                          href={`/chat/${conv._id}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          onClick={(e) => e.stopPropagation()}
+                          className="text-xs text-primary hover:underline truncate font-mono"
+                          title={conv._id}
+                        >
+                          {conv._id.slice(0, 8)}...
+                        </a>
+                        <button
+                          onClick={(e) => copyId(e, conv._id)}
+                          className="shrink-0 p-0.5 rounded hover:bg-muted"
+                          title="Copy conversation ID"
+                        >
+                          {copiedId === conv._id ? (
+                            <Check className="h-3 w-3 text-green-500" />
+                          ) : (
+                            <Copy className="h-3 w-3 text-muted-foreground" />
+                          )}
+                        </button>
+                      </div>
+                      <div className="text-center text-muted-foreground">
+                        {conv.message_count}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {new Date(conv.created_at).toLocaleDateString()}
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        {new Date(conv.updated_at).toLocaleDateString()}
+                      </div>
+                      <div className="text-center">
+                        {statusBadge(conv.status)}
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              {/* Pagination */}
+              {result.total > result.page_size && (
+                <div className="flex items-center justify-between pt-2 text-sm">
+                  <span className="text-muted-foreground">
+                    Page {result.page} of {Math.ceil(result.total / result.page_size)}
+                  </span>
+                  <div className="flex gap-2">
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handlePageChange(page - 1)}
+                      disabled={page <= 1 || loading}
+                    >
+                      <ChevronLeft className="h-4 w-4" />
+                    </Button>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      onClick={() => handlePageChange(page + 1)}
+                      disabled={!result.has_more || loading}
+                    >
+                      <ChevronRight className="h-4 w-4" />
+                    </Button>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConversationDetailDialog
+        conversationId={selectedConversationId}
+        open={detailOpen}
+        onOpenChange={setDetailOpen}
+      />
+    </>
+  );
+}

--- a/ui/src/components/admin/ConversationDetailDialog.tsx
+++ b/ui/src/components/admin/ConversationDetailDialog.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import { Loader2, User, Bot, ChevronLeft, ChevronRight, ThumbsUp, ThumbsDown, Tag, Share2, ExternalLink, Copy, Check } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import type { Message, Conversation } from "@/types/mongodb";
+
+interface ConversationDetailDialogProps {
+  conversationId: string | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+interface ConversationDetail {
+  conversation: Pick<
+    Conversation,
+    "_id" | "title" | "owner_id" | "created_at" | "updated_at" | "tags" | "sharing" | "is_archived" | "deleted_at"
+  >;
+  messages: {
+    items: Message[];
+    total: number;
+    page: number;
+    page_size: number;
+    has_more: boolean;
+  };
+}
+
+export function ConversationDetailDialog({
+  conversationId,
+  open,
+  onOpenChange,
+}: ConversationDetailDialogProps) {
+  const [data, setData] = useState<ConversationDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [page, setPage] = useState(1);
+  const [copied, setCopied] = useState(false);
+
+  const copyId = () => {
+    if (!conversationId) return;
+    navigator.clipboard.writeText(conversationId);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1500);
+  };
+
+  const fetchMessages = useCallback(async (id: string, p: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        `/api/admin/audit-logs/${encodeURIComponent(id)}/messages?page=${p}&page_size=50`,
+      );
+      const json = await res.json();
+      if (!json.success) throw new Error(json.error || "Failed to load messages");
+      setData(json.data);
+    } catch (err: any) {
+      setError(err.message);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open && conversationId) {
+      setPage(1);
+      fetchMessages(conversationId, 1);
+    } else {
+      setData(null);
+      setError(null);
+    }
+  }, [open, conversationId, fetchMessages]);
+
+  const handlePageChange = (newPage: number) => {
+    if (!conversationId) return;
+    setPage(newPage);
+    fetchMessages(conversationId, newPage);
+  };
+
+  const conv = data?.conversation;
+  const msgs = data?.messages;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[85vh] overflow-hidden" style={{ display: "flex", flexDirection: "column" }}>
+        <DialogHeader className="shrink-0">
+          <DialogTitle className="truncate pr-8">
+            {conv?.title || "Loading..."}
+          </DialogTitle>
+          <DialogDescription>
+            {conv ? `Conversation by ${conv.owner_id}` : "Loading conversation details..."}
+          </DialogDescription>
+        </DialogHeader>
+
+        {conv && (
+          <div className="shrink-0 flex flex-wrap gap-2 text-xs text-muted-foreground border-b pb-3">
+            <span>Owner: <strong className="text-foreground">{conv.owner_id}</strong></span>
+            <span className="text-border">|</span>
+            <span className="inline-flex items-center gap-1">
+              ID: <code className="font-mono text-foreground">{conv._id}</code>
+              <button onClick={copyId} className="p-0.5 rounded hover:bg-muted" title="Copy ID">
+                {copied ? <Check className="h-3 w-3 text-green-500" /> : <Copy className="h-3 w-3" />}
+              </button>
+              <a
+                href={`/chat/${conv._id}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="p-0.5 rounded hover:bg-muted text-primary"
+                title="Open in chat"
+              >
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </span>
+            <span className="text-border">|</span>
+            <span>Created: {new Date(conv.created_at).toLocaleString()}</span>
+            <span className="text-border">|</span>
+            <span>Updated: {new Date(conv.updated_at).toLocaleString()}</span>
+            {conv.is_archived && (
+              <>
+                <span className="text-border">|</span>
+                <Badge variant="secondary" className="text-[10px] px-1.5 py-0">Archived</Badge>
+              </>
+            )}
+            {conv.deleted_at && (
+              <>
+                <span className="text-border">|</span>
+                <Badge variant="destructive" className="text-[10px] px-1.5 py-0">Deleted</Badge>
+              </>
+            )}
+            {conv.tags?.length > 0 && (
+              <>
+                <span className="text-border">|</span>
+                <span className="inline-flex items-center gap-1">
+                  <Tag className="h-3 w-3" />
+                  {conv.tags.join(", ")}
+                </span>
+              </>
+            )}
+            {conv.sharing?.shared_with?.length > 0 && (
+              <>
+                <span className="text-border">|</span>
+                <span className="inline-flex items-center gap-1">
+                  <Share2 className="h-3 w-3" />
+                  Shared with {conv.sharing.shared_with.length} user(s)
+                </span>
+              </>
+            )}
+          </div>
+        )}
+
+        <div className="flex-1 min-h-0 overflow-y-auto">
+          {loading && !data && (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          )}
+
+          {error && (
+            <div className="text-center py-8 text-destructive text-sm">{error}</div>
+          )}
+
+          {msgs && msgs.items.length === 0 && (
+            <div className="text-center py-8 text-muted-foreground text-sm">
+              No messages in this conversation.
+            </div>
+          )}
+
+          {msgs && msgs.items.length > 0 && (
+            <div className="space-y-3 pr-2">
+              {msgs.items.map((msg, idx) => (
+                <div
+                  key={msg.message_id || msg._id?.toString() || idx}
+                  className="rounded-lg border p-3 space-y-1.5"
+                >
+                  <div className="flex items-center gap-2 text-xs">
+                    {msg.role === "user" ? (
+                      <User className="h-3.5 w-3.5 text-blue-500" />
+                    ) : msg.role === "assistant" ? (
+                      <Bot className="h-3.5 w-3.5 text-green-500" />
+                    ) : (
+                      <span className="h-3.5 w-3.5 rounded-full bg-muted-foreground/30 inline-block" />
+                    )}
+                    <Badge
+                      variant="outline"
+                      className="text-[10px] px-1.5 py-0 capitalize"
+                    >
+                      {msg.role}
+                    </Badge>
+                    {msg.sender_email && (
+                      <span className="text-muted-foreground">{msg.sender_email}</span>
+                    )}
+                    {msg.metadata?.agent_name && (
+                      <Badge variant="secondary" className="text-[10px] px-1.5 py-0">
+                        {msg.metadata.agent_name}
+                      </Badge>
+                    )}
+                    <span className="ml-auto text-muted-foreground">
+                      {new Date(msg.created_at).toLocaleString()}
+                    </span>
+                  </div>
+                  <div className="text-sm whitespace-pre-wrap break-words pl-5">
+                    {msg.content}
+                  </div>
+                  {msg.feedback && (
+                    <div className="flex items-center gap-1.5 pl-5 pt-1">
+                      {msg.feedback.rating === "positive" ? (
+                        <ThumbsUp className="h-3 w-3 text-green-500" />
+                      ) : (
+                        <ThumbsDown className="h-3 w-3 text-red-500" />
+                      )}
+                      {msg.feedback.comment && (
+                        <span className="text-xs text-muted-foreground italic">
+                          {msg.feedback.comment}
+                        </span>
+                      )}
+                    </div>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {msgs && msgs.total > msgs.page_size && (
+          <div className="shrink-0 flex items-center justify-between border-t pt-3 text-sm">
+            <span className="text-muted-foreground">
+              Page {msgs.page} of {Math.ceil(msgs.total / msgs.page_size)} ({msgs.total} messages)
+            </span>
+            <div className="flex gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handlePageChange(page - 1)}
+                disabled={page <= 1 || loading}
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => handlePageChange(page + 1)}
+                disabled={!msgs.has_more || loading}
+              >
+                <ChevronRight className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/chat/ChatPanel.tsx
+++ b/ui/src/components/chat/ChatPanel.tsx
@@ -1302,7 +1302,8 @@ export function ChatPanel({ endpoint, conversationId, conversationTitle, readOnl
           </div>
 
           <p className="text-xs text-muted-foreground text-center">
-            {getConfig('appName')} can make mistakes. Verify important information.
+            {getConfig('appName')} can make mistakes. Verify important info.
+            {getConfig('auditLogsEnabled') && ' · Conversations are logged for audit.'}
           </p>
         </div>
       </div>

--- a/ui/src/lib/__tests__/config.test.ts
+++ b/ui/src/lib/__tests__/config.test.ts
@@ -70,7 +70,7 @@ describe('getServerConfig', () => {
         'ALLOW_DEV_ADMIN_WHEN_SSO_DISABLED', 'SHOW_POWERED_BY',
         'LOGO_STYLE', 'SPINNER_COLOR', 'TAGLINE', 'DESCRIPTION',
         'APP_NAME', 'LOGO_URL', 'GRADIENT_FROM', 'GRADIENT_TO',
-        'SUPPORT_EMAIL',
+        'SUPPORT_EMAIL', 'FEEDBACK_ENABLED', 'NPS_ENABLED', 'AUDIT_LOGS_ENABLED',
         'DEFAULT_FONT_SIZE', 'DEFAULT_FONT_FAMILY',
         'DEFAULT_THEME', 'DEFAULT_GRADIENT_THEME',
       );
@@ -89,6 +89,7 @@ describe('getServerConfig', () => {
       expect(cfg.ssoEnabled).toBe(false);
       expect(cfg.ragEnabled).toBe(true); // default true
       expect(cfg.feedbackEnabled).toBe(true); // default true
+      expect(cfg.npsEnabled).toBe(false);
       expect(cfg.mongodbEnabled).toBe(false);
       expect(cfg.tagline).toBe('Multi-Agent Workflow Automation');
       expect(cfg.description).toBe(
@@ -104,6 +105,7 @@ describe('getServerConfig', () => {
       expect(cfg.showPoweredBy).toBe(true);
       expect(cfg.supportEmail).toBe('support@example.com');
       expect(cfg.allowDevAdminWhenSsoDisabled).toBe(false);
+      expect(cfg.auditLogsEnabled).toBe(false);
       expect(cfg.storageMode).toBe('localStorage');
     });
 
@@ -124,7 +126,7 @@ describe('getServerConfig', () => {
         'gradientFrom', 'gradientTo', 'logoStyle', 'spinnerColor',
         'showPoweredBy', 'supportEmail', 'allowDevAdminWhenSsoDisabled',
         'storageMode', 'enabledIntegrationIcons', 'faviconUrl',
-        'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'feedbackEnabled', 'npsEnabled',
+        'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'feedbackEnabled', 'npsEnabled', 'auditLogsEnabled',
         'defaultFontSize', 'defaultFontFamily', 'defaultTheme', 'defaultGradientTheme',
       ];
       expect(Object.keys(cfg).sort()).toEqual(expectedKeys.sort());
@@ -698,7 +700,7 @@ describe('getClientConfigScript (XSS safety)', () => {
       'gradientFrom', 'gradientTo', 'logoStyle', 'spinnerColor',
       'showPoweredBy', 'supportEmail', 'allowDevAdminWhenSsoDisabled',
       'storageMode', 'enabledIntegrationIcons', 'faviconUrl',
-      'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'feedbackEnabled', 'npsEnabled',
+      'docsUrl', 'sourceUrl', 'workflowRunnerEnabled', 'feedbackEnabled', 'npsEnabled', 'auditLogsEnabled',
       'defaultFontSize', 'defaultFontFamily', 'defaultTheme', 'defaultGradientTheme',
     ];
     expect(Object.keys(parsed).sort()).toEqual(expectedKeys.sort());

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -101,6 +101,12 @@ export interface Config {
    * endpoints are all disabled. Set NPS_ENABLED=true to enable.
    */
   npsEnabled: boolean;
+  /**
+   * Whether the admin audit logs feature is enabled.
+   * When false (default), the Audit Logs tab is hidden and API routes return 403.
+   * Set AUDIT_LOGS_ENABLED=true to enable.
+   */
+  auditLogsEnabled: boolean;
   /** Default font size for new users: "small" | "medium" | "large" | "x-large" */
   defaultFontSize: string;
   /** Default font family for new users: "inter" | "source-sans" | "ibm-plex" | "system" */
@@ -161,6 +167,7 @@ const DEFAULT_CONFIG: Config = {
   workflowRunnerEnabled: false,
   feedbackEnabled: true,
   npsEnabled: false,
+  auditLogsEnabled: false,
   defaultFontSize: DEFAULT_FONT_SIZE,
   defaultFontFamily: DEFAULT_FONT_FAMILY,
   defaultTheme: DEFAULT_THEME,
@@ -228,6 +235,7 @@ export function getServerConfig(): Config {
   const workflowRunnerEnabled = env('WORKFLOW_RUNNER_ENABLED') === 'true';
   const feedbackEnabled = env('FEEDBACK_ENABLED') !== 'false';
   const npsEnabled = env('NPS_ENABLED') === 'true';
+  const auditLogsEnabled = env('AUDIT_LOGS_ENABLED') === 'true';
 
   const showPoweredByEnv = env('SHOW_POWERED_BY');
   const showPoweredBy = showPoweredByEnv !== undefined ? showPoweredByEnv !== 'false' : true;
@@ -269,6 +277,7 @@ export function getServerConfig(): Config {
     workflowRunnerEnabled,
     feedbackEnabled,
     npsEnabled,
+    auditLogsEnabled,
     defaultFontSize: validated(env('DEFAULT_FONT_SIZE'), VALID_FONT_SIZES, DEFAULT_FONT_SIZE),
     defaultFontFamily: validated(env('DEFAULT_FONT_FAMILY'), VALID_FONT_FAMILIES, DEFAULT_FONT_FAMILY),
     defaultTheme: validated(env('DEFAULT_THEME'), VALID_THEMES, DEFAULT_THEME),

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -319,3 +319,22 @@ export interface UserActivity {
   resource_id: string;
   details?: Record<string, any>;
 }
+
+// ============================================================================
+// Audit Log Types (Admin-only)
+// ============================================================================
+
+export interface AuditConversation extends Conversation {
+  message_count: number;
+  last_message_at?: Date;
+  status: 'active' | 'archived' | 'deleted';
+}
+
+export interface AuditLogFilters {
+  owner_email?: string;
+  search?: string;
+  date_from?: string;
+  date_to?: string;
+  include_deleted?: boolean;
+  status?: 'active' | 'archived' | 'deleted';
+}


### PR DESCRIPTION
## Summary

- Add an optional, feature-gated admin audit logs tab (`AUDIT_LOGS_ENABLED=true`) that lets full admins browse, search, and export all conversations and messages across all users for compliance auditing
- Four new API endpoints: list conversations with filters/pagination, view conversation messages, export to CSV (up to 10k rows), and searchable owner typeahead
- UI includes searchable owner email dropdown, conversation UUID display with copy-to-clipboard and direct chat link, scrollable message dialog, and Download CSV button
- 40 unit tests covering authentication, authorization (full admin only — readonly viewers rejected), feature flag enforcement, filtering, pagination, CSV generation/escaping, and owner search
- Spec: `.specify/specs/admin-audit-logs.md`
- ADR: `docs/docs/changes/2026-03-03-admin-audit-logs.md`

## Test plan

- [x] 40 unit tests pass (`npx jest admin-audit-logs`)
- [x] 134 config tests pass (`npx jest config.test.ts`)
- [x] Full UI test suite passes (2196 tests, 92 suites)
- [ ] Manual: Set `AUDIT_LOGS_ENABLED=true` and verify the Audit Logs tab appears for full admins
- [ ] Manual: Verify the tab is hidden for readonly admin viewers and regular users
- [ ] Manual: Unset the env var and verify API returns 403
- [ ] Manual: Search by owner email using the autocomplete dropdown
- [ ] Manual: Filter by title, date range, and status
- [ ] Manual: Click a conversation to view messages with scrolling
- [ ] Manual: Copy conversation UUID and open the direct chat link
- [ ] Manual: Download CSV and verify contents match active filters