### PR TITLE
fix(victorops): fix deployment issues in victorops agent

### DIFF
--- a/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/server.py
+++ b/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/server.py
@@ -21,7 +21,9 @@ from mcp_victorops.tools import (
     api_public_v1_incidents,
     incidentnumber_notes_notename,
     incidentnumber_notes,
-    api_public_v1_chat
+    api_public_v1_chat,
+    api_public_v1_team,
+    api_public_v2_team_oncall
 )
 
 def main():
@@ -57,6 +59,7 @@ def main():
         mcp = FastMCP(f"{SERVER_NAME} MCP Server")
 
     # Register tools
+    mcp.tool()(api_public_v1_incidents.get_api_public_v1_incidents)
     mcp.tool()(api_public_v2_user.get_api_public_v2_user)
     mcp.tool()(api_reporting_v2_incidents.get_api_reporting_v2_incidents)
     mcp.tool()(api_public_v1_incidents.post_api_public_v1_incidents)
@@ -65,6 +68,8 @@ def main():
     mcp.tool()(incidentnumber_notes_notename.put_api_public_v1_incidents_incident_number_notes_note_name)
     mcp.tool()(incidentnumber_notes_notename.delete_api_public_v1_incidents_incident_number_notes_note_name)
     mcp.tool()(api_public_v1_chat.post_api_public_v1_chat)
+    mcp.tool()(api_public_v1_team.get_api_public_v1_team)
+    mcp.tool()(api_public_v2_team_oncall.get_api_public_v2_team_oncall_schedule)
 
     # Run the MCP server
     mcp.run(transport=MCP_MODE.lower())

--- a/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/api_public_v1_team.py
+++ b/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/api_public_v1_team.py
@@ -1,0 +1,43 @@
+# Copyright 2025 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tools for /api-public/v1/team operations"""
+
+import logging
+from typing import Dict, Any
+from ..api.client import make_api_request
+
+# Configure logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("mcp_tools")
+
+
+async def get_api_public_v1_team() -> Dict[str, Any]:
+    """
+        List all teams
+
+        OpenAPI Description:
+            Get a list of teams for your organization.
+            Returns team name, slug, and memberCount for each team.
+            Use the team slug to query on-call schedules.
+
+    This API may be called a maximum of 2 times per second.
+
+
+        Returns:
+            Dict[str, Any]: The JSON response from the API call.
+
+        Raises:
+            Exception: If the API request fails or returns an error.
+    """
+    logger.debug("Making GET request to /api-public/v1/team")
+
+    params = {}
+    data = {}
+
+    success, response = await make_api_request("/api-public/v1/team", method="GET", params=params, data=data)
+
+    if not success:
+        logger.error(f"Request failed: {response.get('error')}")
+        return {"error": response.get("error", "Request failed")}
+    return response

--- a/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/api_public_v2_team_oncall.py
+++ b/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/api_public_v2_team_oncall.py
@@ -1,0 +1,49 @@
+# Copyright 2025 CNOE
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tools for /api-public/v2/team/{team}/oncall/schedule operations"""
+
+import logging
+from typing import Dict, Any
+from ..api.client import make_api_request
+
+# Configure logging
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger("mcp_tools")
+
+
+async def get_api_public_v2_team_oncall_schedule(team: str) -> Dict[str, Any]:
+    """
+        Get on-call schedule for a team
+
+        OpenAPI Description:
+            Get the on-call schedule for a team, including the current
+            on-call user, escalation policies, rotation names, shift
+            roll times, and upcoming on-call rolls.
+
+    This API may be called a maximum of 2 times per second.
+
+
+        Args:
+
+            team (str): The team slug (e.g. 'team-FAQfg8VEQklS42Im').
+                Use get_api_public_v1_team to find the slug for a team name.
+
+
+        Returns:
+            Dict[str, Any]: The JSON response from the API call.
+
+        Raises:
+            Exception: If the API request fails or returns an error.
+    """
+    logger.debug(f"Making GET request to /api-public/v2/team/{team}/oncall/schedule")
+
+    params = {}
+    data = {}
+
+    success, response = await make_api_request(f"/api-public/v2/team/{team}/oncall/schedule", method="GET", params=params, data=data)
+
+    if not success:
+        logger.error(f"Request failed: {response.get('error')}")
+        return {"error": response.get("error", "Request failed")}
+    return response

--- a/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/api_public_v2_user.py
+++ b/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/api_public_v2_user.py
@@ -7,14 +7,13 @@
 import logging
 from typing import Dict, Any, Optional
 from ..api.client import make_api_request, assemble_nested_body
-#from mcp_victorops.api.client import make_api_request, assemble_nested_body
 
 # Configure logging
 logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger("mcp_tools")
 
 
-async def get_api_public_v2_user(param_email: Optional[str] = None) -> Dict[str, Any]:
+async def get_api_public_v2_user(email: Optional[str] = None) -> Dict[str, Any]:
     """
         List users
 
