### PR TITLE
feat(rbac): add MCP server team-sharing UI and enforce caller-tool check

### DIFF
--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -262,7 +262,7 @@ function HeroSection() {
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
                   {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-                  {'    --version 0.5.61 -f your-values.yaml'}
+                  {'    --version 0.5.62 -f your-values.yaml'}
                 </code>
               </pre>
             </div>
@@ -417,7 +417,7 @@ function QuickStartSection() {
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
               {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
-              {'    --version 0.5.61 -f your-values.yaml'}
+              {'    --version 0.5.62 -f your-values.yaml'}
             </code>
           </pre>
         </div>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.62"
+version = "0.5.62-dev.1"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/mcp-credential-editor.spec.ts
+++ b/ui/e2e/rbac/mcp-credential-editor.spec.ts
@@ -195,6 +195,83 @@ test.describe("RBAC e2e — MCP credential editor", () => {
     await expect(page.getByText("Preview ghp_...team")).toBeVisible();
   });
 
+  test("loads caller-visible teams and persists MCP server team sharing", async ({ page }) => {
+    const sharingWrites: string[][] = [];
+    let callerTeamsRequests = 0;
+
+    await installMcpBrowserMocks(page, {
+      servers: [JIRA_AGENTGATEWAY_SERVER],
+      providerConnections: [
+        {
+          id: "conn-atlassian",
+          connectorId: "atlassian-connector",
+          provider: "atlassian",
+          status: "connected",
+        },
+      ],
+      oauthConnectors: [
+        {
+          id: "atlassian-connector",
+          name: "Atlassian Cloud",
+          provider: "atlassian",
+        },
+      ],
+    });
+
+    await page.route("**/api/mcp-servers/jira/sharing", async (route) => {
+      if (route.request().method() === "GET") {
+        await route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ success: true, data: { teamSlugs: ["platform-team"] } }),
+        });
+        return;
+      }
+
+      if (route.request().method() === "PUT") {
+        const body = route.request().postDataJSON() as { teamSlugs?: string[] };
+        sharingWrites.push(body.teamSlugs ?? []);
+        await route.fulfill({
+          contentType: "application/json",
+          body: JSON.stringify({ success: true, data: { teamSlugs: body.teamSlugs ?? [] } }),
+        });
+        return;
+      }
+
+      await route.fulfill({ status: 405 });
+    });
+
+    await page.route("**/api/dynamic-agents/teams", async (route) => {
+      callerTeamsRequests += 1;
+      await route.fulfill({
+        contentType: "application/json",
+        body: JSON.stringify({
+          success: true,
+          data: [
+            { slug: "platform-team", name: "Platform Team" },
+            { slug: "observability-team", name: "Observability Team" },
+          ],
+        }),
+      });
+    });
+
+    await gotoMcpServersTab(page);
+    await openMcpServerEditor(page, "Jira");
+
+    const teamPicker = page.getByRole("button", { name: "Add a team…" });
+    await expect(teamPicker).toContainText("Platform Team");
+    await expect.poll(() => callerTeamsRequests).toBe(1);
+
+    await teamPicker.click();
+    await page.getByLabel("Search teams...").fill("observability");
+    await page
+      .getByRole("option", { name: /Observability Team.*team:observability-team/i })
+      .click();
+    await expect(teamPicker).toContainText("Observability Team");
+
+    await page.getByRole("button", { name: "Save Changes" }).click();
+    await expect.poll(() => sharingWrites).toEqual([["platform-team", "observability-team"]]);
+  });
+
   test("hides credential removal and save actions in read-only MCP server view", async ({ page }) => {
     await installMcpBrowserMocks(page, {
       servers: [

--- a/ui/src/app/api/mcp-servers/[id]/sharing/route.ts
+++ b/ui/src/app/api/mcp-servers/[id]/sharing/route.ts
@@ -1,0 +1,120 @@
+/**
+ * GET  /api/mcp-servers/[id]/sharing  — list teams with caller access
+ * PUT  /api/mcp-servers/[id]/sharing  — replace team access set
+ *
+ * Team access is modelled as `team:<slug>#member caller tool:<serverId>/*`
+ * OpenFGA tuples. Both reads and writes go through the same helpers used
+ * by the team-resources route so the tuple shape stays consistent.
+ */
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { getCollection } from "@/lib/mongodb";
+import { buildTeamResourceTupleDiff, readOpenFgaTuples } from "@/lib/rbac/openfga";
+import { requireResourcePermission } from "@/lib/rbac/resource-authz";
+import { reconcileTupleDiff } from "@/lib/authz";
+import type { Team } from "@/types/teams";
+import type { NextRequest } from "next/server";
+
+type RouteContext = { params: Promise<{ id: string }> };
+
+async function listSharingTeamSlugs(serverId: string): Promise<string[]> {
+  const slugs = new Set<string>();
+  let continuationToken: string | undefined;
+  do {
+    const page = await readOpenFgaTuples({
+      tuple: { object: `tool:${serverId}/*`, relation: "caller" },
+      continuationToken,
+    });
+    for (const { key } of page.tuples) {
+      const match = /^team:([^#]+)#member$/.exec(key.user);
+      if (match?.[1]) slugs.add(match[1]);
+    }
+    continuationToken = page.continuationToken;
+  } while (continuationToken);
+  return [...slugs];
+}
+
+export const GET = withErrorHandler(async (req: NextRequest, { params }: RouteContext) => {
+  const { id: serverId } = await params;
+  await getAuthFromBearerOrSession(req);
+
+  const mcpCol = await getCollection("mcp_servers");
+  const server = await mcpCol.findOne({ _id: serverId } as never);
+  if (!server) throw new ApiError("MCP server not found", 404);
+
+  const currentSlugs = await listSharingTeamSlugs(serverId);
+
+  const teamsCol = await getCollection<Team>("teams");
+  const teams = await teamsCol
+    .find({ slug: { $in: currentSlugs } } as never)
+    .project({ _id: 1, name: 1, slug: 1 })
+    .toArray();
+
+  return successResponse({ teams, teamSlugs: currentSlugs });
+});
+
+export const PUT = withErrorHandler(async (req: NextRequest, { params }: RouteContext) => {
+  const { id: serverId } = await params;
+  const { session, user } = await getAuthFromBearerOrSession(req);
+
+  await requireResourcePermission(session, {
+    type: "mcp_server" as const,
+    id: serverId,
+    action: "manage" as const,
+  });
+
+  const body = (await req.json()) as { teamSlugs?: unknown };
+  const nextSlugs: string[] = Array.isArray(body.teamSlugs)
+    ? body.teamSlugs.filter((s): s is string => typeof s === "string" && s.trim().length > 0)
+    : [];
+
+  const currentSlugs = await listSharingTeamSlugs(serverId);
+  const currentSet = new Set(currentSlugs);
+  const nextSet = new Set(nextSlugs);
+
+  const added = nextSlugs.filter((s) => !currentSet.has(s));
+  const removed = currentSlugs.filter((s) => !nextSet.has(s));
+
+  const toolRef = `${serverId}/*`;
+  const ctx = { caller: { type: "user" as const, id: session.sub! }, source: "mcp_server_sharing" };
+
+  await Promise.all([
+    ...added.map((slug) =>
+      reconcileTupleDiff(
+        buildTeamResourceTupleDiff({
+          teamSlug: slug,
+          agents: { added: [], removed: [] },
+          agentAdmins: { added: [], removed: [] },
+          tools: { added: [toolRef], removed: [] },
+          toolWildcard: { added: false, removed: false },
+          allMcpServerIds: [serverId],
+        }),
+        ctx,
+      )
+    ),
+    ...removed.map((slug) =>
+      reconcileTupleDiff(
+        buildTeamResourceTupleDiff({
+          teamSlug: slug,
+          agents: { added: [], removed: [] },
+          agentAdmins: { added: [], removed: [] },
+          tools: { added: [], removed: [toolRef] },
+          toolWildcard: { added: false, removed: false },
+          allMcpServerIds: [serverId],
+        }),
+        ctx,
+      )
+    ),
+  ]);
+
+  console.log(
+    `[MCP Sharing] PUT server=${serverId} added=${added.length} removed=${removed.length} by=${user.email}`,
+  );
+
+  return successResponse({ teamSlugs: nextSlugs });
+});

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -338,6 +338,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
     }
     void loadSharing();
     return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isEditing, server?._id]);
 
   const handleAddArg = () => {

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { TeamPicker,type TeamPickerOption } from "@/components/ui/team-picker";
+import { TeamPicker, TeamMultiPicker, type TeamPickerOption } from "@/components/ui/team-picker";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
@@ -225,6 +225,10 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
   } | null>(null);
   const [credentialProbeLoading, setCredentialProbeLoading] = React.useState(false);
 
+  // Team sharing state (edit mode only)
+  const [sharedTeamSlugs, setSharedTeamSlugs] = React.useState<string[]>([]);
+  const [allTeamOptions, setAllTeamOptions] = React.useState<TeamPickerOption[]>([]);
+
   // Arg input state
   const [newArg, setNewArg] = React.useState("");
 
@@ -309,6 +313,32 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
       cancelled = true;
     };
   }, []);
+
+  // Load current team sharing + full team list (edit mode only)
+  React.useEffect(() => {
+    if (!isEditing || !server?._id) return;
+    let cancelled = false;
+    async function loadSharing() {
+      const [sharingRes, teamsRes] = await Promise.allSettled([
+        fetch(`/api/mcp-servers/${server!._id}/sharing`),
+        fetch("/api/dynamic-agents/teams"),
+      ]);
+      if (cancelled) return;
+      if (sharingRes.status === "fulfilled" && sharingRes.value.ok) {
+        const json = (await sharingRes.value.json()) as { data?: { teamSlugs?: string[] } };
+        setSharedTeamSlugs(json.data?.teamSlugs ?? []);
+      }
+      if (teamsRes.status === "fulfilled" && teamsRes.value.ok) {
+        const json = (await teamsRes.value.json()) as { data?: { teams?: { slug: string; name: string }[] } };
+        const raw = json.data?.teams ?? (Array.isArray(json.data) ? json.data as { slug: string; name: string }[] : []);
+        setAllTeamOptions(
+          raw.map((t) => ({ slug: t.slug, name: t.name ?? t.slug }))
+        );
+      }
+    }
+    void loadSharing();
+    return () => { cancelled = true; };
+  }, [isEditing, server?._id]);
 
   const handleAddArg = () => {
     if (newArg.trim()) {
@@ -554,6 +584,13 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
         if (!data.success) {
           throw new Error(data.error || "Failed to update server");
         }
+
+        // Sync team sharing (best-effort; failures don't block save)
+        await fetch(`/api/mcp-servers/${server._id}/sharing`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ teamSlugs: sharedTeamSlugs }),
+        }).catch(() => {});
       } else {
         const normalizedCredentialSources = credentialSources
           .map((source) => normalizedCredentialSource(source, providerConnectionOptions))
@@ -1272,6 +1309,24 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
                     ))}
                 </p>
               )}
