### PR TITLE
chore(docker-compose): add slack-bot service and bump image tags to 0.2.36

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,14 @@ RAG_SERVER_URL=http://rag_server:9446
 NEXT_PUBLIC_RAG_URL=http://localhost:9446
 NEXT_PUBLIC_RAG_WEBUI_URL=http://localhost:9447
 
+# RAG RBAC Configuration
+# Map OIDC groups to RAG server roles (comma-separated)
+RBAC_ADMIN_GROUPS=
+RBAC_READONLY_GROUPS=
+RBAC_INGESTONLY_GROUPS=
+RBAC_DEFAULT_AUTHENTICATED_ROLE=readonly    # Role when no group matches: admin|readonly|ingestonly
+RBAC_CLIENT_CREDENTIALS_ROLE=ingestonly     # Role for client-credentials (M2M) tokens
+
 # RAG Trusted Network Configuration
 # Enable trusted network access (bypasses JWT authentication for specific IPs/networks)
 ALLOW_TRUSTED_NETWORK=true
@@ -254,6 +262,9 @@ SLACK_INTEGRATION_AUTH_CLIENT_ID=
 SLACK_INTEGRATION_AUTH_CLIENT_SECRET=
 SLACK_INTEGRATION_AUTH_SCOPE=         # Optional
 SLACK_INTEGRATION_AUTH_AUDIENCE=      # Optional
+
+# CAIPE UI base URL (for generating links in Slack messages)
+CAIPE_UI_BASE_URL=http://localhost:3000
 
 # Slack workspace URL for Langfuse feedback permalinks (optional)
 SLACK_WORKSPACE_URL=                 # e.g. https://mycompany.slack.com

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,7 +15,7 @@ services:
   #                                 CAIPE Supervisor Deep Agent                                      #
   ####################################################################################################
   caipe-supervisor:
-    image: ghcr.io/cnoe-io/ai-platform-engineering:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/ai-platform-engineering:${IMAGE_TAG:-0.2.36}
     container_name: caipe-supervisor
     volumes:
       - ${PROMPT_CONFIG_PATH:-./charts/ai-platform-engineering/data/prompt_config.deep_agent.yaml}:/app/prompt_config.yaml
@@ -121,7 +121,7 @@ services:
   ####################################################################################################
   # AWS Agent
   agent-aws:
-    image: ghcr.io/cnoe-io/agent-aws:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-aws:${IMAGE_TAG:-0.2.36}
     container_name: agent-aws
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.aws_agent.yaml:/app/prompt_config.aws_agent.yaml
@@ -153,7 +153,7 @@ services:
 
   # Petstore Agent
   agent-petstore:
-    image: ghcr.io/cnoe-io/agent-template:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-template:${IMAGE_TAG:-0.2.36}
     container_name: agent-petstore
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.petstore_agent.yaml:/app/prompt_config.petstore_agent.yaml
@@ -176,7 +176,7 @@ services:
 
   # GitHub
   agent-github:
-    image: ghcr.io/cnoe-io/agent-github:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-github:${IMAGE_TAG:-0.2.36}
     container_name: agent-github
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.github_agent.yaml:/app/prompt_config.github_agent.yaml
@@ -201,7 +201,7 @@ services:
 
   # Weather Agent
   agent-weather:
-    image: ghcr.io/cnoe-io/agent-weather:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-weather:${IMAGE_TAG:-0.2.36}
     container_name: agent-weather
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.weather_agent.yaml:/app/prompt_config.weather_agent.yaml
@@ -219,7 +219,7 @@ services:
 
   # Backstage Agent
   agent-backstage:
-    image: ghcr.io/cnoe-io/agent-backstage:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-backstage:${IMAGE_TAG:-0.2.36}
     container_name: agent-backstage
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.backstage_agent.yaml:/app/prompt_config.backstage_agent.yaml
@@ -239,7 +239,7 @@ services:
       - all-agents
 
   mcp-backstage:
-    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.2.36}
     container_name: mcp-backstage
     env_file: [.env]
     ports: ["18001:8000"]
@@ -259,7 +259,7 @@ services:
 
   # ArgoCD Agents
   agent-argocd:
-    image: ghcr.io/cnoe-io/agent-argocd:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-argocd:${IMAGE_TAG:-0.2.36}
     container_name: agent-argocd
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.argocd_agent.yaml:/app/prompt_config.argocd_agent.yaml
@@ -279,7 +279,7 @@ services:
       - all-agents
 
   mcp-argocd:
-    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.2.36}
     container_name: mcp-argocd
     env_file: [.env]
     ports: ["18002:8000"]
@@ -299,7 +299,7 @@ services:
 
   # Confluence Agents
   agent-confluence:
-    image: ghcr.io/cnoe-io/agent-confluence:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-confluence:${IMAGE_TAG:-0.2.36}
     container_name: agent-confluence
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.confluence_agent.yaml:/app/prompt_config.confluence_agent.yaml
@@ -333,7 +333,7 @@ services:
 
   # Jira Agent
   agent-jira:
-    image: ghcr.io/cnoe-io/agent-jira:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-jira:${IMAGE_TAG:-0.2.36}
     container_name: agent-jira
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.jira_agent.yaml:/app/prompt_config.jira_agent.yaml
@@ -353,7 +353,7 @@ services:
       - all-agents
 
   mcp-jira:
-    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.2.36}
     container_name: mcp-jira
     env_file: [.env]
     ports: ["18004:8000"]
@@ -373,7 +373,7 @@ services:
 
   # Komodor Agent
   agent-komodor:
