### PR TITLE
feat(rag): add Slack channel as a RAG data source

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/constants.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/constants.py
@@ -68,6 +68,9 @@ CONFLUENCE_INGESTOR_REDIS_QUEUE = "ingestor:confluence:requests"
 CONFLUENCE_INGESTOR_TYPE = "confluence"
 CONFLUENCE_INGESTOR_NAME = "default_confluence"
 
+SLACK_INGESTOR_REDIS_QUEUE = "ingestor:slack:requests"
+SLACK_INGESTOR_TYPE = "slack"
+
 # Default reload interval for datasources without an explicit reload_interval in metadata (in seconds)
 DEFAULT_RELOAD_INTERVAL = 86400  # 24 hours
 

--- a/ai_platform_engineering/knowledge_bases/rag/common/src/common/models/server.py
+++ b/ai_platform_engineering/knowledge_bases/rag/common/src/common/models/server.py
@@ -147,6 +147,31 @@ class ConfluenceIngestorCommand(str, Enum):
 
 
 # ============================================================================
+# Models specific for Slack Ingestor
+# ============================================================================
+
+
+class SlackChannelIngestRequest(BaseModel):
+  channel_id: str = Field(..., description="Slack channel ID (e.g., 'C0123456789')")
+  channel_name: Optional[str] = Field(None, description="Human-readable channel name (without leading '#'), used for display and message links")
+  description: str = Field("", description="Description for this data source")
+  lookback_days: int = Field(30, description="How many days of channel history to fetch. 0 fetches all history.", ge=0)
+  include_bots: bool = Field(False, description="Whether to include messages posted by bots")
+  # Owning team for a NEW Slack channel data source (spec 2026-06-03).
+  owner_team_slug: Optional[str] = Field(None, description="Slug of the team that will own this new data source. Required for non-org-admin authors adding a new Slack channel.")
+
+
+class SlackReloadRequest(BaseModel):
+  datasource_id: str = Field(..., description="ID of the Slack datasource to reload")
+
+
+class SlackIngestorCommand(str, Enum):
+  INGEST_CHANNEL = "ingest-channel"
+  RELOAD_ALL = "reload-all"
+  RELOAD_DATASOURCE = "reload-datasource"
+
+
+# ============================================================================
 # Models for Graph Exploration and Querying
 # ============================================================================
 class ExploreNeighborhoodRequest(BaseModel):

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/slack/ingestor.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/slack/ingestor.py
@@ -8,15 +8,25 @@ Each channel becomes a datasource, and each thread becomes a document.
 import os
 import json
 import time
+import asyncio
+import traceback
 from datetime import datetime
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Set
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 from langchain_core.documents import Document
+from redis.asyncio import Redis
 
 from common.ingestor import IngestorBuilder, Client
 from common.models.rag import DataSourceInfo, DocumentMetadata
-from common.job_manager import JobStatus
+from common.models.server import (
+  IngestorRequest,
+  SlackChannelIngestRequest,
+  SlackReloadRequest,
+  SlackIngestorCommand,
+)
+from common.job_manager import JobStatus, JobManager
+from common.constants import SLACK_INGESTOR_REDIS_QUEUE
 from common.utils import get_logger, get_fresh_until, derive_friendly_name
 
 logger = get_logger(__name__)
@@ -25,6 +35,13 @@ logger = get_logger(__name__)
 # Sync interval (also used to calculate fresh_until)
 sync_interval = int(os.environ.get("SYNC_INTERVAL", "86400"))  # Default 24 hours
 init_delay = int(os.environ.get("INIT_DELAY_SECONDS", "0"))
+max_ingestion_tasks = int(os.environ.get("SLACK_MAX_INGESTION_TASKS", "5"))
+
+# Redis configuration - used for the on-demand ingestion listener (mirrors
+# the webloader/confluence ingestors, which accept ad-hoc requests from the
+# RAG server's REST API in addition to their periodic env-configured sync).
+REDIS_URL = os.getenv("REDIS_URL", "redis://localhost:6379")
+redis_client = Redis.from_url(REDIS_URL, decode_responses=True)
 
 
 def get_message_fresh_until(message_ts: str, lookback_days: int) -> int:
@@ -295,6 +312,39 @@ class SlackChannelSyncer:
     return Document(page_content=content, metadata=metadata.model_dump())
 
 
