### PR TITLE
fix(rag-stack): use default StorageClass for neo4j instead of hardcoded gp2

### DIFF
--- a/charts/rag-stack/README.md
+++ b/charts/rag-stack/README.md
@@ -135,8 +135,9 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.2.38
 | neo4j.neo4j.resources.memory | string | `"2Gi"` |  |
 | neo4j.podSpec.annotations | object | `{}` |  |
 | neo4j.services.neo4j.enabled | bool | `false` |  |
-| neo4j.volumes.data.dynamic.storageClassName | string | `"gp2"` |  |
-| neo4j.volumes.data.mode | string | `"dynamic"` |  |
+| neo4j.volumes.data.defaultStorageClass.accessModes[0] | string | `"ReadWriteOnce"` |  |
+| neo4j.volumes.data.defaultStorageClass.requests.storage | string | `"100Gi"` |  |
+| neo4j.volumes.data.mode | string | `"defaultStorageClass"` |  |
 | rag-ingestors.enabled | bool | `false` |  |
 | rag-ingestors.ingestors | list | `[]` |  |
 | rag-ingestors.ragServerUrl | string | `"http://rag-server:9446"` |  |

--- a/charts/rag-stack/values.yaml
+++ b/charts/rag-stack/values.yaml
@@ -242,9 +242,12 @@ neo4j:
 
   volumes:
     data:
-      mode: "dynamic"
-      dynamic:
-        storageClassName: gp2
+      mode: "defaultStorageClass"
+      defaultStorageClass:
+        accessModes:
+          - ReadWriteOnce
+        requests:
+          storage: 100Gi
 
 # RAG Redis configuration
 rag-redis:


### PR DESCRIPTION
## Description

Switch the neo4j data volume from `mode: dynamic` + `storageClassName: gp2` to `mode: defaultStorageClass`, so the PVC binds whatever StorageClass the cluster marks default instead of a hardcoded, provider-specific class.

`gp2` is backed by the in-tree `kubernetes.io/aws-ebs` provisioner, which only ever existed on AWS, so the chart was **not portable**. neo4j would hang on GKE/AKS/kind/minikube, none of which have a `gp2` class.

`defaultStorageClass` mode omits `storageClassName` entirely, so the PVC uses the cluster's default StorageClass; portable across providers (EKS Auto Mode's `auto-ebs-sc`, GKE `standard-rwo`, AKS `managed-csi`, kind/minikube `standard`). This also aligns the rest of the stack: rag-redis, milvus/etcd/minio, and mongodb already rely on the default class. neo4j was the lone hardcoded outlier.

The existing 100Gi request is preserved.

## Compatibility

| Deployment method | Impact |
|---|---|
| Helm: any cloud (EKS/GKE/AKS) | Fixed: uses the cluster default SC instead of a missing `gp2` |
| ArgoCD | Same chart, covered |
| Local kind (`setup-caipe.sh`) | Already overrode to `defaultStorageClass` at deploy time; no change in behavior |
| docker-compose | Not applicable (host bind-mounts, no StorageClass) |

## Testing

- `helm template` confirms the neo4j `volumeClaimTemplate` renders with `ReadWriteOnce` / `100Gi` and **no `storageClassName`** (inherits default); no `gp2` anywhere in the rendered output.
- Live EKS smoke test: `rag-neo4j-0` (plus milvus etcd/minio) bind volumes on the default StorageClass and reach `Running`, where previously they sat `Pending`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
