### PR TITLE
fix(webex): use CAIPE-WEBEX as default workspace ref fallback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.18"
+version = "1.0.0-dev.19"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/lib/rbac/self-check.ts
+++ b/ui/src/lib/rbac/self-check.ts
@@ -27,7 +27,7 @@ import type {
 const OPENFGA_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~@|*+=,/-]{0,191}$/;
 const DEFAULT_ORG_ID = "caipe";
 const DEFAULT_SLACK_WORKSPACE = "CAIPE";
-const DEFAULT_WEBEX_WORKSPACE = "Cisco";
+const DEFAULT_WEBEX_WORKSPACE = "CAIPE-WEBEX";
 const MAX_FINDINGS = 500;
 const ORPHAN_CANDIDATE_LIMIT = 75;
 

--- a/ui/src/lib/rbac/self-check.ts
+++ b/ui/src/lib/rbac/self-check.ts
@@ -33,7 +33,7 @@ import type {
 const OPENFGA_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~@|*+=,/-]{0,191}$/;
 const DEFAULT_ORG_ID = "caipe";
 const DEFAULT_SLACK_WORKSPACE = "CAIPE";
-const DEFAULT_WEBEX_WORKSPACE = "Cisco";
+const DEFAULT_WEBEX_WORKSPACE = "CAIPE-WEBEX";
 const MAX_FINDINGS = 500;
 const ORPHAN_CANDIDATE_LIMIT = 75;
 

--- a/ui/src/lib/rbac/webex-space-grant-store.ts
+++ b/ui/src/lib/rbac/webex-space-grant-store.ts
@@ -31,7 +31,7 @@ export function webexWorkspaceRef(workspaceId?: string | null): string {
   if (alias) return alias;
   const candidate = workspaceId?.trim();
   if (candidate) return candidate;
-  return process.env.WEBEX_WORKSPACE_ID?.trim() || "unknown";
+  return process.env.WEBEX_WORKSPACE_ID?.trim() || "CAIPE-WEBEX";
 }
 
 export function webexSpaceSubjectId(workspaceId: string, spaceId: string): string {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev18"
+version = "1.0.0.dev19"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- `webexWorkspaceRef()` fell back to `"unknown"` when neither `WEBEX_WORKSPACE_ALIAS` nor `WEBEX_WORKSPACE_ID` was set — any space configured via the admin UI got grants stored with `workspace_id: "unknown"` and mismatched OpenFGA tuples
- Also aligns `DEFAULT_WEBEX_WORKSPACE` in `self-check.ts` which was inconsistently set to `"Cisco"`

## Changes
- `ui/src/lib/rbac/webex-space-grant-store.ts`: fallback `"unknown"` → `"CAIPE-WEBEX"`
- `ui/src/lib/rbac/self-check.ts`: `DEFAULT_WEBEX_WORKSPACE` `"Cisco"` → `"CAIPE-WEBEX"`

## Impact
Deployments that set `WEBEX_WORKSPACE_ALIAS` are unaffected. Deployments without it previously silently wrote broken grants; they will now write working ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)