+def get_slack_client_and_syncer() -> tuple[WebClient, "SlackChannelSyncer", str]:
+  """Build a Slack WebClient + channel syncer from env config.
+
+  Shared by the periodic env-configured sync and the on-demand (Redis-triggered)
+  ingestion paths so both use the same bot token / workspace URL.
+  """
+  slack_token = os.environ.get("SLACK_BOT_TOKEN")
+  if not slack_token:
+    raise ValueError("SLACK_BOT_TOKEN environment variable is required")
+  workspace_url = os.environ.get("SLACK_WORKSPACE_URL", "https://slack.com")
+  slack_client = WebClient(token=slack_token)
+  syncer = SlackChannelSyncer(slack_client, workspace_url)
+  return slack_client, syncer, workspace_url
+
+
+def fetch_and_build_documents(
+  syncer: "SlackChannelSyncer",
+  channel_id: str,
+  channel_name: str,
+  lookback_days: int,
+  include_bots: bool,
+  last_ts: Optional[str],
+  datasource_id: str,
+  ingestor_id: str,
+) -> tuple[List[Document], str]:
+  """Fetch channel messages since last_ts and build thread/message documents."""
+  messages, newest_ts = syncer.fetch_channel_messages(channel_id, channel_name, lookback_days, last_ts)
+  if not messages:
+    return [], newest_ts
+  documents = syncer.group_messages_by_thread(messages, channel_id, channel_name, include_bots, datasource_id, ingestor_id, lookback_days)
+  return documents, newest_ts
+
+
 async def sync_slack_channels(client: Client):
   """Sync function that processes all configured Slack channels"""
 
@@ -303,23 +353,20 @@ async def sync_slack_channels(client: Client):
   if not bot_name:
     raise ValueError("SLACK_BOT_NAME environment variable is required")
 
-  workspace_url = os.environ.get("SLACK_WORKSPACE_URL", "https://slack.com")
+  if not os.environ.get("SLACK_BOT_TOKEN"):
+    logger.warning("SLACK_BOT_TOKEN not set — skipping sync")
+    return
+
   channels_json = os.environ.get("SLACK_CHANNELS", "{}")
   try:
     channels = json.loads(channels_json)
   except json.JSONDecodeError:
     channels = {}
   if not channels:
-    logger.warning("No channels configured (SLACK_CHANNELS not set or empty) — skipping sync")
-    return
-  slack_token = os.environ.get("SLACK_BOT_TOKEN")
-  if not slack_token:
-    logger.warning("SLACK_BOT_TOKEN not set — skipping sync")
-    return
+    logger.info("No statically-configured channels (SLACK_CHANNELS not set or empty) — will still check on-demand channels")
 
   # Initialize Slack client and syncer
-  slack_client = WebClient(token=slack_token)
-  syncer = SlackChannelSyncer(slack_client, workspace_url)
+  slack_client, syncer, workspace_url = get_slack_client_and_syncer()
 
   # Load timestamps and lookback_days from previous runs (stored in datasource metadata)
   existing_datasources = await client.list_datasources(ingestor_id=client.ingestor_id)
@@ -334,7 +381,7 @@ async def sync_slack_channels(client: Client):
       if "lookback_days" in ds.metadata:
         stored_lookback_map[ch_id] = ds.metadata["lookback_days"]
 
-  # Process each channel
+  # Process each statically-configured channel
   for channel_id, config in channels.items():
     channel_name = config.get("name", channel_id)
     lookback_days = config.get("lookback_days", 30)
@@ -408,6 +455,199 @@ async def sync_slack_channels(client: Client):
       await client.add_job_error(job_id, [str(e)])
       await client.update_job(job_id=job_id, job_status=JobStatus.FAILED, message=f"Failed to ingest documents: {str(e)}")
 