+            </div>
+          )}
+
+          {/* Team Access (edit mode only) */}
+          {isEditing && (
+            <div className="space-y-3">
+              <h3 className="text-sm font-medium">Team Access</h3>
+              <p className="text-xs text-muted-foreground">
+                Teams listed here can assign this server&apos;s tools to their agents.
+                With caller-tool enforcement enabled, members must hold this grant to invoke tools at runtime.
+              </p>
+              <TeamMultiPicker
+                options={allTeamOptions}
+                selected={sharedTeamSlugs}
+                onChange={setSharedTeamSlugs}
+                disabled={readOnly}
+                placeholder="Add a team…"
+              />
             </div>
           )}
 

--- a/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
@@ -64,6 +64,18 @@ describe("MCPServersTab AgentGateway repair", () => {
           json: async () => ({ success: true, data: jiraServer }),
         } as Response);
       }
+      if (url === "/api/mcp-servers/jira/sharing") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, data: { teamSlugs: [] } }),
+        } as Response);
+      }
+      if (url === "/api/dynamic-agents/teams") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, data: [] }),
+        } as Response);
+      }
       if (url === "/api/mcp-servers/agentgateway/sync" && init?.method === "POST") {
         return Promise.resolve({
           json: async () => ({
@@ -518,6 +530,18 @@ describe("MCPServersTab AgentGateway repair", () => {
       if (typeof url === "string" && url.startsWith("/api/mcp-servers?id=") && init?.method === "PUT") {
         putCalls.push(url);
       }
+      if (url === "/api/mcp-servers/jira/sharing") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, data: { teamSlugs: [] } }),
+        } as Response);
+      }
+      if (url === "/api/dynamic-agents/teams") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, data: [] }),
+        } as Response);
+      }
       throw new Error(`Unexpected fetch: ${url}`);
     }) as unknown as typeof fetch;
 
