### PR TITLE
fix(ui): remove unsafe AgentGateway repair action

### DIFF
--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -47,10 +47,6 @@ const DEFAULT_ROW_PERMISSIONS = {
   can_discover: false,
 } as const;
 
-const DEFAULT_LIST_CAPABILITIES = {
-  repair_agentgateway: false,
-} as const;
-
 interface ProbeResult {
   server_id: string;
   loading: boolean;
@@ -59,14 +55,6 @@ interface ProbeResult {
 }
 
 type ToolHealthStatus = "healthy" | "degraded" | "checking" | "unknown" | "disabled";
-
-interface AgentGatewayMigrationWarning {
-  id: string;
-  endpoint: string;
-  target_endpoint?: string;
-  existing_endpoint?: string;
-  message: string;
-}
 
 interface FetchServersOptions {
   showLoading?: boolean;
@@ -202,7 +190,6 @@ export function MCPServersTab({
   onSelectedServerChange,
 }: MCPServersTabProps = {}) {
   const [servers, setServers] = React.useState<MCPServerConfigWithPermissions[]>([]);
-  const [listCapabilities, setListCapabilities] = React.useState(DEFAULT_LIST_CAPABILITIES);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [editingServer, setEditingServer] = React.useState<MCPServerConfigWithPermissions | null>(null);
@@ -214,12 +201,6 @@ export function MCPServersTab({
   const [showCatalog, setShowCatalog] = React.useState(false);
   const [catalogInitialValues, setCatalogInitialValues] = React.useState<MCPServerInitialValues | null>(null);
   const [probeResults, setProbeResults] = React.useState<Record<string, ProbeResult>>({});
-  const [agentGatewayMigrationWarnings, setAgentGatewayMigrationWarnings] = React.useState<
-    AgentGatewayMigrationWarning[]
-  >([]);
-  const [agentGatewaySyncing, setAgentGatewaySyncing] = React.useState(false);
-  const [agentGatewayMessage, setAgentGatewayMessage] = React.useState<string | null>(null);
-  const [agentGatewayError, setAgentGatewayError] = React.useState<string | null>(null);
   const [testingServer, setTestingServer] = React.useState<MCPServerConfigWithPermissions | null>(null);
   const [pendingDeleteServerId, setPendingDeleteServerId] = React.useState<string | null>(null);
   const [deletingServerId, setDeletingServerId] = React.useState<string | null>(null);
@@ -246,7 +227,6 @@ export function MCPServersTab({
             permissions: server.permissions ?? DEFAULT_ROW_PERMISSIONS,
           })),
         );
-        setListCapabilities(data.data.capabilities ?? DEFAULT_LIST_CAPABILITIES);
         setError(null);
       } else {
         if (!preserveListOnError) {
@@ -463,38 +443,6 @@ export function MCPServersTab({
     }
   };
 
-  const handleSyncAgentGateway = async () => {
-    setAgentGatewaySyncing(true);
-    setAgentGatewayError(null);
-    setAgentGatewayMessage(null);
-    setAgentGatewayMigrationWarnings([]);
-    try {
-      const response = await fetch("/api/mcp-servers/agentgateway/sync", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      const data = await response.json();
-      if (!data.success) {
-        throw new Error(data.error || "Failed to sync AgentGateway MCP servers");
-      }
-      const addedCount = data.data.added?.length || 0;
-      const migratedCount = data.data.migrated?.length || 0;
-      const refreshedCount = data.data.refreshed?.length || 0;
-      setAgentGatewayMessage(
-        `Added ${addedCount}, migrated ${migratedCount}, and refreshed ${refreshedCount} MCP server${
-          addedCount + migratedCount + refreshedCount === 1 ? "" : "s"
-        } from AgentGateway.`,
-      );
-      setAgentGatewayMigrationWarnings(data.data.migration_warnings || []);
-      await fetchServers();
-    } catch (err: unknown) {
-      setAgentGatewayError(errorMessage(err, "Failed to sync AgentGateway MCP servers"));
-    } finally {
-      setAgentGatewaySyncing(false);
-    }
-  };
-
   /**
    * Export server configuration as YAML file
    */
@@ -640,22 +588,6 @@ export function MCPServersTab({
             </CardDescription>
           </div>
           <div className="flex items-center gap-2">
-            {listCapabilities.repair_agentgateway && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleSyncAgentGateway}
-                disabled={agentGatewaySyncing}
-                title="Admin repair: re-import built-in AgentGateway MCP routes and repair stale registrations"
-              >
-                {agentGatewaySyncing ? (
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                ) : (
-                  <Globe className="h-4 w-4 mr-2" />
-                )}
-                Repair AgentGateway
-              </Button>
-            )}
             <Button variant="outline" size="sm" onClick={() => fetchServers()} disabled={loading}>
               <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
               Refresh
@@ -668,56 +600,6 @@ export function MCPServersTab({
         </div>
       </CardHeader>
       <CardContent>
-        {agentGatewayError && (
-          <div className="mb-4 flex items-start gap-2 rounded-lg bg-destructive/10 border border-destructive/30 p-3">
-            <AlertCircle className="h-4 w-4 text-destructive mt-0.5 flex-shrink-0" />
-            <p className="text-sm text-destructive">{agentGatewayError}</p>
-          </div>
-        )}
-
-        {agentGatewayMessage && (
-          <div className="mb-4 flex items-start gap-2 rounded-lg bg-green-500/10 border border-green-500/30 p-3">
-            <CheckCircle2 className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
-            <p className="text-sm text-green-700 dark:text-green-400">{agentGatewayMessage}</p>
-          </div>
-        )}
-
-        {agentGatewayMigrationWarnings.length > 0 && (
-          <div className="mb-6 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
-            <div className="flex items-start gap-2">
-              <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
-              <div className="space-y-3">
-                <div>
-                  <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-300">
-                    {agentGatewayMigrationWarnings.length} legacy MCP server
-                    {agentGatewayMigrationWarnings.length === 1 ? "" : "s"} conflict
-                    {agentGatewayMigrationWarnings.length === 1 ? "s" : ""} with AgentGateway targets.
-                  </h3>
-                  <p className="text-sm text-amber-700 dark:text-amber-400">
-                    Remove or rename the legacy MCP server to let AgentGateway manage it. Use the row actions below to
-                    delete the legacy entry after you confirm it is no longer needed.
-                  </p>
-                </div>
-                <div className="space-y-2">
-                  {agentGatewayMigrationWarnings.map((warning) => (
-                    <div key={warning.id} className="rounded-md border border-amber-500/20 bg-background/70 p-3">
-                      <div className="font-mono text-xs font-semibold">{warning.id}</div>
-                      {warning.existing_endpoint && (
-                        <p className="text-xs text-muted-foreground">
-                          Current: {warning.existing_endpoint}
-                        </p>
-                      )}
-                      <p className="text-xs text-muted-foreground">
-                        AgentGateway: {warning.target_endpoint || warning.endpoint}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
         {loading ? (
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
@@ -41,7 +41,7 @@ const agentGatewayRagServer = {
 
 const listCapabilities = { repair_agentgateway: true };
 
-describe("MCPServersTab AgentGateway repair", () => {
+describe("MCPServersTab", () => {
   let serverItems: Record<string, unknown>[];
 
   beforeEach(() => {
@@ -62,28 +62,6 @@ describe("MCPServersTab AgentGateway repair", () => {
       if (url === "/api/mcp-servers?id=jira") {
         return Promise.resolve({
           json: async () => ({ success: true, data: jiraServer }),
-        } as Response);
-      }
-      if (url === "/api/mcp-servers/agentgateway/sync" && init?.method === "POST") {
-        return Promise.resolve({
-          json: async () => ({
-            success: true,
-            data: {
-              added: ["rag"],
-              skipped: [{ id: "jira", reason: "conflict" }],
-              summary: { added: 1, existing: 0, conflicts: 1, skipped: 1 },
-              migration_warnings: [
-                {
-                  id: "jira",
-                  endpoint: "http://agentgateway:4000/mcp",
-                  target_endpoint: "http://mcp-jira:8000/mcp",
-                  existing_endpoint: "http://legacy-jira:8000/mcp",
-                  message:
-                    "Legacy MCP server conflicts with AgentGateway target \"jira\". Remove or rename the legacy MCP server to let AgentGateway manage it.",
-                },
-              ],
-            },
-          }),
         } as Response);
       }
       if (url === "/api/mcp-servers/probe?id=jira" && init?.method === "POST") {
@@ -146,34 +124,15 @@ describe("MCPServersTab AgentGateway repair", () => {
     }) as unknown as typeof fetch;
   });
 
-  it("repairs AgentGateway MCP server registrations and shows migration conflicts", async () => {
+  it("does not expose the unsafe AgentGateway repair action", async () => {
     render(<MCPServersTab />);
 
     await screen.findByText("Jira");
-    fireEvent.click(screen.getByRole("button", { name: /Repair AgentGateway/i }));
-
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        "/api/mcp-servers/agentgateway/sync",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({}),
-        }),
-      );
-    });
-
-    // Message format changed to break down counts:
-    //   "Added 1, migrated 0, and refreshed 0 MCP server from AgentGateway."
-    expect(
-      await screen.findByText(/Added 1, migrated 0, and refreshed 0 MCP server/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/1 legacy MCP server conflicts with AgentGateway targets/i),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Remove or rename the legacy MCP server/i)).toBeInTheDocument();
-    expect(screen.getAllByText("jira").length).toBeGreaterThan(0);
-    expect(screen.getByText(/Current: http:\/\/legacy-jira:8000\/mcp/i)).toBeInTheDocument();
-    expect(screen.getByText(/AgentGateway: http:\/\/mcp-jira:8000\/mcp/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Repair AgentGateway/i })).not.toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "/api/mcp-servers/agentgateway/sync",
+      expect.anything(),
+    );
   });
 
   it("marks AgentGateway-registered MCP servers in the table", async () => {
@@ -384,7 +343,7 @@ describe("MCPServersTab AgentGateway repair", () => {
     jest.useRealTimers();
   });
 
-  it("hides repair, probe, test, and delete actions when row permissions deny them", async () => {
+  it("hides probe, test, and delete actions when row permissions deny them", async () => {
     serverItems = [
       {
         ...jiraServer,
@@ -423,11 +382,11 @@ describe("MCPServersTab AgentGateway repair", () => {
     expect(await screen.findByText("Add MCP Server")).toBeInTheDocument();
   });
 
-  it("shows repair, probe, test, and delete when list permissions allow them", async () => {
+  it("shows probe, test, and delete when list permissions allow them", async () => {
     render(<MCPServersTab />);
 
     await screen.findByText("Jira");
-    expect(screen.getByRole("button", { name: /Repair AgentGateway/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Repair AgentGateway/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Probe tools for Jira/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /test mcp tools for jira/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Delete Jira/i })).toBeInTheDocument();


### PR DESCRIPTION
## What changed

- Removes the **Repair AgentGateway** button from the MCP Servers UI.
- Removes the client-side sync mutation, result banners, and migration-conflict state used only by that action.
- Keeps the authenticated backend repair endpoint available for controlled remediation.
- Adds a regression assertion that the button remains hidden even when the API advertises the repair capability.

## Why

The current repair path does not fully refresh existing MongoDB MCP server documents from GitOps and preserves legacy `credential_sources` during migration. In production this retains stale aliases and authentication metadata, which the config bridge then re-emits into AgentGateway. Removing the browser-exposed action prevents administrators from accidentally mutating a healthy gateway configuration while the reconciliation implementation is corrected.

## Validation

- `npm test -- --runInBand src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx` — 17 tests passed.
- `npx eslint src/components/dynamic-agents/MCPServersTab.tsx src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx` — passed.