+  # Also reload channels added on-demand via the REST API (not present in
+  # SLACK_CHANNELS) that haven't been refreshed within the sync interval —
+  # mirrors the confluence ingestor's periodic_reload behavior.
+  job_manager = JobManager(redis_client)
+  existing_datasources = await client.list_datasources(ingestor_id=client.ingestor_id)
+  current_time = int(time.time())
+  configured_channel_ids = set(channels.keys())
+  for ds in existing_datasources:
+    channel_id = (ds.metadata or {}).get("channel_id")
+    if not channel_id or channel_id in configured_channel_ids:
+      continue
+    if (current_time - ds.last_updated) < sync_interval:
+      continue
+    try:
+      await reload_slack_datasource(client, job_manager, ds)
+    except Exception as e:
+      logger.error(f"Error reloading on-demand datasource {ds.datasource_id}: {e}")
+
+
+async def process_channel_ingestion(client: Client, job_manager: JobManager, ingest_request: SlackChannelIngestRequest):
+  """Process on-demand channel ingestion from Redis (server already created datasource and job)."""
+  datasource_id = f"slack-channel-{ingest_request.channel_id}"
+  job_id = None
+  try:
+    datasources = await client.list_datasources(ingestor_id=client.ingestor_id)
+    datasource_info = next((ds for ds in datasources if ds.datasource_id == datasource_id), None)
+    if not datasource_info:
+      raise ValueError(f"Datasource not found: {datasource_id}")
+
+    jobs = await job_manager.get_jobs_by_datasource(datasource_id)
+    if not jobs:
+      raise ValueError(f"No job found for datasource: {datasource_id}")
+    job_id = jobs[0].job_id
+
+    if jobs[0].status == JobStatus.TERMINATED:
+      logger.info(f"Job {job_id} was already terminated, skipping processing")
+      return
+
+    await job_manager.upsert_job(job_id=job_id, status=JobStatus.IN_PROGRESS, message=f"Starting Slack channel ingestion for #{ingest_request.channel_name or ingest_request.channel_id}")
+
+    _, syncer, workspace_url = get_slack_client_and_syncer()
+    channel_name = ingest_request.channel_name or (datasource_info.metadata or {}).get("channel_name", ingest_request.channel_id)
+    last_ts = (datasource_info.metadata or {}).get("last_ts")
+
+    documents, newest_ts = fetch_and_build_documents(
+      syncer,
+      ingest_request.channel_id,
+      channel_name,
+      ingest_request.lookback_days,
+      ingest_request.include_bots,
+      last_ts,
+      datasource_id,
+      client.ingestor_id or "",
+    )
+
+    datasource_info.metadata = {
+      **(datasource_info.metadata or {}),
+      "channel_id": ingest_request.channel_id,
+      "channel_name": channel_name,
+      "last_ts": newest_ts if newest_ts else last_ts,
+      "workspace_url": workspace_url,
+      "lookback_days": ingest_request.lookback_days,
+    }
+    datasource_info.last_updated = int(time.time())
+    await client.upsert_datasource(datasource_info)
+
+    if not documents:
+      await job_manager.upsert_job(job_id=job_id, status=JobStatus.COMPLETED, message=f"No new messages for #{channel_name}")
+      return
+
+    await job_manager.upsert_job(job_id=job_id, total=len(documents), message=f"Ingesting {len(documents)} threads/messages from #{channel_name}")
+    fresh_until = get_fresh_until(sync_interval)
+    await client.ingest_documents(job_id=job_id, datasource_id=datasource_id, documents=documents, fresh_until=fresh_until)
+    await job_manager.upsert_job(job_id=job_id, status=JobStatus.COMPLETED, message=f"Successfully ingested {len(documents)} documents from #{channel_name}")
+
+  except Exception as e:
+    error_msg = f"Error processing Slack channel {ingest_request.channel_id}: {e}"
+    logger.error(error_msg)
+    logger.error(traceback.format_exc())
+    if job_id:
+      await job_manager.add_error_msg(job_id, error_msg)
+      await job_manager.upsert_job(job_id=job_id, status=JobStatus.FAILED, message=error_msg)
+    raise
+
+
+async def reload_slack_datasource(client: Client, job_manager: JobManager, datasource_info: DataSourceInfo):
+  """Reload a single Slack channel datasource, refetching its full lookback window."""
+  metadata = datasource_info.metadata or {}
+  channel_id = metadata.get("channel_id")
+  if not channel_id:
+    logger.warning(f"No channel_id in metadata for {datasource_info.datasource_id}")
+    return
+
+  channel_name = metadata.get("channel_name", channel_id)
+  lookback_days = metadata.get("lookback_days", 30)
+  include_bots = metadata.get("include_bots", False)
+
+  _, syncer, workspace_url = get_slack_client_and_syncer()
+  documents, newest_ts = fetch_and_build_documents(syncer, channel_id, channel_name, lookback_days, include_bots, None, datasource_info.datasource_id, client.ingestor_id or "")
+
+  job_response = await client.create_job(datasource_id=datasource_info.datasource_id, job_status=JobStatus.IN_PROGRESS, message=f"Reloading #{channel_name}", total=len(documents))
+  job_id = job_response["job_id"]
+
+  try:
+    if documents:
+      fresh_until = get_fresh_until(sync_interval)
+      await client.ingest_documents(job_id=job_id, datasource_id=datasource_info.datasource_id, documents=documents, fresh_until=fresh_until)
+    await job_manager.upsert_job(job_id=job_id, status=JobStatus.COMPLETED, message=f"Reloaded {len(documents)} documents from #{channel_name}")
+
+    datasource_info.metadata = {**metadata, "last_ts": newest_ts, "workspace_url": workspace_url}
+    datasource_info.last_updated = int(time.time())
+    await client.upsert_datasource(datasource_info)
+  except Exception as e:
+    logger.error(f"Error reloading {datasource_info.datasource_id}: {e}")
+    await job_manager.add_error_msg(job_id, str(e))
+    await job_manager.upsert_job(job_id=job_id, status=JobStatus.FAILED, message=str(e))
+    raise
+
+
+async def redis_listener(client: Client):
+  """Listen for Slack ingest requests on Redis queue (mirrors the confluence ingestor's listener)."""
+  job_manager = JobManager(redis_client)
+  active_tasks: Set[asyncio.Task] = set()
+
+  logger.info(f"Starting Redis listener on queue: {SLACK_INGESTOR_REDIS_QUEUE}")
+
+  async def handle_task(coro, task_name: str):
+    try:
+      await coro
+    except Exception as e:
+      logger.error(f"Error in {task_name}: {e}")
+      logger.error(traceback.format_exc())
+
+  try:
+    while True:
+      try:
+        done_tasks = {task for task in active_tasks if task.done()}
+        active_tasks -= done_tasks
+
+        if len(active_tasks) >= max_ingestion_tasks:
+          await asyncio.sleep(0.5)
+          continue
+
+        result = await redis_client.blpop([SLACK_INGESTOR_REDIS_QUEUE], timeout=1)
+        if result is None:
+          continue
+
+        _, message = result
+        try:
+          ingestor_request = IngestorRequest.model_validate_json(message)
+          if ingestor_request.ingestor_id != client.ingestor_id:
+            continue
+
+          if ingestor_request.command == SlackIngestorCommand.INGEST_CHANNEL:
+            ingest_request = SlackChannelIngestRequest.model_validate(ingestor_request.payload)
+            task = asyncio.create_task(handle_task(process_channel_ingestion(client, job_manager, ingest_request), f"Channel ingestion: {ingest_request.channel_id}"))
+            active_tasks.add(task)
+
+          elif ingestor_request.command == SlackIngestorCommand.RELOAD_ALL:
+            task = asyncio.create_task(handle_task(sync_slack_channels(client), "Reload all Slack datasources"))
+            active_tasks.add(task)
+
+          elif ingestor_request.command == SlackIngestorCommand.RELOAD_DATASOURCE:
+            reload_request = SlackReloadRequest.model_validate(ingestor_request.payload)
+            datasources = await client.list_datasources(ingestor_id=client.ingestor_id)
+            datasource_info = next((ds for ds in datasources if ds.datasource_id == reload_request.datasource_id), None)
+            if datasource_info:
+              task = asyncio.create_task(handle_task(reload_slack_datasource(client, job_manager, datasource_info), f"Reload datasource: {reload_request.datasource_id}"))
+              active_tasks.add(task)
+            else:
+              logger.warning(f"Datasource not found: {reload_request.datasource_id}")
+
+        except Exception as e:
+          logger.error(f"Error processing message: {e}")
+          logger.error(traceback.format_exc())
+
+      except asyncio.CancelledError:
+        logger.info("Redis listener cancelled, waiting for tasks...")
+        if active_tasks:
+          await asyncio.gather(*active_tasks, return_exceptions=True)
+        break
+      except Exception as e:
+        logger.error(f"Listener loop error: {e}")
+        logger.error(traceback.format_exc())
+        await asyncio.sleep(5)
+
+  finally:
+    if active_tasks:
+      for task in active_tasks:
+        task.cancel()
+      await asyncio.gather(*active_tasks, return_exceptions=True)
+    await redis_client.close()
+
 
 def main():
   """Main entry point for the Slack ingestor"""