@@ -543,6 +567,18 @@ describe("MCPServersTab AgentGateway repair", () => {
               capabilities: listCapabilities,
             },
           }),
+        } as Response);
+      }
+      if (url === "/api/mcp-servers/jira/sharing") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, data: { teamSlugs: [] } }),
+        } as Response);
+      }
+      if (url === "/api/dynamic-agents/teams") {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ success: true, data: [] }),
         } as Response);
       }
       if (typeof url === "string" && url.startsWith("/api/mcp-servers?id=jira") && init?.method === "DELETE") {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.62"
+version = "0.5.62.dev1"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
Fixes #2266.

- Add `GET`/`PUT /api/mcp-servers/[id]/sharing` to read and update which teams have caller access to an MCP server's tools; writes the full OpenFGA tuple set per team (`mcp_server` reader/user/invoker/manager + `tool:<id>/*` caller) via `buildTeamResourceTupleDiff`.
- Add a Team Access section to `MCPServerEditor` (edit mode only) with `TeamMultiPicker`; loads current sharing on mount, persists on Save Changes alongside the server config update.
- `CAIPE_CALLER_TOOL_CHECK_ENABLED` (existing operator-configurable flag) now has a real UI path to grant the access it enforces: with it on, `openfga-authz-bridge` requires user-can-use-agent AND agent-can-call-tool AND user-can-call-tool at tool-call time, closing a confused-deputy gap where a user could invoke a tool through an agent they had no direct grant for.

## Notes
- Cherry-picked from an older local branch (`oidc-team-sharing`) onto current `main`; that branch had drifted significantly and bundled several other fixes that are already merged separately (#2262, #2282) or still-open under a different issue (#2264 — not touched here, its root cause is unrelated to this commit).
- One merge conflict in `MCPServerEditor.tsx` against the "Test Connection" section added since (#2263) — resolved by keeping both sections (Test Connection, then Team Access).
- Fixed a pre-existing `react-hooks/exhaustive-deps` lint error in the team-sharing load effect (intentionally keys off `server?._id`, matching the existing pattern elsewhere in this file).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — clean
- [x] `npx jest src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx` — 13/13 pass
- [x] `npm run build` — production build succeeds, `/api/mcp-servers/[id]/sharing` registers as a route
- [ ] Manual: open an existing MCP server, add/remove a team under Team Access, Save, confirm OpenFGA tuples update and the team's members gain/lose tool-call access