-    image: ghcr.io/cnoe-io/agent-komodor:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-komodor:${IMAGE_TAG:-0.2.36}
     container_name: agent-komodor
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.komodor_agent.yaml:/app/prompt_config.komodor_agent.yaml
@@ -392,7 +392,7 @@ services:
       - komodor
 
   mcp-komodor:
-    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.2.36}
     container_name: mcp-komodor
     env_file: [.env]
     ports: ["18005:8000"]
@@ -411,7 +411,7 @@ services:
 
   # PagerDuty Agent
   agent-pagerduty:
-    image: ghcr.io/cnoe-io/agent-pagerduty:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-pagerduty:${IMAGE_TAG:-0.2.36}
     container_name: agent-pagerduty
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.pagerduty_agent.yaml:/app/prompt_config.pagerduty_agent.yaml
@@ -431,7 +431,7 @@ services:
       - all-agents
 
   mcp-pagerduty:
-    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.2.36}
     container_name: mcp-pagerduty
     env_file: [.env]
     ports: ["18006:8000"]
@@ -451,7 +451,7 @@ services:
 
   # Slack Agent
   agent-slack:
-    image: ghcr.io/cnoe-io/agent-slack:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-slack:${IMAGE_TAG:-0.2.36}
     container_name: agent-slack
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.slack_agent.yaml:/app/prompt_config.slack_agent.yaml
@@ -471,7 +471,7 @@ services:
       - all-agents
 
   mcp-slack:
-    image: ghcr.io/cnoe-io/mcp-slack:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-slack:${IMAGE_TAG:-0.2.36}
     container_name: mcp-slack
     env_file: [.env]
     ports: ["18007:8000"]
@@ -491,7 +491,7 @@ services:
 
   # Splunk
   agent-splunk:
-    image: ghcr.io/cnoe-io/agent-splunk:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-splunk:${IMAGE_TAG:-0.2.36}
     container_name: agent-splunk
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.splunk_agent.yaml:/app/prompt_config.splunk_agent.yaml
@@ -511,7 +511,7 @@ services:
       - all-agents
 
   mcp-splunk:
-    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.2.36}
     container_name: mcp-splunk
     env_file: [.env]
     ports: ["18008:8000"]
@@ -531,7 +531,7 @@ services:
 
   # Webex
   agent-webex:
-    image: ghcr.io/cnoe-io/agent-webex:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-webex:${IMAGE_TAG:-0.2.36}
     container_name: agent-webex
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.webex_agent.yaml:/app/prompt_config.webex_agent.yaml
@@ -551,7 +551,7 @@ services:
       - all-agents
 
   mcp-webex:
-    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.2.36}
     container_name: mcp-webex
     env_file: [.env]
     ports: ["18009:8000"]
@@ -571,7 +571,7 @@ services:
 
   # NetUtils Agent
   agent-netutils:
-    image: ghcr.io/cnoe-io/agent-netutils:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/agent-netutils:${IMAGE_TAG:-0.2.36}
     container_name: agent-netutils
     volumes:
       - ./charts/ai-platform-engineering/data/prompt_config.netutils_agent.yaml:/app/prompt_config.netutils_agent.yaml
@@ -591,7 +591,7 @@ services:
       - all-agents
 
   mcp-netutils:
-    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-0.2.36}
     container_name: mcp-netutils
     env_file: [.env]
     ports: ["18011:8000"]
@@ -680,7 +680,7 @@ services:
   #   - Configure via MONGODB_* environment variables
   #   - See mongodb service configuration above
   caipe-ui:
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.2.36}
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -728,7 +728,7 @@ services:
   #                                      RAG Services                                                #
   ####################################################################################################
   rag_server:
-    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.2.36}
     container_name: rag_server
     ports: ["9446:9446"]
     environment:
@@ -756,7 +756,7 @@ services:
       - graph_rag
 
   agent_ontology:
-    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.2.36}
     container_name: agent_ontology
     ports: ["8098:8098"]
     environment:
@@ -775,7 +775,7 @@ services:
 
 
   rag_web_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.2.21}
+    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.2.36}
     container_name: web-ingestor
     environment:
       - INGESTOR_TYPE=webloader
@@ -1100,6 +1100,24 @@ services:
       start_period: 10s
     profiles:
       - evaluation
+
+  ####################################################################################################
+  #                                 Slack Bot Integration                                            #
+  ####################################################################################################
+  slack-bot:
+    image: ghcr.io/cnoe-io/caipe-slack-bot:${IMAGE_TAG:-0.2.36}
+    container_name: slack-bot
+    env_file: [.env]
+    ports: ["8030:3000"]
+    environment:
+      - CAIPE_URL=${CAIPE_URL:-http://caipe-supervisor:8000}
+      - MONGODB_URI=${MONGODB_URI:-}
+      - CAIPE_UI_BASE_URL=${CAIPE_UI_BASE_URL:-http://localhost:3000}
+    depends_on:
+      - caipe-supervisor
+    profiles:
+      - slack-bot
+      - all-integrations
 
 volumes:
   caipe_ui_mongodb_data:


### PR DESCRIPTION
## Summary
- Add the missing `slack-bot` integration service to `docker-compose.yaml` (previously only in `docker-compose.dev.yaml`), under the `slack-bot` and `all-integrations` profiles
- Bump all default `IMAGE_TAG` references from `0.2.21` to `0.2.36` across all 29 service image definitions

## Test plan
- [ ] Verify `docker compose --profile slack-bot config` renders the new service correctly
- [ ] Verify `docker compose config` shows all images with `0.2.36` tag
- [ ] Verify slack-bot starts with `docker compose --profile slack-bot up -d` when Slack env vars are configured

Made with [Cursor](https://cursor.com)