@@ -26,7 +25,7 @@ async def get_api_public_v2_user(param_email: Optional[str] = None) -> Dict[str,
 
         Args:
 
-            param_email (str): An email address with which to search for users
+            email (str): An email address with which to search for users
 
 
         Returns:
@@ -40,8 +39,8 @@ async def get_api_public_v2_user(param_email: Optional[str] = None) -> Dict[str,
     params = {}
     data = {}
 
-    if param_email is not None:
-        params["email"] = str(param_email).lower() if isinstance(param_email, bool) else param_email
+    if email is not None:
+        params["email"] = str(email).lower() if isinstance(email, bool) else email
 
     flat_body = {}
     data = assemble_nested_body(flat_body)

--- a/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/api_reporting_v2_incidents.py
+++ b/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/api_reporting_v2_incidents.py
@@ -14,16 +14,16 @@ logger = logging.getLogger("mcp_tools")
 
 
 async def get_api_reporting_v2_incidents(
-    param_offset: Optional[int] = None,
-    param_limit: Optional[int] = None,
-    param_entityId: Optional[str] = None,
-    param_incidentNumber: Optional[str] = None,
-    param_startedAfter: Optional[str] = None,
-    param_startedBefore: Optional[str] = None,
-    param_host: Optional[str] = None,
-    param_service: Optional[str] = None,
-    param_currentPhase: Optional[str] = None,
-    param_routingKey: Optional[str] = None,
+    offset: Optional[int] = None,
+    limit: Optional[int] = None,
+    entityId: Optional[str] = None,
+    incidentNumber: Optional[str] = None,
+    startedAfter: Optional[str] = None,
+    startedBefore: Optional[str] = None,
+    host: Optional[str] = None,
+    service: Optional[str] = None,
+    currentPhase: Optional[str] = None,
+    routingKey: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
         Get/search incident history
@@ -45,26 +45,26 @@ async def get_api_reporting_v2_incidents(
 
         Args:
 
-            param_offset (int): The offset within the set of matching incidents
+            offset (int): The offset within the set of matching incidents
 
-            param_limit (int): The maximum number of matching incidents to return (100 max)
+            limit (int): The maximum number of matching incidents to return (100 max)
 
-            param_entityId (str): The entity ID involved  This is the unique identifier for the entity causing the incident.
+            entityId (str): The entity ID involved  This is the unique identifier for the entity causing the incident.
 
-            param_incidentNumber (str): The incident number as shown in VictorOps Multiple values and ranges are allowed: 4,5,20:50
+            incidentNumber (str): The incident number as shown in VictorOps Multiple values and ranges are allowed: 4,5,20:50
 
 
-            param_startedAfter (str): Return incidents started after this timestamp Specify the timestamp in ISO8601 format
+            startedAfter (str): Return incidents started after this timestamp Specify the timestamp in ISO8601 format
 
-            param_startedBefore (str): Find incidents started before this timestamp  Specify the timestamp in ISO8601 format
+            startedBefore (str): Find incidents started before this timestamp  Specify the timestamp in ISO8601 format
 
-            param_host (str): The host involved in the incident Multiple values can be separated with commas.
+            host (str): The host involved in the incident Multiple values can be separated with commas.
 
-            param_service (str): The service involved in the incident (if any) Multiple values can be separated with commas.
+            service (str): The service involved in the incident (if any) Multiple values can be separated with commas.
 
-            param_currentPhase (str): The current phase of the incident "resolved", "triggered" or "acknowledged". Multiple values can be separated with commas. By default, response contains only "resolved" incidents
+            currentPhase (str): The current phase of the incident "resolved", "triggered" or "acknowledged". Multiple values can be separated with commas. By default, response contains only "resolved" incidents
 
-            param_routingKey (str): The original routing of the incident
+            routingKey (str): The original routing of the incident
 
 
         Returns:
@@ -78,43 +78,43 @@ async def get_api_reporting_v2_incidents(
     params = {}
     data = {}
 
-    if param_offset is not None:
-        params["offset"] = str(param_offset).lower() if isinstance(param_offset, bool) else param_offset
+    if offset is not None:
+        params["offset"] = str(offset).lower() if isinstance(offset, bool) else offset
 
-    if param_limit is not None:
-        params["limit"] = str(param_limit).lower() if isinstance(param_limit, bool) else param_limit
+    if limit is not None:
+        params["limit"] = str(limit).lower() if isinstance(limit, bool) else limit
 
-    if param_entityId is not None:
-        params["entityId"] = str(param_entityId).lower() if isinstance(param_entityId, bool) else param_entityId
+    if entityId is not None:
+        params["entityId"] = str(entityId).lower() if isinstance(entityId, bool) else entityId
 
-    if param_incidentNumber is not None:
+    if incidentNumber is not None:
         params["incidentNumber"] = (
-            str(param_incidentNumber).lower() if isinstance(param_incidentNumber, bool) else param_incidentNumber
+            str(incidentNumber).lower() if isinstance(incidentNumber, bool) else incidentNumber
         )
 
-    if param_startedAfter is not None:
+    if startedAfter is not None:
         params["startedAfter"] = (
-            str(param_startedAfter).lower() if isinstance(param_startedAfter, bool) else param_startedAfter
+            str(startedAfter).lower() if isinstance(startedAfter, bool) else startedAfter
         )
 
-    if param_startedBefore is not None:
+    if startedBefore is not None:
         params["startedBefore"] = (
-            str(param_startedBefore).lower() if isinstance(param_startedBefore, bool) else param_startedBefore
+            str(startedBefore).lower() if isinstance(startedBefore, bool) else startedBefore
         )
 
-    if param_host is not None:
-        params["host"] = str(param_host).lower() if isinstance(param_host, bool) else param_host
+    if host is not None:
+        params["host"] = str(host).lower() if isinstance(host, bool) else host
 
-    if param_service is not None:
-        params["service"] = str(param_service).lower() if isinstance(param_service, bool) else param_service
+    if service is not None:
+        params["service"] = str(service).lower() if isinstance(service, bool) else service
 
-    if param_currentPhase is not None:
+    if currentPhase is not None:
         params["currentPhase"] = (
-            str(param_currentPhase).lower() if isinstance(param_currentPhase, bool) else param_currentPhase
+            str(currentPhase).lower() if isinstance(currentPhase, bool) else currentPhase
         )
 
-    if param_routingKey is not None:
-        params["routingKey"] = str(param_routingKey).lower() if isinstance(param_routingKey, bool) else param_routingKey
+    if routingKey is not None:
+        params["routingKey"] = str(routingKey).lower() if isinstance(routingKey, bool) else routingKey
 
     flat_body = {}
     data = assemble_nested_body(flat_body)

--- a/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/incidentnumber_notes.py
+++ b/ai_platform_engineering/agents/victorops/mcp/mcp_victorops/tools/incidentnumber_notes.py
@@ -47,8 +47,13 @@ async def get_api_public_v1_incidents_incident_number_notes(path_incidentNumber:
     )
 
     if not success:
-        logger.error(f"Request failed: {response.get('error')}")
-        return {"error": response.get("error", "Request failed")}
+        error_msg = response.get("error", "")
+        # VictorOps returns 404 when an incident has no notes — treat as empty
+        if "404" in error_msg:
+            logger.debug(f"No notes found for incident {path_incidentNumber}")
+            return {"notes": []}
+        logger.error(f"Request failed: {error_msg}")
+        return {"error": error_msg or "Request failed"}
     return response
 
 

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -6,7 +6,7 @@ description: Parent chart to deploy multiple agent subcharts as different platfo
 sources:
   - https://github.com/cnoe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
-version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:
   # AI Platform Engineer Multi-Agent
   - name: supervisor-agent

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -14,7 +14,7 @@ dependencies:
     version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
   # Single agent chart used multiple times with different aliases
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-argocd
     tags:
       - agent-argocd
@@ -24,7 +24,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.argocd
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-aws
     tags:
       - agent-aws
@@ -33,7 +33,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.aws
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-backstage
     tags:
       - agent-backstage
@@ -43,7 +43,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.backstage
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-confluence
     tags:
       - agent-confluence
@@ -52,7 +52,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.confluence
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-github
     tags:
       - agent-github
@@ -62,7 +62,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.github
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-gitlab
     tags:
       - agent-gitlab
@@ -71,7 +71,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.gitlab
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-jira
     tags:
       - agent-jira
@@ -80,7 +80,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.jira
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-komodor
     tags:
       - agent-komodor
@@ -89,7 +89,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.komodor
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-pagerduty
     tags:
       - agent-pagerduty
@@ -98,7 +98,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.pagerduty
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-slack
     tags:
       - agent-slack
@@ -107,7 +107,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.slack
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-splunk
     tags:
       - agent-splunk
@@ -116,7 +116,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.splunk
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-victorops
     tags:
       - agent-victorops
@@ -124,7 +124,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.victorops
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-webex
     tags:
       - agent-webex
@@ -133,7 +133,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.webex
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-netutils
     tags:
       - agent-netutils
@@ -142,7 +142,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.netutils
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-weather
     tags:
       - agent-weather
@@ -151,7 +151,7 @@ dependencies:
       - child: agentExports.data
         parent: global.enabledSubAgents.weather
   - name: agent
-    version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+    version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
     alias: agent-petstore
     tags:
       - agent-petstore

--- a/charts/ai-platform-engineering/charts/agent/Chart.yaml
+++ b/charts/ai-platform-engineering/charts/agent/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.34 # Do NOT bump this. It will be updated automatically using the PR or release workflow
+version: 0.2.34-rc.helm.1 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/charts/ai-platform-engineering/charts/agent/templates/agent-secret.yaml
+++ b/charts/ai-platform-engineering/charts/agent/templates/agent-secret.yaml
@@ -10,7 +10,7 @@ type: Opaque
 data:
   {{- range $key, $value := .Values.agentSecrets.data }}
   {{- if $value }}
-  {{ $key }}: {{ $value | b64enc | quote }}
+  {{ $key }}: {{ $value | toString | b64enc | quote }}
   {{- end }}
   {{- end }}
 {{- end }}

--- a/charts/ai-platform-engineering/data/prompt_config.victorops_agent.yaml
+++ b/charts/ai-platform-engineering/data/prompt_config.victorops_agent.yaml
@@ -1,0 +1,132 @@
+# VictorOps Agent Prompt Configuration
+# This file contains configurable prompts for the VictorOps sub-agent
+
+agent_name: "VictorOps"
+agent_description: "VictorOps Agent for incident management"
+
+agent_purpose: |
+  manage incidents, on-call schedules, and users via the VictorOps (Splunk On-Call) API. You can list current and historical incidents, create incidents, manage incident notes, look up who is on-call for a team, list teams, look up users, and send chat messages
+
+# Include standard behaviors
+include_error_handling: true
+include_date_handling: true
+include_human_in_loop: false
+include_logging_notes: false
+
+additional_guidelines:
+  # CRITICAL: ROUTING KEY SCOPING - HIGHEST PRIORITY
+  - "=== CRITICAL: ROUTING KEY SCOPING - HIGHEST PRIORITY ==="
+  - "🔴 MANDATORY RULE #1: When a user provides or mentions a routing key, ALWAYS scope subsequent queries to that routing key"
+  - "🔴 MANDATORY RULE #2: Extract routing context from ANY of these sources:"
+  - "  - Explicit routing key mention: 'for api-gateway', 'routing key web-frontend'"
+  - "  - Team mention: 'SRE team', 'Platform team' → use as routingKey filter"
+  - "  - Previous incident context → maintain routing key context"
+  - "🔴 MANDATORY RULE #3: Once a routing key context is established, filter ALL incident queries by that routing key"
+  - ""
+
+  # CRITICAL: "MY" VS "ALL" QUERIES
+  - "=== CRITICAL: USER-SPECIFIC VS GENERAL QUERIES ==="
+  - "🔴 IMPORTANT: Distinguish between user-specific and general queries:"
+  - "  - 'Show MY incidents' / 'my alerts' / 'assigned to me' → Requires username, ask if not provided"
+  - "  - 'Show incidents' / 'list alerts' / 'triggered incidents' → General query, NO user info needed"
+  - ""
+  - "DO NOT ask for username for general queries like:"
+  - "  - 'Show all triggered incidents'"
+  - "  - 'List incidents from last 24 hours'"
+  - "🔴 When looking up a specific user, ALWAYS use the email filter. The unfiltered user list can be very large and will be truncated."
+  - ""
+
+  # TOOL SELECTION
+  - "=== CRITICAL: TOOL SELECTION ==="
+  - "You have TWO incident tools — choose the right one:"
+  - "  get_api_public_v1_incidents → current open/acked/recently-resolved. No filters. Fast. No rate limit."
+  - "  get_api_reporting_v2_incidents → historical search with filters. ⚠️ Rate-limited to 1 call/minute."
+  - "🔴 Use v1 for 'show active incidents'. Use reporting/v2 only when you need date range, phase, or routing key filters."
+  - ""
+
+  # INCIDENT OPERATIONS SOPs
+  - "=== INCIDENT OPERATIONS SOPs ==="
+  - "📌 SOP: List Current Incidents"
+  - "  Step 1: Use get_api_public_v1_incidents to get open/acknowledged/recently resolved incidents"
+  - "  Step 2: Present in table format with phase, routing key, and entity"
+  - ""
+  - "📌 SOP: Search Incident History"
+  - "  Step 1: Extract time range (default: last 24 hours)"
+  - "  Step 2: Extract phase filter (triggered, acknowledged, resolved)"
+  - "  Step 3: Use get_api_reporting_v2_incidents with filters (⚠️ max 1 call/minute)"
+  - "  🔴 Step 4: CRITICAL: This endpoint returns ONLY resolved incidents by default!"
+  - "  Step 5: ALWAYS pass currentPhase='triggered,acknowledged' when searching for active incidents"
+  - ""
+  - "📌 SOP: Create Incident"
+  - "  Step 1: Require: summary, details, userName"
+  - "  Step 2: Require: targets (list of User or EscalationPolicy slugs)"
+  - "  Step 3: Create incident and confirm"
+  - "  Note: Write operations depend on API key permissions and may return 401 if the key is read-only."
+  - ""
+
+  # CRITICAL: DATE HANDLING
+  - "=== CRITICAL: DATE HANDLING ==="
+  - "When querying incidents, calculate date ranges based on the current date provided above"
+  - "Always convert relative dates (today, yesterday, this week) to ISO 8601 format"
+  - "Default time ranges:"
+  - "  - Incidents: last 24 hours (unless specified)"
+  - "  - Historical queries: last 30 days max"
+  - ""
+
+  # TABLE FORMATTING
+  - "=== TABLE FORMATTING ==="
+  - "When listing incidents, use markdown tables with phase indicators:"
+  - ""
+  - "**Phase Indicators:** 🔔 Triggered | ✅ Acknowledged | ✔️ Resolved"
+  - ""
+  - "**Incident Listings:**"
+  - "| # | Phase | Incident | Entity | Routing Key | Started | Alert Count |"
+  - "|---|-------|----------|--------|-------------|---------|-------------|"
+  - "| 1 | 🔔 Triggered | [INC-123](https://portal.victorops.com/client/{org}/#/incident/123) | api-gateway | platform-sre | 15m ago | 3 |"
+  - ""
+
+  # HYPERLINK CONSTRUCTION
+  - "=== HYPERLINK CONSTRUCTION ==="
+  - "ALWAYS format incident numbers as clickable markdown links"
+  - "Incident URL format: https://portal.victorops.com/client/{org}/#/incident/{incidentNumber}"
+  - "Extract {org} from VICTOROPS_API_URL or incident response data"
+  - ""
+
+  # SEARCH AND FILTERING
+  - "=== SEARCH AND FILTERING ==="
+  - "🔴 CONTEXT OVERFLOW PREVENTION: Default limit is 20 incidents per query (max 100)"
+  - "  - Only increase if user explicitly requests more"
+  - "Common filters for incident history:"
+  - "  - currentPhase: triggered, acknowledged, resolved (comma-separated)"
+  - "  - routingKey: filter by routing key"
+  - "  - service: filter by service name"
+  - "  - host: filter by host"
+  - "  - entityId: filter by entity ID"
+  - "  - startedAfter/startedBefore: ISO 8601 timestamps"
+  - ""
+
+  # ON-CALL OPERATIONS SOP
+  - "=== ON-CALL OPERATIONS SOP ==="
+  - "📌 SOP: Who Is On-Call for a Team"
+  - "  Step 1: Call get_api_public_v1_team to list all teams"
+  - "  Step 2: Match the user's team name to a team slug (fuzzy match on name is fine)"
+  - "  Step 3: Call get_api_public_v2_team_oncall_schedule with the team slug"
+  - "  Step 4: Present: current on-call user(s), rotation name, shift end time, and next on-call roll"
+  - "  🔴 ALWAYS use the two-step workflow. Do NOT guess team slugs."
+  - ""
+
+  # LIMITATIONS — actions this agent CANNOT perform
+  - "=== LIMITATIONS ==="
+  - "🔴 You CANNOT acknowledge, resolve, or reroute incidents. Do NOT offer to do so."
+  - "🔴 You CANNOT list escalation policies or routing keys."
+  - "🔴 You CANNOT fetch detailed alert payloads (only incident summaries)."
+  - "If a user asks for any of these, explain that the capability is not yet available."
+  - ""
+
+response_format_instruction: |
+  Select status as completed if the request is complete.
+  Select status as input_required if the input is a question to the user.
+  Set response status to error if the input indicates an error.
+
+tool_working_message: "Querying VictorOps..."
+tool_processing_message: "Processing VictorOps data..."


### PR DESCRIPTION
## Summary

- Add missing `prompt_config.victorops_agent.yaml` that caused pods to be stuck in `ContainerCreating` (ConfigMap not created)
- Register `get_api_public_v1_incidents` tool in MCP server (was defined but never exposed)
- Remove `param_` prefix from MCP tool parameters that caused intermittent LLM validation failures in FastMCP
- Handle 404 on incident notes endpoint as empty response instead of logging ERROR (VictorOps returns 404 when no notes exist)
- Add `toString` pipe before `b64enc` in shared agent-secret template to handle numeric secret values

## Test plan

- [x] `make lint` passes
- [x] `make test-agents` passes (153 tests)
- [ ] Deploy victorops agent and verify pod starts (prompt ConfigMap created)
- [ ] Verify `get_api_public_v1_incidents` tool is available via MCP
- [ ] Verify incident history search works without `param_` prefix errors
- [ ] Verify querying notes on incident without notes returns empty list (no ERROR logs)
- [ ] Verify Helm install with numeric `X_VO_API_ID` value succeeds