### PR TITLE
fix(docs): escape MDX curly braces in ADR to fix Docusaurus build

### DIFF
--- a/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
+++ b/docs/docs/changes/2026-03-03-admin-feedback-nps-dashboard.md
@@ -90,7 +90,7 @@ Instead of automatic periodic surveys, admins create time-bounded campaigns:
 
 `NPSSurvey` component checks for active campaigns and shows:
 - Campaign name
-- Question: "How well does {appName} help you get your work done?"
+- Question: "How well does \{appName\} help you get your work done?"
 - 0–10 score scale (color-coded: red detractors, yellow passives, green promoters)
 - Optional comment
 - Dismissal tracked per campaign in localStorage


### PR DESCRIPTION
## Summary

- Escape `{appName}` → `\{appName\}` in the NPS ADR markdown so MDX treats it as literal text instead of a JavaScript expression
- Fixes the Docusaurus build failure: `ReferenceError: appName is not defined` at path `/changes/2026-03-03-admin-feedback-nps-dashboard`

## Test plan

- [ ] Verify the [Publish][Docs] GH Pages CI workflow passes
- [ ] Confirm the ADR page renders correctly at `/changes/2026-03-03-admin-feedback-nps-dashboard`

Made with [Cursor](https://cursor.com)