### PR TITLE
fix(supervisor): add get_skills_status() and _rebuild_graph() to DeepAgent

### DIFF
--- a/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
+++ b/ai_platform_engineering/multi_agents/platform_engineer/deep_agent.py
@@ -1100,6 +1100,9 @@ class PlatformEngineerDeepAgent:
         self._graph_lock = threading.RLock()
         self._graph = None
         self._graph_generation = 0
+        self._skills_loaded_count: int = 0
+        self._skills_merged_at: Optional[str] = None
+        self._last_built_catalog_generation: int = 0
         self._initialized = False
         self._subagent_tools: Dict[str, List[str]] = {}
         self._distributed_agents = _get_distributed_agents()
@@ -1173,6 +1176,25 @@ class PlatformEngineerDeepAgent:
             if self._platform_registry:
                 status["registry_status"] = self._platform_registry.get_registry_status()
             return status
+
+    def get_skills_status(self) -> dict:
+        """Skills load metadata for the /internal/supervisor/skills-status endpoint (FR-016)."""
+        from ai_platform_engineering.skills_middleware.catalog import get_catalog_cache_generation
+
+        current_gen = get_catalog_cache_generation()
+        if self._last_built_catalog_generation == current_gen:
+            sync_status = "synced"
+        else:
+            sync_status = "stale"
+
+        return {
+            "graph_generation": self._graph_generation,
+            "skills_loaded_count": self._skills_loaded_count,
+            "skills_merged_at": self._skills_merged_at,
+            "catalog_cache_generation": current_gen,
+            "last_built_catalog_generation": self._last_built_catalog_generation,
+            "sync_status": sync_status,
+        }
 
     def _on_agents_changed(self):
         """Callback triggered when agent registry detects changes (distributed mode)."""
@@ -1286,6 +1308,21 @@ class PlatformEngineerDeepAgent:
     def _build_graph(self) -> None:
         """Sync wrapper for _build_graph_async (backwards-compatible entry point)."""
         asyncio.run(self._build_graph_async())
+
+    def _rebuild_graph(self) -> bool:
+        """Sync wrapper for _rebuild_graph_async (called by skills refresh endpoint)."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+
+        if loop and loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor() as pool:
+                future = pool.submit(asyncio.run, self._rebuild_graph_async())
+                return future.result(timeout=120)
+        else:
+            return asyncio.run(self._rebuild_graph_async())
 
     async def _build_graph_async(self) -> None:
         """Build the deep agent graph with subagents (async to load MCP tools)."""
@@ -1492,11 +1529,20 @@ This format is required so the UI can display agent stickers next to each task.
         try:
             skills = get_merged_skills(include_content=True)
             self._skills_files, self._skills_sources = build_skills_files(skills)
+            self._skills_loaded_count = len(skills)
+            from datetime import datetime, timezone
+            self._skills_merged_at = datetime.now(timezone.utc).isoformat()
+            try:
+                from ai_platform_engineering.skills_middleware.catalog import get_catalog_cache_generation
+                self._last_built_catalog_generation = get_catalog_cache_generation()
+            except Exception:
+                pass
             logger.info(f"📚 Loaded {len(skills)} skills for supervisor ({len(self._skills_sources)} sources)")
         except Exception as e:
             logger.warning(f"Failed to load skills catalog: {e}")
             self._skills_files = {}
             self._skills_sources = []
+            self._skills_loaded_count = 0
 
         # Build SkillsMiddleware with sources from catalog
         skills_middleware_list = []


### PR DESCRIPTION
## Summary

- The skills middleware router expects `get_skills_status()` and `_rebuild_graph()` on the MAS instance for FR-016 and FR-012 endpoints
- `PlatformEngineerDeepAgent` was missing both methods, causing `hasattr` checks to fail
- `/internal/supervisor/skills-status` returned all nulls with `mas_registered: false`, making the UI Supervisor skills load panel show Status unavailable
- `/skills/refresh` silently skipped graph rebuild

## Changes

- Added `_skills_loaded_count`, `_skills_merged_at`, `_last_built_catalog_generation` tracking attributes to `__init__`
- Track skills count and timestamp during `_build_graph_async()` after catalog merge
- Added `get_skills_status()` method returning the exact dict shape `router.py` expects, with `sync_status` computed from catalog cache generation
- Added sync `_rebuild_graph()` wrapper that delegates to `_rebuild_graph_async()`, handling the case where called from within a running event loop (FastAPI context)

## Test plan

- [ ] Verify `/internal/supervisor/skills-status` returns real metadata instead of null fallback
- [ ] Verify `/skills/refresh` triggers graph rebuild and returns `supervisor_rebuilt: true`
- [ ] Verify UI Supervisor skills load panel displays skills count, generation, and sync status
- [ ] Verify no regression in existing `get_status()` or `_rebuild_graph_async()` behavior

Assisted-by: Claude:claude-opus-4-6