### PR TITLE
fix(mcp): sync AgentGateway routes on startup and fail-closed on unconfirmed routes

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/mcp_client.py
@@ -353,6 +353,21 @@ def build_mcp_connections(
             agent_gateway_url
             and server.transport in (TransportType.HTTP, TransportType.SSE)
         )
+
+        # assisted-by Claude Code claude-sonnet-4-6
+        # A gitops-configured server with agentgateway_target_endpoint is meant
+        # to route through AgentGateway, but seed's full-document replace wipes
+        # agentgateway_discovered back to False on every restart until a sync
+        # (startup or config-bridge's next poll) confirms the route is live.
+        # Wiring the tool up before that confirmation would just hand the agent
+        # a tool whose calls 404 against AgentGateway's not-yet-programmed
+        # route, so skip it until agentgateway_discovered is True.
+        if use_gateway and server.agentgateway_target_endpoint and not server.agentgateway_discovered:
+            logger.warning(
+                f"MCP server '{server_id}' is pending AgentGateway sync, skipping"
+            )
+            continue
+
         connections[server_id] = build_mcp_connection_config(
             server,
             agent_gateway_url=agent_gateway_url if use_gateway else None,

--- a/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_token_forwarding.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_mcp_client_token_forwarding.py
@@ -225,7 +225,8 @@ def test_gateway_routing_routes_all_network_servers_when_gateway_is_configured(m
 
 
 def test_gateway_routes_manual_network_mcp_servers(monkeypatch):
-    """Manual network MCP rows route through AgentGateway too."""
+    """Manual network MCP rows route through AgentGateway too, once AgentGateway
+    has confirmed the route (agentgateway_discovered=True)."""
     servers = [
         MCPServerConfig(
             id="knowledge-base",
@@ -235,6 +236,7 @@ def test_gateway_routes_manual_network_mcp_servers(monkeypatch):
             enabled=True,
             source="agentgateway",
             agentgateway_target_endpoint="http://rag-server:9446/mcp",
+            agentgateway_discovered=True,
         ),
         MCPServerConfig(
             id="manual-tool",
@@ -253,6 +255,31 @@ def test_gateway_routes_manual_network_mcp_servers(monkeypatch):
 
     assert connections["knowledge-base"]["url"] == "http://agentgateway:4000/mcp/knowledge-base"
     assert connections["manual-tool"]["url"] == "http://agentgateway:4000/mcp/manual-tool"
+
+
+def test_gateway_skips_undiscovered_target_endpoint_servers(monkeypatch):
+    """A server declaring agentgateway_target_endpoint but not yet confirmed
+    live (agentgateway_discovered=False, the state right after a seed/restart)
+    must not be handed to the agent — calling it would just 404 against
+    AgentGateway's not-yet-programmed route."""
+    servers = [
+        MCPServerConfig(
+            id="confluence-admin",
+            name="Confluence",
+            transport=TransportType.HTTP,
+            endpoint="http://agentgateway:4000/mcp/confluence-admin",
+            enabled=True,
+            agentgateway_target_endpoint="http://mcp-confluence-admin:8000/mcp",
+        ),
+    ]
+
+    connections = build_mcp_connections(
+        servers,
+        ["confluence-admin"],
+        agent_gateway_url="http://agentgateway:4000",
+    )
+
+    assert "confluence-admin" not in connections
 
 
 def test_warn_if_agent_gateway_missing_hmac_logs_when_gateway_set_without_secret(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.60-dev.5"
+version = "0.5.60-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/mcp-servers/agentgateway/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/__tests__/route.test.ts
@@ -309,7 +309,33 @@ describe("AgentGateway MCP server discovery API", () => {
 
     expect(response.status).toBe(200);
     expect(insertOne).not.toHaveBeenCalled();
-    expect(updateOne).not.toHaveBeenCalled();
+    // "existing" still persists agentgateway_discovered (and the endpoint
+    // fields) on every sync, not just on first discovery — seed's
+    // full-document replaceOne wipes agentgateway_discovered back to
+    // undefined on every restart, so a confirmed-live route must be
+    // re-persisted here or dynamic-agents tool wiring treats it as pending.
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: "rag" },
+      {
+        $set: {
+          agentgateway_discovered: true,
+          agentgateway_endpoint: "http://agentgateway:4000/mcp",
+          agentgateway_target_endpoint: expect.any(String),
+          updated_at: expect.any(String),
+        },
+      },
+    );
+    expect(updateOne).toHaveBeenCalledWith(
+      { _id: "jira" },
+      {
+        $set: {
+          agentgateway_discovered: true,
+          agentgateway_endpoint: "http://agentgateway:4000/mcp",
+          agentgateway_target_endpoint: expect.any(String),
+          updated_at: expect.any(String),
+        },
+      },
+    );
     expect(mockReconcileConfigDrivenMcpServerRelationships).toHaveBeenCalledWith({
       serverId: "rag",
       organizationId: "caipe",

--- a/ui/src/app/api/mcp-servers/agentgateway/_lib.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/_lib.ts
@@ -56,6 +56,23 @@ export async function syncSelectedAgentGatewayMcpServers(ids?: string[]) {
   for (const target of discovery.targets) {
     if (!selectedIds.has(target.id)) continue;
     if (target.status === "existing") {
+      // The route is live in AgentGateway's own config right now (that's what
+      // "existing" means — see buildAgentGatewayMcpDiscovery), but seed's
+      // full-document replaceOne wipes agentgateway_discovered back to
+      // undefined on every restart. Persist the confirmation here so the UI
+      // and dynamic-agents tool wiring can trust the field for every
+      // gitops-configured server, not just newly-discovered ones.
+      await collection.updateOne(
+        { _id: target.id } as never,
+        {
+          $set: {
+            agentgateway_discovered: true,
+            agentgateway_endpoint: target.endpoint,
+            agentgateway_target_endpoint: target.target_endpoint,
+            updated_at: new Date().toISOString(),
+          },
+        } as never,
+      );
       await reconcileConfigDrivenMcpServerRelationships({
         serverId: target.id,
         organizationId: caipeOrgKey(),

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -58,7 +58,7 @@ interface ProbeResult {
   error?: string;
 }
 
-type ToolHealthStatus = "healthy" | "degraded" | "checking" | "unknown" | "disabled";
+type ToolHealthStatus = "healthy" | "degraded" | "checking" | "unknown" | "disabled" | "pending";
 
 interface AgentGatewayMigrationWarning {
   id: string;
@@ -149,6 +149,15 @@ function toolHealthStatus(
       title: `${probe.tools.length} tool${probe.tools.length === 1 ? "" : "s"} available`,
     };
   }
+  if (server.source === "agentgateway" && server.agentgateway_discovered !== true) {
+    return {
+      status: "pending",
+      label: "Waiting for sync",
+      title:
+        "AgentGateway has not confirmed this route yet. It self-heals within a few " +
+        "minutes, or click Repair AgentGateway to sync now.",
+    };
+  }
   if (!serverCanProbe(server)) {
     return {
       status: "unknown",
@@ -176,6 +185,8 @@ function toolHealthClass(status: ToolHealthStatus): string {
       return "text-green-600 dark:text-green-400";
     case "degraded":
       return "text-amber-600 dark:text-amber-400";
+    case "pending":
+      return "text-cyan-600 dark:text-cyan-400";
     case "checking":
     case "unknown":
     case "disabled":
@@ -191,6 +202,8 @@ function toolHealthDotClass(status: ToolHealthStatus): string {
       return "bg-amber-500";
     case "checking":
       return "bg-blue-500";
+    case "pending":
+      return "bg-cyan-500";
     case "unknown":
     case "disabled":
       return "bg-muted-foreground/60";

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -149,7 +149,13 @@ function toolHealthStatus(
       title: `${probe.tools.length} tool${probe.tools.length === 1 ? "" : "s"} available`,
     };
   }
-  if (server.source === "agentgateway" && server.agentgateway_discovered !== true) {
+  // Any gitops-configured server declaring agentgateway_target_endpoint is
+  // meant to route through AgentGateway, whether or not it also sets
+  // source: "agentgateway" (that field is only set on auto-discovered rows;
+  // hand-authored gitops entries like a shared-access "*-admin" server often
+  // omit it). Gate on the target endpoint instead so every AgentGateway-routed
+  // server gets the same "pending" treatment until confirmed live.
+  if (server.agentgateway_target_endpoint && server.agentgateway_discovered !== true) {
     return {
       status: "pending",
       label: "Waiting for sync",
@@ -775,7 +781,7 @@ export function MCPServersTab({
                   <div
                     className={`grid grid-cols-12 gap-4 py-3 px-2 rounded-lg hover:bg-muted/50 items-center ${
                       serverCanManage(server) ? "cursor-pointer" : "cursor-default"
-                    }`}
+                    } ${toolHealth.status === "pending" ? "opacity-60" : ""}`}
                     onClick={() => openServer(server)}
                   >
                     <div className="col-span-3">

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -1259,6 +1259,36 @@ export async function applySeedConfig(): Promise<void> {
             ? `, ${credBackfillCount} MCP credential_sources backfilled`
             : ""),
       );
+
+      // Immediately re-associate AgentGateway routes after seed so the UI
+      // reflects live route state without waiting for the next config-bridge
+      // poll cycle (~8 min). Seed clears agentgateway_discovered on every
+      // restart; this restores it in the same startup cycle. Best-effort —
+      // an unreachable AgentGateway is logged and skipped (config-bridge
+      // will heal on its next poll).
+      try {
+        const { syncSelectedAgentGatewayMcpServers } = await import(
+          "@/app/api/mcp-servers/agentgateway/_lib"
+        );
+        const syncResult = await syncSelectedAgentGatewayMcpServers();
+        const synced =
+          syncResult.summary.added +
+          syncResult.summary.migrated +
+          syncResult.summary.refreshed;
+        if (synced > 0) {
+          console.log(
+            `[seed-config] AgentGateway sync on startup: ` +
+              `added ${syncResult.summary.added}, ` +
+              `migrated ${syncResult.summary.migrated}, ` +
+              `refreshed ${syncResult.summary.refreshed}`,
+          );
+        }
+      } catch (syncErr) {
+        console.warn(
+          "[seed-config] AgentGateway sync on startup skipped (AgentGateway not yet reachable):",
+          syncErr,
+        );
+      }
     } catch (err) {
       // Log but don't crash — seeding failure shouldn't prevent startup
       console.error("[seed-config] Failed to apply seed config:", err);

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.60.dev5"
+version = "0.5.60.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary

- Seed (`applySeedConfig`) replaces every YAML-declared MCP server doc via `replaceOne`, which clears `agentgateway_discovered` and related fields on every pod restart
- The existing `selfHealDiscoveredMcpServersIfEmpty` only fires when the collection is empty (first-run / DB-wipe recovery), skipping on normal restarts -- leaving a gap until the next config-bridge poll cycle restores the association
- This fix calls `syncSelectedAgentGatewayMcpServers` immediately after the seed completes, so agentgateway routes are re-associated **in the same startup cycle** rather than waiting for config-bridge

Two related gaps were found and fixed along the way:

- **`_lib.ts` "existing" branch never persisted confirmation.** `status === "existing"` means AgentGateway's own live config already has the route, but the sync code only ever set `agentgateway_discovered: true` for newly-discovered targets, never for already-registered ones (e.g. a shared-access `*-admin` MCP server that never set `source: "agentgateway"`). Now every `existing` match persists `agentgateway_discovered` / `agentgateway_endpoint` / `agentgateway_target_endpoint`, uniformly, regardless of `source`.
- **No fail-closed gate on tool availability.** `build_mcp_connections` (dynamic-agents) wired up every enabled server regardless of whether AgentGateway had actually confirmed the route, so a server mid seed-to-sync gap could be handed to an agent as a callable tool that would just 404 once invoked. It now skips servers that declare `agentgateway_target_endpoint` but are not yet `agentgateway_discovered` -- no confirmed route, no tool.
- **UI now shows "Waiting for sync"** (distinct from generic "Not scanned") and greys out the row for any AgentGateway-routed server that hasn't been confirmed live yet. A successful probe still overrides this immediately.

All three checks key off `agentgateway_target_endpoint` presence, not `source === "agentgateway"`, so the behavior is uniform across every gitops-configured AgentGateway-routed server.

## Behavior

- **Before**: After a restart, all MCP servers show "Not scanned" for up to ~8 minutes, and a mid-gap tool call would 404 against AgentGateway's not-yet-programmed route.
- **After**: AgentGateway routes already present in the live route table are restored to MongoDB immediately on startup. Any server still not confirmed (e.g. AgentGateway briefly unreachable) shows "Waiting for sync" in the UI and is withheld from dynamic-agent tool wiring until confirmed -- fail-closed instead of silently 404ing.

## Test plan

- [x] `uv run pytest` on `dynamic_agents` mcp-related tests (72 passed) plus the new regression test for the skip path
- [x] `npm test` on the affected UI suites (104 passed across 13 suites)
- [x] `tsc --noEmit` / `eslint` / `ruff check` clean on all changed files
- [ ] Restart caipe-ui pod (`kubectl rollout restart deployment <caipe-ui>`) in a live cluster and confirm MCP servers with agentgateway routes appear correctly without clicking "Repair AgentGateway"
- [ ] Confirm startup logs show `[seed-config] AgentGateway sync on startup: ...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