@@ -421,9 +661,18 @@ def main():
     channels = {}
 
   # Build and run ingestor
-  IngestorBuilder().name(f"slack-{bot_name}").type("slack").description(f"Slack ingestor for {workspace_url}").metadata({"workspace_url": workspace_url, "bot_name": bot_name, "sync_interval": sync_interval, "init_delay": init_delay, "channels": channels}).sync_with_fn(sync_slack_channels).every(
-    sync_interval
-  ).with_init_delay(init_delay).run()
+  (
+    IngestorBuilder()
+    .name(f"slack-{bot_name}")
+    .type("slack")
+    .description(f"Slack ingestor for {workspace_url}")
+    .metadata({"workspace_url": workspace_url, "bot_name": bot_name, "sync_interval": sync_interval, "init_delay": init_delay, "channels": channels})
+    .sync_with_fn(sync_slack_channels)
+    .with_startup(redis_listener)
+    .every(sync_interval)
+    .with_init_delay(init_delay)
+    .run()
+  )
 
 
 if __name__ == "__main__":

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -33,6 +33,9 @@ from common.models.server import (
   UrlReloadRequest,
   ConfluenceIngestRequest,
   ConfluenceReloadRequest,
+  SlackIngestorCommand,
+  SlackChannelIngestRequest,
+  SlackReloadRequest,
   JobsBatchRequest,
   MCPToolInvokeRequest,
   MCPToolInvokeResponse,
@@ -67,7 +70,19 @@ from server.rbac import (
 )
 from common.graph_db.neo4j.graph_db import Neo4jDB
 from common.graph_db.base import GraphDB
-from common.constants import DATASOURCE_ID_KEY, WEBLOADER_INGESTOR_REDIS_QUEUE, WEBLOADER_INGESTOR_NAME, WEBLOADER_INGESTOR_TYPE, CONFLUENCE_INGESTOR_REDIS_QUEUE, CONFLUENCE_INGESTOR_NAME, CONFLUENCE_INGESTOR_TYPE, DEFAULT_DATA_LABEL, DEFAULT_SCHEMA_LABEL
+from common.constants import (
+  DATASOURCE_ID_KEY,
+  WEBLOADER_INGESTOR_REDIS_QUEUE,
+  WEBLOADER_INGESTOR_NAME,
+  WEBLOADER_INGESTOR_TYPE,
+  CONFLUENCE_INGESTOR_REDIS_QUEUE,
+  CONFLUENCE_INGESTOR_NAME,
+  CONFLUENCE_INGESTOR_TYPE,
+  SLACK_INGESTOR_REDIS_QUEUE,
+  SLACK_INGESTOR_TYPE,
+  DEFAULT_DATA_LABEL,
+  DEFAULT_SCHEMA_LABEL,
+)
 from common.embeddings_factory import EmbeddingsFactory
 import redis.asyncio as redis
 from langchain_milvus import BM25BuiltInFunction, Milvus
@@ -1806,6 +1821,163 @@ async def reload_all_confluence_pages(user: UserContext = Depends(require_role(R
   logger.info("Re-queued Confluence ingestion request for all datasources")
 
   return {"message": "Reload all Confluence pages request queued"}
+
+
+async def get_slack_ingestor_id() -> Optional[str]:
+  """Look up the ingestor_id of the most-recently-seen registered Slack ingestor.
+
+  Unlike webloader/confluence, the Slack ingestor's name is derived from the
+  SLACK_BOT_NAME env var at container startup, so there's no static
+  ingestor_id constant to build one from.
+  """
+  if not metadata_storage:
+    return None
+  ingestors = await metadata_storage.fetch_all_ingestor_info()
+  slack_ingestors = [i for i in ingestors if i.ingestor_type == SLACK_INGESTOR_TYPE]
+  if not slack_ingestors:
+    return None
+  slack_ingestors.sort(key=lambda i: i.last_seen or 0, reverse=True)
+  return slack_ingestors[0].ingestor_id
+
+
+@app.post("/v1/ingest/slack/channel", status_code=status.HTTP_202_ACCEPTED)
+async def ingest_slack_channel(
+  slack_request: SlackChannelIngestRequest,
+  request: Request,
+  user: UserContext = Depends(require_authenticated_user),
+):
+  """Queue a Slack channel for ingestion by the slack ingestor."""
+  if not metadata_storage or not jobmanager:
+    raise HTTPException(status_code=500, detail="Server not initialized")
+
+  logger.info(f"Received Slack channel ingestion request: {slack_request.channel_id}")
+
+  slack_ingestor_id = await get_slack_ingestor_id()
+  if not slack_ingestor_id:
+    raise HTTPException(status_code=503, detail="No Slack ingestor is currently registered. Ensure the slack ingestor service is running.")
+
+  datasource_id = f"slack-channel-{slack_request.channel_id}"
+
+  # Check if datasource already exists. Adding a channel that's already
+  # ingested is an "ingest into KB X" operation (per-KB check); creating a
+  # NEW channel datasource is the explicit org-level author capability +
+  # owning-team gate (spec 2026-06-03).
+  existing_datasource = await metadata_storage.get_datasource_info(datasource_id)
+  if existing_datasource:
+    await check_datasource_access(request, user, datasource_id, "ingest")
+  else:
+    await authorize_datasource_create(request, user, datasource_id, slack_request.owner_team_slug)
+
+  if not existing_datasource:
+    if not slack_request.description:
+      slack_request.description = f"Slack channel #{slack_request.channel_name or slack_request.channel_id}"
+
+    datasource_info = DataSourceInfo(
+      datasource_id=datasource_id,
+      name=utils.derive_friendly_name(source_type="slack", channel_name=slack_request.channel_name, fallback=datasource_id),
+      ingestor_id=slack_ingestor_id,
+      description=slack_request.description,
+      source_type="slack",
+      last_updated=int(time.time()),
+      default_chunk_size=1000,
+      default_chunk_overlap=200,
+      # Config is the source of truth for ownership; OpenFGA is the derived
+      # projection (spec 2026-06-03). Persist the same owner/creator the
+      # tuples below encode so the sharing panel reflects the owning team.
+      owner_team_slug=(slack_request.owner_team_slug or "").strip() or None,
+      creator_subject=user.subject,
+      owner_subject=user.subject if not (slack_request.owner_team_slug or "").strip() else None,
+      metadata={
+        "channel_id": slack_request.channel_id,
+        "channel_name": slack_request.channel_name,
+        "lookback_days": slack_request.lookback_days,
+        "include_bots": slack_request.include_bots,
+      },
+    )
+
+    await metadata_storage.store_datasource_info(datasource_info)
+    logger.info(f"Created datasource: {datasource_id}")
+
+    # Write ownership tuples for the brand-new Slack channel (spec
+    # 2026-06-03). Best-effort; non-fatal.
+    await write_datasource_ownership(datasource_id, slack_request.owner_team_slug, user)
+
+  # Check if there is already a job for this datasource in progress or pending
+  existing_jobs = await jobmanager.get_jobs_by_datasource(datasource_id)
+  if existing_jobs:
+    existing_pending_jobs = [job for job in existing_jobs if job.status in (JobStatus.IN_PROGRESS, JobStatus.PENDING)]
+    if existing_pending_jobs:
+      logger.info(f"An ingestion job is already in progress or pending for datasource {datasource_id}, job ID: {existing_pending_jobs[0].job_id}")
+      raise HTTPException(status_code=400, detail=f"An ingestion job is already in progress or pending for this Slack channel (job ID: {existing_pending_jobs[0].job_id})")
+
+  # Create job with PENDING status
+  job_id = str(uuid.uuid4())
+  success = await jobmanager.upsert_job(
+    job_id,
+    status=JobStatus.PENDING,
+    message="Waiting for ingestor to process...",
+    total=0,  # Unknown until channel history is fetched
+    datasource_id=datasource_id,
+  )
+
+  if not success:
+    raise HTTPException(status_code=500, detail="Failed to create job")
+
+  logger.info(f"Created job {job_id} for datasource {datasource_id}")
+
+  # Queue the request for the ingestor
+  ingestor_request = IngestorRequest(ingestor_id=slack_ingestor_id, command=SlackIngestorCommand.INGEST_CHANNEL, payload=slack_request.model_dump())
+
+  # Push to Redis queue
+  await redis_client.rpush(SLACK_INGESTOR_REDIS_QUEUE, ingestor_request.model_dump_json())  # type: ignore
+  logger.info(f"Queued Slack channel ingestion request for {slack_request.channel_id} to {SLACK_INGESTOR_REDIS_QUEUE}")
+
+  return {"datasource_id": datasource_id, "job_id": job_id, "message": "Slack channel ingestion request queued"}
+
+
+@app.post("/v1/ingest/slack/reload", status_code=status.HTTP_202_ACCEPTED)
+async def reload_slack_channel(
+  reload_request: SlackReloadRequest,
+  request: Request,
+  user: UserContext = Depends(require_authenticated_user),
+):
+  """Reloads a previously ingested Slack channel by re-queuing it for ingestion."""
+  if not metadata_storage or not jobmanager:
+    raise HTTPException(status_code=500, detail="Server not initialized")
+
+  # Fetch existing datasource
+  datasource_info = await metadata_storage.get_datasource_info(reload_request.datasource_id)
+  if not datasource_info:
+    raise HTTPException(status_code=404, detail="Datasource not found")
+  await check_datasource_access(request, user, reload_request.datasource_id, "ingest")
+
+  # Queue the request for the ingestor
+  ingestor_request = IngestorRequest(ingestor_id=datasource_info.ingestor_id, command=SlackIngestorCommand.RELOAD_DATASOURCE, payload=reload_request.model_dump())
+
+  # Push to Redis queue
+  await redis_client.rpush(SLACK_INGESTOR_REDIS_QUEUE, ingestor_request.model_dump_json())  # type: ignore
+  logger.info(f"Re-queued Slack channel ingestion request for {reload_request.datasource_id}")
+  return {"datasource_id": reload_request.datasource_id, "message": "Slack channel reload request queued"}
+
+
+@app.post("/v1/ingest/slack/reload-all", status_code=status.HTTP_202_ACCEPTED)
+async def reload_all_slack_channels(user: UserContext = Depends(require_role(Role.ADMIN))):
+  """Reloads all previously ingested Slack channels by re-queuing them for ingestion."""
+  if not metadata_storage or not jobmanager:
+    raise HTTPException(status_code=500, detail="Server not initialized")
+
+  slack_ingestor_id = await get_slack_ingestor_id()
+  if not slack_ingestor_id:
+    raise HTTPException(status_code=503, detail="No Slack ingestor is currently registered. Ensure the slack ingestor service is running.")
+
+  # Queue the request for the ingestor
+  ingestor_request = IngestorRequest(ingestor_id=slack_ingestor_id, command=SlackIngestorCommand.RELOAD_ALL, payload={})
+
+  # Push to Redis queue
+  await redis_client.rpush(SLACK_INGESTOR_REDIS_QUEUE, ingestor_request.model_dump_json())  # type: ignore
+  logger.info("Re-queued Slack ingestion request for all datasources")
+
+  return {"message": "Reload all Slack channels request queued"}
 
 
 @app.post("/v1/ingest")

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -6,7 +6,7 @@ import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
 const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.45 -f your-values.yaml';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.5.46 -f your-values.yaml';
 const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.45 -f your-values.yaml'}
+                  {'    --version 0.5.46 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.45 -f your-values.yaml'}
+              {'    --version 0.5.46 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.46"
+version = "0.5.46-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/components/rag/IngestView.tsx
+++ b/ui/src/components/rag/IngestView.tsx
@@ -74,6 +74,7 @@ getJobsBatch,
 getJobsByDataSource,
 getJobStatus,
 ingestLocalFile,
+ingestSlackChannel,
 ingestUrl,
 JIRA_INGESTOR_ID,
 reloadDataSource,
@@ -222,6 +223,12 @@ export default function IngestView() {
   const [description, setDescription] = useState('')
   const [includeSubPages, setIncludeSubPages] = useState(false)
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false)
+
+  // Slack-specific ingest state
+  const [slackChannelId, setSlackChannelId] = useState('')
+  const [slackChannelName, setSlackChannelName] = useState('')
+  const [slackLookbackDays, setSlackLookbackDays] = useState(30)
+  const [slackIncludeBots, setSlackIncludeBots] = useState(false)
   
   // Scrapy settings state (for web ingest type)
   const [crawlMode, setCrawlMode] = useState<'single' | 'sitemap' | 'recursive'>('sitemap')
@@ -881,7 +888,8 @@ export default function IngestView() {
 
   const handleIngest = async () => {
     if (ingestType === 'file' && selectedFiles.length === 0) return
-    if (ingestType !== 'file' && !url) return
+    if (ingestType === 'slack' && !slackChannelId) return
+    if (ingestType !== 'file' && ingestType !== 'slack' && !url) return
     if (ingestOwnerTeamMissing) {
       toast('Select an owning team for this data source', 'error')
       return
@@ -895,6 +903,15 @@ export default function IngestView() {
             owner_team_slug: ingestOwnerTeamSlug || undefined,
             chunk_size: chunkSize,
             chunk_overlap: chunkOverlap,
+          })
+        : ingestType === 'slack'
+        ? await ingestSlackChannel({
+            channel_id: slackChannelId,
+            channel_name: slackChannelName || undefined,
+            description,
+            lookback_days: slackLookbackDays,
+            include_bots: slackIncludeBots,
+            owner_team_slug: ingestOwnerTeamSlug || undefined,
           })
         : await ingestUrl({
             url,
@@ -933,6 +950,8 @@ export default function IngestView() {
       setSelectedFiles([])
       setDescription('')
       setIngestOwnerTeamSlug('')
+      setSlackChannelId('')
+      setSlackChannelName('')
     } catch (error: any) {
       console.error('Error ingesting data:', error)
       toast(`Ingestion failed: ${error?.message || 'unknown error'}`, 'error')
@@ -1116,7 +1135,7 @@ export default function IngestView() {
             {/* Source Input */}
             <div className="mb-4">
               <label className="block text-sm font-medium text-muted-foreground mb-2">
-                {ingestType === 'file' ? 'Files' : 'URL'}
+                {ingestType === 'file' ? 'Files' : ingestType === 'slack' ? 'Channel' : 'URL'}
               </label>
               <div className="flex gap-2">
                 <div className="relative flex-1">
@@ -1138,6 +1157,29 @@ export default function IngestView() {
                         </p>
                       )}
                     </>
+                  ) : ingestType === 'slack' ? (
+                    <div className="flex gap-2">
+                      <div className="relative flex-1">
+                        <FileText className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+                        <Input
+                          type="text"
+                          placeholder="Channel ID (e.g. C0123456789)"
+                          value={slackChannelId}
+                          onChange={(e) => setSlackChannelId(e.target.value)}
+                          className="pl-10"
+                          onKeyDown={(e) => e.key === 'Enter' && handleIngest()}
+                        />
+                      </div>
+                      <div className="relative flex-1">
+                        <Input
+                          type="text"
+                          placeholder="Channel name (optional, e.g. engineering)"
+                          value={slackChannelName}
+                          onChange={(e) => setSlackChannelName(e.target.value)}
+                          onKeyDown={(e) => e.key === 'Enter' && handleIngest()}
+                        />
+                      </div>
+                    </div>
                   ) : (
                     <>
                       <LinkIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
@@ -1155,7 +1197,7 @@ export default function IngestView() {
                 <Button
                   onClick={handleIngest}
                   disabled={
-                    (ingestType === 'file' ? selectedFiles.length === 0 : !url) ||
+                    (ingestType === 'file' ? selectedFiles.length === 0 : ingestType === 'slack' ? !slackChannelId : !url) ||
                     !hasPermission(Permission.INGEST) ||
                     ingestOwnerTeamMissing
                   }
@@ -1168,7 +1210,9 @@ export default function IngestView() {
                           ? selectedFiles.length > 1
                             ? `Ingest ${selectedFiles.length} files`
                             : 'Ingest this file'
-                          : 'Ingest this URL'
+                          : ingestType === 'slack'
+                            ? 'Ingest this Slack channel'
+                            : 'Ingest this URL'
                   }
                 >
                   Ingest
@@ -1254,6 +1298,29 @@ export default function IngestView() {
                   />
                   <span className="text-sm text-muted-foreground">Include child pages</span>
                 </label>
+              )}
+              {ingestType === 'slack' && (
+                <div className="flex items-center gap-4 mt-2 ml-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm text-muted-foreground">Lookback days:</span>
+                    <Input
+                      type="number"
+                      min={0}
+                      value={slackLookbackDays}
+                      onChange={(e) => setSlackLookbackDays(Number(e.target.value))}
+                      className="w-20 h-8"
+                    />
+                  </div>
+                  <label className="flex items-center gap-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={slackIncludeBots}
+                      onChange={(e) => setSlackIncludeBots(e.target.checked)}
+                      className="rounded border-border text-primary focus:ring-primary h-4 w-4"
+                    />
+                    <span className="text-sm text-muted-foreground">Include bot messages</span>
+                  </label>
+                </div>
               )}
 
               {/* Description - outside advanced options */}
@@ -1769,8 +1836,9 @@ export default function IngestView() {
                       const hasActiveJob = latestJob && (latestJob.status === 'in_progress' || latestJob.status === 'pending')
                       const isWebloaderDatasource = ds.ingestor_id === WEBLOADER_INGESTOR_ID
                       const isConfluenceDatasource = ds.ingestor_id === CONFLUENCE_INGESTOR_ID
+                      const isSlackDatasource = ds.source_type === 'slack'
                       const isJiraDatasource = ds.ingestor_id === JIRA_INGESTOR_ID
-                      const supportsReload = isWebloaderDatasource || isConfluenceDatasource
+                      const supportsReload = isWebloaderDatasource || isConfluenceDatasource || isSlackDatasource
                       const isConfigDriven = isJiraDatasource
                       const icon = getIconForType(ds.source_type)
                       

--- a/ui/src/components/rag/api/index.ts
+++ b/ui/src/components/rag/api/index.ts
@@ -189,6 +189,24 @@ export const ingestUrl = async (params: {
     }
 };
 
+export const ingestSlackChannel = async (params: {
+    channel_id: string;
+    channel_name?: string;
+    description?: string;
+    lookback_days?: number;
+    include_bots?: boolean;
+    owner_team_slug?: string;
+}): Promise<{ datasource_id: string | null; job_id: string | null; message: string }> => {
+    return apiPost('/v1/ingest/slack/channel', {
+        channel_id: params.channel_id,
+        channel_name: params.channel_name || null,
+        description: params.description || '',
+        lookback_days: params.lookback_days ?? 30,
+        include_bots: params.include_bots || false,
+        owner_team_slug: params.owner_team_slug || null
+    });
+};
+
 export const ingestLocalFile = async (params: {
     files: File[];
     description?: string;
@@ -209,6 +227,8 @@ export const reloadDataSource = async (datasourceId: string): Promise<{ datasour
     // Determine endpoint based on datasource ID pattern
     if (datasourceId.includes('src_confluence___')) {
         return apiPost('/v1/ingest/confluence/reload', { datasource_id: datasourceId });
+    } else if (datasourceId.startsWith('slack-channel-')) {
+        return apiPost('/v1/ingest/slack/reload', { datasource_id: datasourceId });
     } else {
         return apiPost('/v1/ingest/webloader/reload', { datasource_id: datasourceId });
     }

--- a/ui/src/components/rag/typeConfig.ts
+++ b/ui/src/components/rag/typeConfig.ts
@@ -62,6 +62,11 @@ export const ingestTypeConfigs: Record<string, IngestTypeConfig> = {
         requiredIngestorType: 'confluence',
         icon: '/confluence.svg'
     },
+    'slack': {
+        label: 'Slack',
+        requiredIngestorType: 'slack',
+        icon: '/slack.svg'
+    },
     // Add future ingestor types here:
     // 'github': {
     //     label: 'GitHub',

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.46"
+version = "0.5.46.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Wires the existing Slack ingestor container into the on-demand ingestion flow so users can add and reload Slack channels from the RAG UI's "Data Sources" panel, the same way they already do for file/web/Confluence sources.

## Backend
- Add `SLACK_INGESTOR_REDIS_QUEUE` / `SLACK_INGESTOR_TYPE` constants
- Add `SlackChannelIngestRequest` / `SlackReloadRequest` / `SlackIngestorCommand` models
- Add REST endpoints: `POST /v1/ingest/slack/channel`, `/v1/ingest/slack/reload`, `/v1/ingest/slack/reload-all`
- Resolve the Slack ingestor's `ingestor_id` dynamically at request time, since (unlike webloader/Confluence) it's derived from `SLACK_BOT_NAME` at container startup rather than a static name
- Fix `sync_slack_channels()` so the on-demand channel reload check still runs when `SLACK_CHANNELS` is unset, supporting fully config-free deployments

## Frontend
- Add a `slack` entry to `ingestTypeConfigs` so the "Slack" source-type button appears once a Slack ingestor is registered
- Add `ingestSlackChannel()` API call and reload routing for `slack-channel-*` datasource IDs
- Add a Slack ingest form (channel ID, optional channel name, lookback days, include-bots toggle) to the ingestion panel

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass (`ruff check`, `npm run lint`, `npm run build`)
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass (verified no new failures vs. main)