### PR TITLE
fix(chat): optimize conversation sharing authorization and search

### DIFF
--- a/ui/src/app/api/__tests__/chat-conversations-remaining-rbac.test.ts
+++ b/ui/src/app/api/__tests__/chat-conversations-remaining-rbac.test.ts
@@ -285,9 +285,19 @@ describe("remaining conversation routes use OpenFGA instead of legacy owner/team
   it("share updates accept OpenFGA share permission without legacy owner equality", async () => {
     const conversations = collectionWithItems([conversation()]);
     const sharingAccess = { find: jest.fn(), insertMany: jest.fn(), updateOne: jest.fn() };
+    const users = {
+      find: jest.fn().mockReturnValue({
+        project: jest.fn().mockReturnValue({
+          toArray: jest.fn().mockResolvedValue([
+            { email: "viewer@example.com", keycloak_sub: "viewer-sub" },
+          ]),
+        }),
+      }),
+    };
     mockGetCollection.mockImplementation(async (name: string) => {
       if (name === "conversations") return conversations;
       if (name === "sharing_access") return sharingAccess;
+      if (name === "users") return users;
       throw new Error(`unexpected collection ${name}`);
     });
     const { POST } = await import("../chat/conversations/[id]/share/route");

--- a/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
@@ -115,6 +115,7 @@ function createMockCollection() {
     insertOne: jest.fn().mockResolvedValue({ insertedId: new ObjectId() }),
     insertMany: jest.fn().mockResolvedValue({ insertedCount: 0 }),
     updateOne: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
+    updateMany: jest.fn().mockResolvedValue({ modifiedCount: 1 }),
     countDocuments: jest.fn().mockResolvedValue(0),
   };
 }
@@ -149,6 +150,19 @@ function makeConversation(overrides: unknown = {}) {
   };
 }
 
+function mockShareableUsers(
+  users: Array<{ email: string; keycloak_sub?: string; metadata?: { keycloak_sub?: string } }>,
+) {
+  const usersCol = createMockCollection();
+  usersCol.find.mockReturnValue({
+    project: jest.fn().mockReturnValue({
+      toArray: jest.fn().mockResolvedValue(users),
+    }),
+  });
+  mockCollections['users'] = usersCol;
+  return usersCol;
+}
+
 // ============================================================================
 // Import after mocks
 // ============================================================================
@@ -161,6 +175,7 @@ import { requireConversationAccess } from '@/lib/api-middleware';
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 0, deletes: 0 });
   Object.keys(mockCollections).forEach((key) => delete mockCollections[key]);
 });
 
@@ -474,6 +489,7 @@ describe('PATCH /api/chat/conversations/[id]/share — permission updates', () =
 
     const sharingAccessCol = createMockCollection();
     mockCollections['sharing_access'] = sharingAccessCol;
+    mockShareableUsers([{ email: VIEWER_EMAIL, keycloak_sub: 'viewer-sub' }]);
 
     mockGetServerSession.mockResolvedValue({
       user: { email: OWNER_EMAIL, name: 'Owner' },
@@ -511,6 +527,9 @@ describe('PATCH /api/chat/conversations/[id]/share — permission updates', () =
       .mockResolvedValueOnce(conv)
       .mockResolvedValue({ ...conv });
     mockCollections['conversations'] = convsCol;
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue({ _id: TEAM_ID, slug: TEAM_ID, name: 'Test Team' });
+    mockCollections['teams'] = teamsCol;
 
     mockGetServerSession.mockResolvedValue({
       user: { email: OWNER_EMAIL, name: 'Owner' },
@@ -595,6 +614,7 @@ describe('POST /api/chat/conversations/[id]/share — permission storage', () =>
 
     const sharingAccessCol = createMockCollection();
     mockCollections['sharing_access'] = sharingAccessCol;
+    mockShareableUsers([{ email: VIEWER_EMAIL, keycloak_sub: 'viewer-sub' }]);
 
     mockGetServerSession.mockResolvedValue({
       user: { email: OWNER_EMAIL, name: 'Owner' },
@@ -671,7 +691,74 @@ describe('POST /api/chat/conversations/[id]/share — permission storage', () =>
     });
   });
 
-  it('keeps Mongo direct-share fallback when a direct-share recipient is not provisioned', async () => {
+  it('does not persist a share when the OpenFGA grant fails', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [], shared_with_teams: [] },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+    const sharingAccessCol = createMockCollection();
+    mockCollections['sharing_access'] = sharingAccessCol;
+    mockShareableUsers([{ email: VIEWER_EMAIL, keycloak_sub: 'viewer-sub' }]);
+    mockWriteOpenFgaTuples.mockRejectedValueOnce(new Error('OpenFGA unavailable'));
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
+    });
+
+    const { POST } = await import('@/app/api/chat/conversations/[id]/share/route');
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'POST',
+      body: JSON.stringify({ user_emails: [VIEWER_EMAIL], permission: 'view' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(500);
+    expect(sharingAccessCol.insertMany).not.toHaveBeenCalled();
+    expect(convsCol.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('prevalidates all recipients before applying a mixed user and team share', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [], shared_with_teams: [] },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValue(conv);
+    mockCollections['conversations'] = convsCol;
+    const sharingAccessCol = createMockCollection();
+    mockCollections['sharing_access'] = sharingAccessCol;
+    mockShareableUsers([{ email: VIEWER_EMAIL, keycloak_sub: 'viewer-sub' }]);
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue(null);
+    mockCollections['teams'] = teamsCol;
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
+    });
+
+    const { POST } = await import('@/app/api/chat/conversations/[id]/share/route');
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'POST',
+      body: JSON.stringify({
+        user_emails: [VIEWER_EMAIL],
+        team_ids: ['missing-team'],
+        permission: 'view',
+      }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await POST(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(404);
+    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
+    expect(sharingAccessCol.insertMany).not.toHaveBeenCalled();
+    expect(convsCol.updateOne).not.toHaveBeenCalled();
+  });
+
+  it('rejects a direct-share recipient who is not provisioned in Keycloak', async () => {
     const conv = makeConversation({
       sharing: { shared_with: [], shared_with_teams: [] },
     });
@@ -710,8 +797,12 @@ describe('POST /api/chat/conversations/[id]/share — permission storage', () =>
 
     const res = await POST(req, { params: Promise.resolve({ id: conv._id }) });
 
-    expect(res.status).toBe(200);
-    expect(sharingAccessCol.insertMany).toHaveBeenCalled();
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual(expect.objectContaining({
+      code: 'SHARE_RECIPIENT_NOT_PROVISIONED',
+    }));
+    expect(sharingAccessCol.insertMany).not.toHaveBeenCalled();
+    expect(convsCol.updateOne).not.toHaveBeenCalled();
     expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
   });
 
@@ -803,5 +894,137 @@ describe('POST /api/chat/conversations/[id]/share — permission storage', () =>
       ]),
       deletes: [],
     });
+  });
+});
+
+describe('DELETE /api/chat/conversations/[id]/share — access revocation', () => {
+  it('revokes direct user tuples and removes Mongo sharing state', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [VIEWER_EMAIL], shared_with_teams: [] },
+    });
+    const updated = makeConversation({
+      sharing: { shared_with: [], shared_with_teams: [] },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne
+      .mockResolvedValueOnce(conv)
+      .mockResolvedValue(updated);
+    mockCollections['conversations'] = convsCol;
+    const sharingAccessCol = createMockCollection();
+    mockCollections['sharing_access'] = sharingAccessCol;
+    mockShareableUsers([{ email: VIEWER_EMAIL, keycloak_sub: 'viewer-sub' }]);
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
+    });
+
+    const { DELETE } = await import('@/app/api/chat/conversations/[id]/share/route');
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'DELETE',
+      body: JSON.stringify({ email: VIEWER_EMAIL }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await DELETE(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [],
+      deletes: expect.arrayContaining([
+        { user: 'user:viewer-sub', relation: 'reader', object: `conversation:${conv._id}` },
+        { user: 'user:viewer-sub', relation: 'writer', object: `conversation:${conv._id}` },
+      ]),
+    });
+    expect(sharingAccessCol.updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        conversation_id: conv._id,
+        granted_to: { $in: [VIEWER_EMAIL] },
+        revoked_at: null,
+      }),
+      { $set: { revoked_at: expect.any(Date), revoked_by: OWNER_EMAIL } },
+    );
+    expect(convsCol.updateOne).toHaveBeenCalledWith(
+      { _id: conv._id },
+      { $set: { 'sharing.shared_with': [] } },
+    );
+  });
+
+  it('cleans up a legacy unprovisioned direct share without requiring a tuple', async () => {
+    const conv = makeConversation({
+      sharing: { shared_with: [VIEWER_EMAIL], shared_with_teams: [] },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne
+      .mockResolvedValueOnce(conv)
+      .mockResolvedValue(makeConversation());
+    mockCollections['conversations'] = convsCol;
+    mockCollections['sharing_access'] = createMockCollection();
+    mockShareableUsers([]);
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
+    });
+
+    const { DELETE } = await import('@/app/api/chat/conversations/[id]/share/route');
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'DELETE',
+      body: JSON.stringify({ email: VIEWER_EMAIL }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await DELETE(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteOpenFgaTuples).not.toHaveBeenCalled();
+    expect(convsCol.updateOne).toHaveBeenCalled();
+  });
+
+  it('revokes observed team reader and writer tuples', async () => {
+    const conv = makeConversation({
+      sharing: {
+        shared_with: [],
+        shared_with_teams: ['platform'],
+        team_permissions: { platform: 'comment' },
+      },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne
+      .mockResolvedValueOnce(conv)
+      .mockResolvedValue(makeConversation());
+    mockCollections['conversations'] = convsCol;
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue({ _id: new ObjectId(), slug: 'platform', name: 'Platform' });
+    mockCollections['teams'] = teamsCol;
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
+    });
+
+    const { DELETE } = await import('@/app/api/chat/conversations/[id]/share/route');
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'DELETE',
+      body: JSON.stringify({ team_id: 'platform' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await DELETE(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [],
+      deletes: expect.arrayContaining([
+        { user: 'team:platform#member', relation: 'reader', object: `conversation:${conv._id}` },
+        { user: 'team:platform#member', relation: 'writer', object: `conversation:${conv._id}` },
+      ]),
+    });
+    expect(convsCol.updateOne).toHaveBeenCalledWith(
+      { _id: conv._id },
+      {
+        $set: {
+          'sharing.shared_with_teams': [],
+          'sharing.team_permissions': {},
+        },
+      },
+    );
   });
 });

--- a/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
+++ b/ui/src/app/api/__tests__/chat-sharing-readonly.test.ts
@@ -551,6 +551,52 @@ describe('PATCH /api/chat/conversations/[id]/share — permission updates', () =
       { _id: conv._id },
       { $set: { 'sharing.team_permissions': { [TEAM_ID]: 'comment' } } }
     );
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: expect.arrayContaining([
+        { user: `team:${TEAM_ID}#member`, relation: 'reader', object: `conversation:${conv._id}` },
+        { user: `team:${TEAM_ID}#member`, relation: 'writer', object: `conversation:${conv._id}` },
+      ]),
+      deletes: [],
+    });
+  });
+
+  it('removes the team writer grant when changing permission to view', async () => {
+    const conv = makeConversation({
+      sharing: {
+        shared_with: [],
+        shared_with_teams: [TEAM_ID],
+        team_permissions: { [TEAM_ID]: 'comment' },
+      },
+    });
+    const convsCol = createMockCollection();
+    convsCol.findOne.mockResolvedValueOnce(conv).mockResolvedValue({ ...conv });
+    mockCollections['conversations'] = convsCol;
+    const teamsCol = createMockCollection();
+    teamsCol.findOne.mockResolvedValue({ _id: new ObjectId(TEAM_ID), name: 'Example Team' });
+    mockCollections['teams'] = teamsCol;
+    mockGetServerSession.mockResolvedValue({
+      user: { email: OWNER_EMAIL, name: 'Owner' },
+      sub: 'owner-sub',
+    });
+
+    const { PATCH } = await import('@/app/api/chat/conversations/[id]/share/route');
+    const req = new NextRequest(`http://localhost/api/chat/conversations/${TEST_CONV_ID}/share`, {
+      method: 'PATCH',
+      body: JSON.stringify({ team_id: TEAM_ID, permission: 'view' }),
+      headers: { 'Content-Type': 'application/json' },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ id: conv._id }) });
+
+    expect(res.status).toBe(200);
+    expect(mockWriteOpenFgaTuples).toHaveBeenCalledWith({
+      writes: [
+        { user: `team:${TEAM_ID}#member`, relation: 'reader', object: `conversation:${conv._id}` },
+      ],
+      deletes: [
+        { user: `team:${TEAM_ID}#member`, relation: 'writer', object: `conversation:${conv._id}` },
+      ],
+    });
   });
 
   it('rejects PATCH with invalid permission value', async () => {

--- a/ui/src/app/api/chat/conversations/[id]/share/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/share/route.ts
@@ -1,6 +1,6 @@
 // GET /api/chat/conversations/[id]/share - Get sharing info
 // POST /api/chat/conversations/[id]/share - Share conversation with users
-// PATCH / DELETE /api/chat/conversations/[id]/share - Update or revoke access
+// DELETE /api/chat/conversations/[id]/share - Revoke user or team access
 
 import {
 ApiError,
@@ -193,8 +193,9 @@ function teamConversationGrantDiff(
   const deletes: OpenFgaTupleKey[] = [];
   for (const team of resolvedTeams) {
     const user = `team:${team.subjectRef}#member`;
-    writes.push({ user, relation: 'reader', object: `conversation:${conversationId}` });
-    const writerTuple = { user, relation: 'writer', object: `conversation:${conversationId}` };
+    const object = `conversation:${conversationId}`;
+    writes.push({ user, relation: 'reader', object });
+    const writerTuple = { user, relation: 'writer', object };
     if (permission === 'comment') {
       writes.push(writerTuple);
     } else {
@@ -204,14 +205,18 @@ function teamConversationGrantDiff(
   return { writes, deletes };
 }
 
-async function writeTeamConversationGrantTuples(
+async function writeTeamConversationGrantTuplesBestEffort(
   conversationId: string,
   resolvedTeams: ResolvedTeamShare[],
   permission: SharePermission,
 ): Promise<void> {
   const diff = teamConversationGrantDiff(conversationId, resolvedTeams, permission);
   if (diff.writes.length === 0 && diff.deletes.length === 0) return;
-  await writeOpenFgaTuples(diff);
+  try {
+    await writeOpenFgaTuples(diff);
+  } catch (err) {
+    console.warn('[chat/share] Team conversation grant write failed (best-effort):', err);
+  }
 }
 
 // GET /api/chat/conversations/[id]/share
@@ -381,6 +386,7 @@ export const POST = withErrorHandler(async (
         permission,
       );
 
+      await writeTeamConversationGrantTuplesBestEffort(conversationId, resolvedTeams, permission);
     }
 
     if (disablesPublicSharing) {
@@ -456,20 +462,16 @@ export const PATCH = withErrorHandler(async (
 
     if (team_id) {
       const resolvedTeams = await resolveTeamShares([team_id]);
-      await writeTeamConversationGrantTuples(
-        conversationId,
-        resolvedTeams,
-        permission as SharePermission,
-      );
       const teamPerms = mergeTeamPermissions(
         conversation.sharing?.team_permissions,
         resolvedTeams,
-        permission as SharePermission,
+        permission,
       );
       await conversations.updateOne(
         { _id: conversationId },
         { $set: { 'sharing.team_permissions': teamPerms } }
       );
+      await writeTeamConversationGrantTuplesBestEffort(conversationId, resolvedTeams, permission);
     }
 
     const updated = await conversations.findOne({ _id: conversationId });

--- a/ui/src/app/api/chat/conversations/[id]/share/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/share/route.ts
@@ -1,6 +1,6 @@
 // GET /api/chat/conversations/[id]/share - Get sharing info
 // POST /api/chat/conversations/[id]/share - Share conversation with users
-// DELETE /api/chat/conversations/[id]/share/[userId] handled in separate file
+// PATCH / DELETE /api/chat/conversations/[id]/share - Update or revoke access
 
 import {
 ApiError,
@@ -13,7 +13,11 @@ withErrorHandler
 } from '@/lib/api-middleware';
 import { getCollection } from '@/lib/mongodb';
 import { requireConversationResourcePermission } from '@/lib/rbac/conversation-implicit-authz';
-import { writeOpenFgaTuples, type OpenFgaTupleKey } from '@/lib/rbac/openfga';
+import { writeOpenFgaTuples,type OpenFgaTupleKey } from '@/lib/rbac/openfga';
+import {
+stableKeycloakSubject,
+type ShareableUserDocument,
+} from '@/lib/rbac/shareable-users';
 import type { Conversation,ShareConversationRequest,SharingAccess } from '@/types/mongodb';
 import { ObjectId,type Document } from 'mongodb';
 import { NextRequest } from 'next/server';
@@ -30,14 +34,6 @@ interface ResolvedTeamShare {
   shareRef: string;
   subjectRef: string;
   aliases: string[];
-}
-
-interface UserShareDocument {
-  email?: string;
-  keycloak_sub?: string;
-  metadata?: {
-    keycloak_sub?: string;
-  };
 }
 
 interface ResolvedUserShare {
@@ -57,19 +53,11 @@ function uniqueEmails(values: string[]): string[] {
   return uniqueStrings(values.map(normalizedEmail));
 }
 
-function stableUserSubject(user: UserShareDocument): string | undefined {
-  const candidates = [
-    user.keycloak_sub,
-    user.metadata?.keycloak_sub,
-  ];
-  return candidates.find((candidate) => typeof candidate === 'string' && candidate.trim())?.trim();
-}
-
-async function resolveUserShares(emails: string[]): Promise<ResolvedUserShare[]> {
+async function lookupUserShares(emails: string[]): Promise<ResolvedUserShare[]> {
   const recipientEmails = uniqueEmails(emails);
   if (recipientEmails.length === 0) return [];
 
-  const users = await getCollection<UserShareDocument>('users');
+  const users = await getCollection<ShareableUserDocument>('users');
   const docs = await users
     .find({ email: { $in: recipientEmails } })
     .project({ email: 1, keycloak_sub: 1, 'metadata.keycloak_sub': 1 })
@@ -81,9 +69,24 @@ async function resolveUserShares(emails: string[]): Promise<ResolvedUserShare[]>
   );
 
   return recipientEmails.flatMap((email) => {
-    const subjectRef = stableUserSubject(docsByEmail.get(email) ?? {});
+    const subjectRef = stableKeycloakSubject(docsByEmail.get(email) ?? {});
     return subjectRef ? [{ email, subjectRef }] : [];
   });
+}
+
+async function resolveUserShares(emails: string[]): Promise<ResolvedUserShare[]> {
+  const recipientEmails = uniqueEmails(emails);
+  const resolvedUsers = await lookupUserShares(recipientEmails);
+  const resolvedEmails = new Set(resolvedUsers.map((user) => user.email));
+  const unavailableEmails = recipientEmails.filter((email) => !resolvedEmails.has(email));
+  if (unavailableEmails.length > 0) {
+    throw new ApiError(
+      `These users must sign in before they can be shared with: ${unavailableEmails.join(', ')}`,
+      400,
+      'SHARE_RECIPIENT_NOT_PROVISIONED',
+    );
+  }
+  return resolvedUsers;
 }
 
 function userConversationGrantDiff(
@@ -106,19 +109,14 @@ function userConversationGrantDiff(
   return { writes, deletes };
 }
 
-async function writeUserConversationGrantTuplesBestEffort(
+async function writeUserConversationGrantTuples(
   conversationId: string,
-  emails: string[],
+  resolvedUsers: ResolvedUserShare[],
   permission: SharePermission,
 ): Promise<void> {
-  try {
-    const resolvedUsers = await resolveUserShares(emails);
-    const diff = userConversationGrantDiff(conversationId, resolvedUsers, permission);
-    if (diff.writes.length === 0 && diff.deletes.length === 0) return;
-    await writeOpenFgaTuples(diff);
-  } catch (err) {
-    console.warn('[chat/share] User conversation grant write failed (best-effort):', err);
-  }
+  const diff = userConversationGrantDiff(conversationId, resolvedUsers, permission);
+  if (diff.writes.length === 0 && diff.deletes.length === 0) return;
+  await writeOpenFgaTuples(diff);
 }
 
 function teamLookupFilter(teamRef: string): Record<string, unknown> {
@@ -186,20 +184,34 @@ function mergeTeamPermissions(
   return next;
 }
 
-function teamConversationGrantTuples(
+function teamConversationGrantDiff(
   conversationId: string,
   resolvedTeams: ResolvedTeamShare[],
   permission: SharePermission,
-): OpenFgaTupleKey[] {
-  const tuples: OpenFgaTupleKey[] = [];
+): { writes: OpenFgaTupleKey[]; deletes: OpenFgaTupleKey[] } {
+  const writes: OpenFgaTupleKey[] = [];
+  const deletes: OpenFgaTupleKey[] = [];
   for (const team of resolvedTeams) {
     const user = `team:${team.subjectRef}#member`;
-    tuples.push({ user, relation: 'reader', object: `conversation:${conversationId}` });
+    writes.push({ user, relation: 'reader', object: `conversation:${conversationId}` });
+    const writerTuple = { user, relation: 'writer', object: `conversation:${conversationId}` };
     if (permission === 'comment') {
-      tuples.push({ user, relation: 'writer', object: `conversation:${conversationId}` });
+      writes.push(writerTuple);
+    } else {
+      deletes.push(writerTuple);
     }
   }
-  return tuples;
+  return { writes, deletes };
+}
+
+async function writeTeamConversationGrantTuples(
+  conversationId: string,
+  resolvedTeams: ResolvedTeamShare[],
+  permission: SharePermission,
+): Promise<void> {
+  const diff = teamConversationGrantDiff(conversationId, resolvedTeams, permission);
+  if (diff.writes.length === 0 && diff.deletes.length === 0) return;
+  await writeOpenFgaTuples(diff);
 }
 
 // GET /api/chat/conversations/[id]/share
@@ -226,7 +238,7 @@ export const GET = withErrorHandler(async (
     const accessList = await sharingAccess
       .find({ 
         conversation_id: conversationId, 
-        revoked_at: { $exists: false }
+        revoked_at: null,
       })
       .toArray();
 
@@ -288,16 +300,42 @@ export const POST = withErrorHandler(async (
     const now = new Date();
     const sharingAccess = await getCollection<SharingAccess>('sharing_access');
     const update: Document = {};
+    let recipientEmails: string[] = [];
+    let resolvedUsers: ResolvedUserShare[] = [];
+    let resolvedTeams: ResolvedTeamShare[] = [];
 
-    // Handle user sharing
+    // Resolve every requested subject before any write so a mixed user/team
+    // request cannot partially persist when one recipient is invalid.
     if (body.user_emails && body.user_emails.length > 0) {
-      // Validate emails
       for (const email of body.user_emails) {
         if (!validateEmail(email)) {
           throw new ApiError(`Invalid email format: ${email}`, 400);
         }
       }
-      const recipientEmails = uniqueEmails(body.user_emails);
+      recipientEmails = uniqueEmails(body.user_emails);
+      resolvedUsers = await resolveUserShares(recipientEmails);
+    }
+    if (body.team_ids && body.team_ids.length > 0) {
+      resolvedTeams = await resolveTeamShares(body.team_ids);
+    }
+
+    if (body.permission && (resolvedUsers.length > 0 || resolvedTeams.length > 0)) {
+      const permission = body.permission as SharePermission;
+      const userDiff = userConversationGrantDiff(conversationId, resolvedUsers, permission);
+      const teamDiff = teamConversationGrantDiff(conversationId, resolvedTeams, permission);
+      const grantDiff = {
+        writes: [...userDiff.writes, ...teamDiff.writes],
+        deletes: [...userDiff.deletes, ...teamDiff.deletes],
+      };
+      if (grantDiff.writes.length > 0 || grantDiff.deletes.length > 0) {
+        // Authorization is the real access gate. Do not persist a successful
+        // share unless every requested recipient has a usable OpenFGA grant.
+        await writeOpenFgaTuples(grantDiff);
+      }
+    }
+
+    // Handle user sharing
+    if (body.user_emails && body.user_emails.length > 0) {
       const permission = body.permission as SharePermission;
 
       // Create sharing access records for users
@@ -312,7 +350,6 @@ export const POST = withErrorHandler(async (
       if (accessRecords.length > 0) {
         await sharingAccess.insertMany(accessRecords);
       }
-      await writeUserConversationGrantTuplesBestEffort(conversationId, recipientEmails, permission);
 
       // Initialize sharing object if it doesn't exist
       if (!conversation.sharing) {
@@ -326,7 +363,6 @@ export const POST = withErrorHandler(async (
 
     // Handle team sharing
     if (body.team_ids && body.team_ids.length > 0) {
-      const resolvedTeams = await resolveTeamShares(body.team_ids);
       const permission = body.permission as SharePermission;
 
       // Initialize sharing object if it doesn't exist
@@ -345,14 +381,6 @@ export const POST = withErrorHandler(async (
         permission,
       );
 
-      const grantTuples = teamConversationGrantTuples(conversationId, resolvedTeams, permission);
-      if (grantTuples.length > 0) {
-        try {
-          await writeOpenFgaTuples({ writes: grantTuples, deletes: [] });
-        } catch (err) {
-          console.warn('[chat/share] Team conversation grant write failed (best-effort):', err);
-        }
-      }
     }
 
     if (disablesPublicSharing) {
@@ -413,20 +441,142 @@ export const PATCH = withErrorHandler(async (
         throw new ApiError(`Invalid email format: ${email}`, 400);
       }
       const recipientEmail = normalizedEmail(email);
+      const resolvedUsers = await resolveUserShares([recipientEmail]);
+      await writeUserConversationGrantTuples(
+        conversationId,
+        resolvedUsers,
+        permission as SharePermission,
+      );
       const sharingAccess = await getCollection<SharingAccess>('sharing_access');
       await sharingAccess.updateOne(
         { conversation_id: conversationId, granted_to: { $in: uniqueStrings([email, recipientEmail]) }, revoked_at: null },
         { $set: { permission, granted_to: recipientEmail } }
       );
-      await writeUserConversationGrantTuplesBestEffort(conversationId, [recipientEmail], permission);
     }
 
     if (team_id) {
-      const teamPerms = conversation.sharing?.team_permissions || {};
-      teamPerms[team_id] = permission;
+      const resolvedTeams = await resolveTeamShares([team_id]);
+      await writeTeamConversationGrantTuples(
+        conversationId,
+        resolvedTeams,
+        permission as SharePermission,
+      );
+      const teamPerms = mergeTeamPermissions(
+        conversation.sharing?.team_permissions,
+        resolvedTeams,
+        permission as SharePermission,
+      );
       await conversations.updateOne(
         { _id: conversationId },
         { $set: { 'sharing.team_permissions': teamPerms } }
+      );
+    }
+
+    const updated = await conversations.findOne({ _id: conversationId });
+    return successResponse(updated);
+  });
+});
+
+// DELETE /api/chat/conversations/[id]/share — revoke access for one user or team
+export const DELETE = withErrorHandler(async (
+  request: NextRequest,
+  context: { params: Promise<{ id: string }> }
+) => {
+  return withAuth(request, async (req, user, session) => {
+    const params = await context.params;
+    const conversationId = params.id;
+    const body = await request.json();
+
+    if (!validateUUID(conversationId)) {
+      throw new ApiError('Invalid conversation ID format', 400);
+    }
+
+    const email = typeof body.email === 'string' ? normalizedEmail(body.email) : '';
+    const teamId = typeof body.team_id === 'string' ? body.team_id.trim() : '';
+    if (Boolean(email) === Boolean(teamId)) {
+      throw new ApiError('Exactly one of email or team_id is required', 400);
+    }
+    if (email && !validateEmail(email)) {
+      throw new ApiError(`Invalid email format: ${email}`, 400);
+    }
+
+    const conversations = await getCollection<Conversation>('conversations');
+    const conversation = await conversations.findOne({ _id: conversationId });
+    if (!conversation) {
+      throw new ApiError('Conversation not found', 404);
+    }
+
+    await requireConversationResourcePermission(session, user.email, conversation, 'share');
+    const now = new Date();
+
+    if (email) {
+      // Revocation remains idempotent for legacy drift: if the recipient was
+      // never provisioned there is no subject tuple to remove, but Mongo state
+      // must still be cleaned up.
+      const resolvedUsers = await lookupUserShares([email]);
+      if (resolvedUsers.length > 0) {
+        const tupleDiff = userConversationGrantDiff(conversationId, resolvedUsers, 'comment');
+        await writeOpenFgaTuples({
+          writes: [],
+          deletes: tupleDiff.writes,
+        });
+      }
+
+      const sharingAccess = await getCollection<SharingAccess>('sharing_access');
+      await sharingAccess.updateMany(
+        {
+          conversation_id: conversationId,
+          granted_to: { $in: uniqueStrings([body.email, email]) },
+          revoked_at: null,
+        },
+        { $set: { revoked_at: now, revoked_by: user.email } },
+      );
+      const nextSharedWith = (conversation.sharing?.shared_with || [])
+        .filter((sharedEmail) => normalizedEmail(sharedEmail) !== email);
+      await conversations.updateOne(
+        { _id: conversationId },
+        { $set: { 'sharing.shared_with': nextSharedWith } },
+      );
+    }
+
+    if (teamId) {
+      let resolvedTeams: ResolvedTeamShare[];
+      try {
+        resolvedTeams = await resolveTeamShares([teamId]);
+      } catch (err) {
+        if (!(err instanceof ApiError) || err.statusCode !== 404) throw err;
+        // A deleted/stale team must still be removable from a conversation.
+        resolvedTeams = [{
+          shareRef: teamId,
+          subjectRef: teamId,
+          aliases: [teamId],
+        }];
+      }
+      const aliases = new Set(resolvedTeams.flatMap((team) => team.aliases));
+      const revokeTuples = resolvedTeams.flatMap((team) => {
+        const tupleUser = `team:${team.subjectRef}#member`;
+        const object = `conversation:${conversationId}`;
+        return [
+          { user: tupleUser, relation: 'reader', object },
+          { user: tupleUser, relation: 'writer', object },
+        ];
+      });
+      await writeOpenFgaTuples({ writes: [], deletes: revokeTuples });
+
+      const nextSharedWithTeams = (conversation.sharing?.shared_with_teams || [])
+        .filter((ref) => !aliases.has(String(ref).trim()));
+      const nextTeamPermissions = Object.fromEntries(
+        Object.entries(conversation.sharing?.team_permissions || {})
+          .filter(([ref]) => !aliases.has(ref)),
+      );
+      await conversations.updateOne(
+        { _id: conversationId },
+        {
+          $set: {
+            'sharing.shared_with_teams': nextSharedWithTeams,
+            'sharing.team_permissions': nextTeamPermissions,
+          },
+        },
       );
     }
 

--- a/ui/src/app/api/dynamic-agents/teams/__tests__/route.test.ts
+++ b/ui/src/app/api/dynamic-agents/teams/__tests__/route.test.ts
@@ -71,4 +71,67 @@ describe("GET /api/dynamic-agents/teams", () => {
       ]),
     );
   });
+
+  it("filters and limits team search on the server for organization admins", async () => {
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    const toArray = jest.fn().mockResolvedValue([
+      { _id: "team-1", name: "Shrinath Utility", slug: "shrinath-utility" },
+    ]);
+    const cursor = {
+      project: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      toArray,
+    };
+    const find = jest.fn().mockReturnValue(cursor);
+    mockGetCollection.mockResolvedValue({ find });
+
+    const { GET } = await import("../route");
+    const response = await GET(
+      new NextRequest("http://localhost/api/dynamic-agents/teams?q=shri.*&limit=20"),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(find).toHaveBeenCalledWith({
+      $or: [
+        { name: { $regex: "shri\\.\\*", $options: "i" } },
+        { slug: { $regex: "shri\\.\\*", $options: "i" } },
+        { description: { $regex: "shri\\.\\*", $options: "i" } },
+      ],
+    });
+    expect(cursor.limit).toHaveBeenCalledWith(20);
+    expect(body.data).toEqual([
+      expect.objectContaining({ slug: "shrinath-utility", user_role: "admin" }),
+    ]);
+  });
+
+  it("supports bounded exact ref lookups for existing share labels", async () => {
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    const cursor = {
+      project: jest.fn().mockReturnThis(),
+      sort: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      toArray: jest.fn().mockResolvedValue([
+        { _id: "team-1", name: "Platform", slug: "platform" },
+        { _id: "team-2", name: "SRE", slug: "sre" },
+      ]),
+    };
+    const find = jest.fn().mockReturnValue(cursor);
+    mockGetCollection.mockResolvedValue({ find });
+
+    const { GET } = await import("../route");
+    const response = await GET(
+      new NextRequest("http://localhost/api/dynamic-agents/teams?ref=platform&ref=sre&limit=2"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(find).toHaveBeenCalledWith({
+      $or: [
+        { slug: { $in: ["platform", "sre"] } },
+        { _id: { $in: ["platform", "sre"] } },
+      ],
+    });
+    expect(cursor.limit).toHaveBeenCalledWith(2);
+  });
 });

--- a/ui/src/app/api/dynamic-agents/teams/route.ts
+++ b/ui/src/app/api/dynamic-agents/teams/route.ts
@@ -13,10 +13,11 @@ import { getRbacCollection } from "@/lib/rbac/mongo-collections";
 import { caipeOrgKey } from "@/lib/rbac/organization";
 import { requireResourcePermission } from "@/lib/rbac/resource-authz";
 import type { TeamMembershipSource } from "@/types/identity-group-sync";
+import { ObjectId,type Filter,type FindCursor } from "mongodb";
 import { NextRequest } from "next/server";
 
 interface Team {
-  _id: unknown;
+  _id: ObjectId | string;
   name: string;
   slug?: string;
   description?: string;
@@ -24,6 +25,51 @@ interface Team {
 
 function normalizeEmail(value: unknown): string {
   return typeof value === "string" ? value.trim().toLowerCase() : "";
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function teamSearchFilter(query: string): Filter<Team> {
+  const escaped = escapeRegex(query);
+  return {
+    $or: [
+      { name: { $regex: escaped, $options: "i" } },
+      { slug: { $regex: escaped, $options: "i" } },
+      { description: { $regex: escaped, $options: "i" } },
+    ],
+  };
+}
+
+function teamRefsFilter(refs: string[]): Filter<Team> {
+  const objectIds = refs
+    .filter((ref) => ObjectId.isValid(ref))
+    .map((ref) => new ObjectId(ref));
+  return {
+    $or: [
+      { slug: { $in: refs } },
+      { _id: { $in: [...refs, ...objectIds] } },
+    ],
+  };
+}
+
+function requestedLimit(request: NextRequest, hasQuery: boolean): number | undefined {
+  const raw = request.nextUrl.searchParams.get("limit");
+  if (!raw && !hasQuery) return undefined;
+  const parsed = Number(raw || 20);
+  return Number.isFinite(parsed) ? Math.min(Math.max(Math.floor(parsed), 1), 50) : 20;
+}
+
+async function loadTeams(
+  cursor: FindCursor<Team>,
+  limit: number | undefined,
+): Promise<Team[]> {
+  const projected = cursor
+    .project({ _id: 1, name: 1, slug: 1, description: 1 })
+    .sort({ name: 1 });
+  if (limit !== undefined) projected.limit(limit);
+  return (await projected.toArray()) as Team[];
 }
 
 async function canManageOrganization(session: Parameters<typeof requireResourcePermission>[0]): Promise<boolean> {
@@ -50,15 +96,22 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     const teamsCollection = await getCollection<Team>("teams");
     const isAdmin = await canManageOrganization(session);
     const normalizedEmail = normalizeEmail(user.email);
+    const query = request.nextUrl.searchParams.get("q")?.trim() || "";
+    const refs = Array.from(new Set(
+      request.nextUrl.searchParams.getAll("ref").map((ref) => ref.trim()).filter(Boolean),
+    )).slice(0, 50);
+    const requestedFilters: Filter<Team>[] = [];
+    if (query) requestedFilters.push(teamSearchFilter(query));
+    if (refs.length > 0) requestedFilters.push(teamRefsFilter(refs));
+    const requestedFilter: Filter<Team> = requestedFilters.length > 1
+      ? { $and: requestedFilters }
+      : requestedFilters[0] || {};
+    const limit = requestedLimit(request, Boolean(query));
 
     if (isAdmin) {
       // Admins see every team; role is always "admin" so dropdowns let
       // them pick any team.
-      const teams = (await teamsCollection
-        .find({})
-        .project({ _id: 1, name: 1, slug: 1, description: 1 })
-        .sort({ name: 1 })
-        .toArray()) as Team[];
+      const teams = await loadTeams(teamsCollection.find(requestedFilter), limit);
       return successResponse(
         teams.map((team) => ({
           _id: String(team._id),
@@ -95,11 +148,15 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     }
     if (roleBySlug.size === 0) return successResponse([]);
 
-    const teams = (await teamsCollection
-      .find({ slug: { $in: Array.from(roleBySlug.keys()) } })
-      .project({ _id: 1, name: 1, slug: 1, description: 1 })
-      .sort({ name: 1 })
-      .toArray()) as Team[];
+    const membershipFilter: Filter<Team> = { slug: { $in: Array.from(roleBySlug.keys()) } };
+    const teams = await loadTeams(
+      teamsCollection.find(
+        requestedFilters.length > 0
+          ? { $and: [membershipFilter, requestedFilter] }
+          : membershipFilter,
+      ),
+      limit,
+    );
 
     return successResponse(
       teams.map((team) => {

--- a/ui/src/app/api/users/search/__tests__/route.test.ts
+++ b/ui/src/app/api/users/search/__tests__/route.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  const actual = jest.requireActual("@/lib/api-error");
+  return {
+    ApiError: actual.ApiError,
+    successResponse: (data: unknown) => Response.json({ success: true, data }),
+    withAuth: async (
+      request: NextRequest,
+      handler: (req: NextRequest, user: { email: string }, session: { sub: string }) => Promise<Response>,
+    ) => handler(request, { email: "owner@example.com" }, { sub: "owner-sub" }),
+    withErrorHandler:
+      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      async (request: NextRequest) => handler(request),
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+describe("GET /api/users/search", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("queries only users with a stable Keycloak subject", async () => {
+    const toArray = jest.fn().mockResolvedValue([
+      {
+        email: "shridhsh@cisco.com",
+        name: "Sridhar Shah",
+        avatar_url: "avatar.png",
+        keycloak_sub: "keycloak-user-1",
+      },
+    ]);
+    const limit = jest.fn().mockReturnValue({ toArray });
+    const find = jest.fn().mockReturnValue({ limit });
+    mockGetCollection.mockResolvedValue({ find });
+
+    const { GET } = await import("../route");
+    const response = await GET(new NextRequest("http://localhost/api/users/search?q=Shri"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(find).toHaveBeenCalledWith({
+      $and: [
+        {
+          $or: [
+            { email: { $regex: "Shri", $options: "i" } },
+            { name: { $regex: "Shri", $options: "i" } },
+          ],
+        },
+        {
+          $or: [
+            { keycloak_sub: { $type: "string", $regex: "\\S" } },
+            { "metadata.keycloak_sub": { $type: "string", $regex: "\\S" } },
+          ],
+        },
+      ],
+    });
+    expect(limit).toHaveBeenCalledWith(10);
+    expect(body.data).toEqual([
+      {
+        email: "shridhsh@cisco.com",
+        name: "Sridhar Shah",
+        avatar_url: "avatar.png",
+      },
+    ]);
+  });
+
+  it("escapes regex metacharacters in directory searches", async () => {
+    const find = jest.fn().mockReturnValue({
+      limit: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([]),
+      }),
+    });
+    mockGetCollection.mockResolvedValue({ find });
+
+    const { GET } = await import("../route");
+    await GET(new NextRequest("http://localhost/api/users/search?q=shri.*"));
+
+    expect(find.mock.calls[0][0].$and[0].$or[0].email.$regex).toBe("shri\\.\\*");
+  });
+});

--- a/ui/src/app/api/users/search/route.ts
+++ b/ui/src/app/api/users/search/route.ts
@@ -7,27 +7,42 @@ withAuth,
 withErrorHandler,
 } from '@/lib/api-middleware';
 import { getCollection } from '@/lib/mongodb';
-import type { User,UserPublicInfo } from '@/types/mongodb';
+import {
+shareableUserIdentityFilter,
+type ShareableUserDocument,
+} from '@/lib/rbac/shareable-users';
+import type { UserPublicInfo } from '@/types/mongodb';
 import { NextRequest } from 'next/server';
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
 
 // GET /api/users/search
 export const GET = withErrorHandler(async (request: NextRequest) => {
   return withAuth(request, async (req) => {
     const url = new URL(req.url);
-    const query = url.searchParams.get('q');
+    const query = url.searchParams.get('q')?.trim();
 
     if (!query || query.length < 2) {
       throw new ApiError('Search query must be at least 2 characters', 400);
     }
 
-    const users = await getCollection<User>('users');
+    const users = await getCollection<ShareableUserDocument>('users');
+    const escapedQuery = escapeRegex(query);
 
-    // Search by email or name (case insensitive)
+    // Only return users with a stable Keycloak subject. Conversation access is
+    // enforced by OpenFGA, so an unlinked Mongo profile is not shareable.
     const results = await users
       .find({
-        $or: [
-          { email: { $regex: query, $options: 'i' } },
-          { name: { $regex: query, $options: 'i' } },
+        $and: [
+          {
+            $or: [
+              { email: { $regex: escapedQuery, $options: 'i' } },
+              { name: { $regex: escapedQuery, $options: 'i' } },
+            ],
+          },
+          shareableUserIdentityFilter(),
         ],
       })
       .limit(10)

--- a/ui/src/components/chat/ShareDialog.tsx
+++ b/ui/src/components/chat/ShareDialog.tsx
@@ -7,7 +7,7 @@ import { useChatStore } from "@/store/chat-store";
 import type { UserPublicInfo } from "@/types/mongodb";
 import type { Team } from "@/types/teams";
 import { Check,Copy,Mail,Trash2,Users,X } from "lucide-react";
-import { useCallback,useEffect,useState } from "react";
+import { useCallback,useEffect,useRef,useState } from "react";
 import { createPortal } from "react-dom";
 
 type SharePermission = 'view' | 'comment';
@@ -44,8 +44,25 @@ function isTeamAlreadyShared(team: Team, sharedTeamRefs: string[]): boolean {
   return teamAliases(team).some((alias) => sharedRefs.has(alias));
 }
 
-async function fetchShareableTeams(): Promise<Team[]> {
-  const teamsResponse = await fetch(TEAM_SHARE_SEARCH_ENDPOINT);
+async function fetchShareableTeams(options: {
+  query?: string;
+  refs?: string[];
+  signal?: AbortSignal;
+} = {}): Promise<Team[]> {
+  const searchParams = new URLSearchParams();
+  if (options.query) {
+    searchParams.set('q', options.query);
+    searchParams.set('limit', '20');
+  }
+  for (const ref of options.refs || []) searchParams.append('ref', ref);
+  if (!options.query && options.refs?.length) {
+    searchParams.set('limit', String(Math.min(options.refs.length, 50)));
+  }
+  const queryString = searchParams.toString();
+  const teamsResponse = await fetch(
+    `${TEAM_SHARE_SEARCH_ENDPOINT}${queryString ? `?${queryString}` : ''}`,
+    { signal: options.signal },
+  );
   if (!teamsResponse.ok) return [];
   const teamsData = await teamsResponse.json();
   if (Array.isArray(teamsData.data)) return teamsData.data;
@@ -76,6 +93,7 @@ export function ShareDialog({
   const [userPermissions, setUserPermissions] = useState<Record<string, SharePermission>>({});
   const [teamPermissions, setTeamPermissions] = useState<Record<string, SharePermission>>({});
   const [defaultPermission, setDefaultPermission] = useState<SharePermission>('comment');
+  const initialSharingRef = useRef(initialSharing);
 
   const shareUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/chat/${conversationId}`;
   const sharedByLabel = sharedBy?.trim();
@@ -112,7 +130,8 @@ export function ShareDialog({
         // Build per-team permission map from sharing.team_permissions
         setTeamPermissions(sharing?.team_permissions || {});
 
-        // Update store with sharing info so Sidebar shows icon immediately
+        // Keep the sidebar snapshot current. initialSharing is intentionally
+        // not a load-effect dependency, so this store update cannot refetch.
         if (sharing) {
           updateConversationSharing(conversationId, {
             is_public: false,
@@ -125,7 +144,7 @@ export function ShareDialog({
         // Load team names for display
         if (teamIds.length > 0) {
           try {
-            const allTeams = await fetchShareableTeams();
+            const allTeams = await fetchShareableTeams({ refs: teamIds });
             const namesMap: Record<string, string> = {};
             allTeams.forEach((team: Team) => {
               for (const alias of teamAliases(team)) {
@@ -160,16 +179,25 @@ export function ShareDialog({
     }
   }, [conversationId, updateConversationSharing]);
 
-  // Load current sharing info
+  // Keep the latest snapshot without making prop identity a fetch dependency.
+  // The previous effect fed each GET response into the chat store, received a
+  // new initialSharing object, and immediately fetched again.
+  useEffect(() => {
+    initialSharingRef.current = initialSharing;
+  }, [conversationId, initialSharing]);
+
+  // Load current sharing info once when the dialog opens or the conversation changes.
   useEffect(() => {
     if (open) {
-      applySharingSnapshot(initialSharing);
+      applySharingSnapshot(initialSharingRef.current);
       void loadSharingInfo();
     }
-  }, [open, canManageSharing, initialSharing, applySharingSnapshot, loadSharingInfo]);
+  }, [open, conversationId, applySharingSnapshot, loadSharingInfo]);
 
   // Search users and teams as they type
   useEffect(() => {
+    const query = searchInput.trim();
+    const controller = new AbortController();
     const searchPeopleAndTeams = async () => {
       if (!canManageSharing) {
         setUserResults([]);
@@ -178,7 +206,7 @@ export function ShareDialog({
         return;
       }
 
-      if (searchInput.length < 2) {
+      if (query.length < 2) {
         setUserResults([]);
         setTeamResults([]);
         setNoResults(false);
@@ -187,51 +215,44 @@ export function ShareDialog({
 
       setSearching(true);
       setNoResults(false);
-      try {
-        // Search users
-        const users = await apiClient.searchUsers(searchInput);
-        const filteredUsers = users.filter(u => !sharedWith.includes(u.email));
-        setUserResults(filteredUsers);
+      const [usersResult, teamsResult] = await Promise.allSettled([
+        apiClient.searchUsers(query, controller.signal),
+        fetchShareableTeams({ query, signal: controller.signal }),
+      ]);
+      if (controller.signal.aborted) return;
 
-        // Search teams (may require admin access - handle gracefully)
-        try {
-          const allTeams = await fetchShareableTeams();
-          // assisted-by Codex Codex-sonnet-4-6
-          // Team chat sharing uses the member-visible team endpoint, not the admin grid API.
-          const searchLower = searchInput.toLowerCase();
-          const matchingTeams = allTeams.filter((team: Team) => {
-            const nameMatch = team.name.toLowerCase().includes(searchLower);
-            const slugMatch = team.slug?.toLowerCase().includes(searchLower);
-            const descMatch = team.description?.toLowerCase().includes(searchLower);
-            const notAlreadyShared = !isTeamAlreadyShared(team, sharedWithTeams);
-            return (nameMatch || slugMatch || descMatch) && notAlreadyShared;
-          });
-          setTeamResults(matchingTeams);
-
-          // Show no results message if both are empty
-          if (filteredUsers.length === 0 && matchingTeams.length === 0 && searchInput.length >= 2) {
-            setNoResults(true);
-          }
-        } catch (teamErr) {
-          console.error("Team search failed:", teamErr);
-          setTeamResults([]);
-          // If team search fails, still check user results
-          if (filteredUsers.length === 0 && searchInput.length >= 2) {
-            setNoResults(true);
-          }
-        }
-      } catch (err) {
-        console.error("Search failed:", err);
-        setUserResults([]);
-        setTeamResults([]);
-        setNoResults(true);
-      } finally {
-        setSearching(false);
+      const users = usersResult.status === 'fulfilled' ? usersResult.value : [];
+      const teams = teamsResult.status === 'fulfilled' ? teamsResult.value : [];
+      if (usersResult.status === 'rejected') {
+        console.error("User search failed:", usersResult.reason);
       }
+      if (teamsResult.status === 'rejected') {
+        console.error("Team search failed:", teamsResult.reason);
+      }
+
+      const filteredUsers = users.filter(u => !sharedWith.includes(u.email));
+      const matchingTeams = teams.filter((team) => !isTeamAlreadyShared(team, sharedWithTeams));
+      setUserResults(filteredUsers);
+      setTeamResults(matchingTeams);
+      setNoResults(filteredUsers.length === 0 && matchingTeams.length === 0);
+      setSearching(false);
     };
 
-    const timer = setTimeout(searchPeopleAndTeams, 300);
-    return () => clearTimeout(timer);
+    const timer = setTimeout(() => {
+      void searchPeopleAndTeams().catch((err) => {
+        if (!controller.signal.aborted) {
+          console.error("Search failed:", err);
+          setUserResults([]);
+          setTeamResults([]);
+          setNoResults(true);
+          setSearching(false);
+        }
+      });
+    }, 300);
+    return () => {
+      clearTimeout(timer);
+      controller.abort();
+    };
   }, [searchInput, sharedWith, sharedWithTeams, canManageSharing]);
 
   const handleShareUser = async (email: string) => {
@@ -279,32 +300,10 @@ export function ShareDialog({
     if (!canManageSharing) return;
     setLoading(true);
     try {
-      // Update conversation to include team in shared_with_teams
-      const response = await fetch(`/api/chat/conversations/${conversationId}/share`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          team_ids: [teamId],
-          permission: defaultPermission,
-        }),
+      const updatedConversation = await apiClient.shareConversation(conversationId, {
+        team_ids: [teamId],
+        permission: defaultPermission,
       });
-
-      if (!response.ok) {
-        // Try to get error message from API response
-        let errorMessage = 'Failed to share with team';
-        try {
-          const errorData = await response.json();
-          errorMessage = errorData.error || errorData.message || errorMessage;
-        } catch {
-          // If response is not JSON, use status text
-          errorMessage = response.statusText || errorMessage;
-        }
-        throw new Error(errorMessage);
-      }
-
-      // Parse response to get updated conversation
-      const responseData = await response.json();
-      const updatedConversation = responseData.data;
       
       // Update store with new sharing info so Sidebar shows icon immediately
       if (updatedConversation?.sharing) {
@@ -331,19 +330,6 @@ export function ShareDialog({
     }
   };
 
-  // Handle sharing by email directly (for users not yet in system)
-  const handleShareByEmail = async () => {
-    if (!canManageSharing) return;
-    // Simple email validation
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!emailRegex.test(searchInput)) {
-      alert("Please enter a valid email address");
-      return;
-    }
-
-    await handleShareUser(searchInput);
-  };
-
   const handleCopyLink = async () => {
     try {
       await navigator.clipboard.writeText(shareUrl);
@@ -360,12 +346,7 @@ export function ShareDialog({
   ) => {
     if (!canManageSharing) return;
     try {
-      const response = await fetch(`/api/chat/conversations/${conversationId}/share`, {
-        method: 'PATCH',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...target, permission: newPermission }),
-      });
-      if (!response.ok) return;
+      await apiClient.updateConversationSharePermission(conversationId, target, newPermission);
       if (target.email) {
         setUserPermissions((prev) => ({ ...prev, [target.email!]: newPermission }));
       }
@@ -374,6 +355,46 @@ export function ShareDialog({
       }
     } catch (err) {
       console.error('Failed to update permission:', err);
+      alert(`Failed to update permission: ${getErrorMessage(err, "") || 'Unknown error'}`);
+    }
+  };
+
+  const handleRemoveAccess = async (target: { email?: string; team_id?: string }) => {
+    if (!canManageSharing) return;
+    setLoading(true);
+    try {
+      const updatedConversation = await apiClient.revokeConversationShare(conversationId, target);
+      if (target.email) {
+        const email = target.email;
+        setSharedWith((current) => current.filter((item) => item !== email));
+        setUserPermissions((current) => {
+          const next = { ...current };
+          delete next[email];
+          return next;
+        });
+      }
+      if (target.team_id) {
+        const teamId = target.team_id;
+        setSharedWithTeams((current) => current.filter((item) => item !== teamId));
+        setTeamPermissions((current) => {
+          const next = { ...current };
+          delete next[teamId];
+          return next;
+        });
+      }
+      if (updatedConversation?.sharing) {
+        updateConversationSharing(conversationId, {
+          is_public: false,
+          shared_with: updatedConversation.sharing.shared_with,
+          shared_with_teams: updatedConversation.sharing.shared_with_teams,
+          share_link_enabled: updatedConversation.sharing.share_link_enabled,
+        });
+      }
+    } catch (err) {
+      console.error('Failed to remove access:', err);
+      alert(`Failed to remove access: ${getErrorMessage(err, "") || 'Unknown error'}`);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -560,27 +581,12 @@ export function ShareDialog({
                   </div>
                 )}
                 
-                {/* No results - offer to share by email */}
+                {/* Only provisioned Keycloak users are shareable. */}
                 {noResults && !searching && userResults.length === 0 && teamResults.length === 0 && (
                   <div className="px-3 py-4">
-                    <p className="text-sm text-muted-foreground mb-2">
+                    <p className="text-sm text-muted-foreground">
                       No people or teams found
                     </p>
-                    {/* Only show email share if it looks like an email */}
-                    {/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(searchInput) && (
-                      <>
-                        <button
-                          onClick={handleShareByEmail}
-                          disabled={loading}
-                          className="w-full px-3 py-2 bg-primary text-primary-foreground rounded-md hover:bg-primary/90 text-sm font-medium"
-                        >
-                          Share with {searchInput}
-                        </button>
-                        <p className="text-xs text-muted-foreground mt-2">
-                          They&apos;ll get access when they log in
-                        </p>
-                      </>
-                    )}
                   </div>
                 )}
               </div>
@@ -626,10 +632,9 @@ export function ShareDialog({
                     </select>
                     <button
                       className="text-muted-foreground hover:text-destructive"
-                      onClick={() => {
-                        // TODO: Implement remove access
-                        setSharedWith(sharedWith.filter(e => e !== email));
-                      }}
+                      onClick={() => void handleRemoveAccess({ email })}
+                      disabled={loading}
+                      aria-label={`Remove access for ${email}`}
                     >
                       <Trash2 className="h-4 w-4" />
                     </button>
@@ -667,10 +672,9 @@ export function ShareDialog({
                     </select>
                     <button
                       className="text-muted-foreground hover:text-destructive"
-                      onClick={() => {
-                        // TODO: Implement remove team access
-                        setSharedWithTeams(sharedWithTeams.filter(t => t !== teamId));
-                      }}
+                      onClick={() => void handleRemoveAccess({ team_id: teamId })}
+                      disabled={loading}
+                      aria-label={`Remove access for ${teamNames[teamId] || teamId}`}
                     >
                       <Trash2 className="h-4 w-4" />
                     </button>

--- a/ui/src/components/chat/ShareDialog.tsx
+++ b/ui/src/components/chat/ShareDialog.tsx
@@ -6,7 +6,7 @@ import { apiClient } from "@/lib/api-client";
 import { useChatStore } from "@/store/chat-store";
 import type { UserPublicInfo } from "@/types/mongodb";
 import type { Team } from "@/types/teams";
-import { Check,Copy,Mail,Trash2,Users,X } from "lucide-react";
+import { Check,Copy,Loader2,Mail,Trash2,Users,X } from "lucide-react";
 import { useCallback,useEffect,useRef,useState } from "react";
 import { createPortal } from "react-dom";
 
@@ -93,7 +93,12 @@ export function ShareDialog({
   const [userPermissions, setUserPermissions] = useState<Record<string, SharePermission>>({});
   const [teamPermissions, setTeamPermissions] = useState<Record<string, SharePermission>>({});
   const [defaultPermission, setDefaultPermission] = useState<SharePermission>('comment');
+  const [pendingAccessAction, setPendingAccessAction] = useState<string | null>(null);
+  const [sharingInfoLoading, setSharingInfoLoading] = useState(false);
   const initialSharingRef = useRef(initialSharing);
+  const permissionsConversationIdRef = useRef(conversationId);
+  const shareableTeamsRef = useRef<Team[] | null>(null);
+  const shareableTeamsRequestRef = useRef<Promise<Team[]> | null>(null);
 
   const shareUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/chat/${conversationId}`;
   const sharedByLabel = sharedBy?.trim();
@@ -102,8 +107,25 @@ export function ShareDialog({
     setSharedWith(sharing?.shared_with || []);
     const teamIds = sharing?.shared_with_teams || [];
     setSharedWithTeams(teamIds);
-    setTeamPermissions(sharing?.team_permissions || {});
-    setUserPermissions({});
+    if (sharing?.team_permissions) {
+      setTeamPermissions(sharing.team_permissions);
+    }
+  }, []);
+
+  const getShareableTeams = useCallback(async (): Promise<Team[]> => {
+    if (shareableTeamsRef.current) return shareableTeamsRef.current;
+    if (shareableTeamsRequestRef.current) return shareableTeamsRequestRef.current;
+
+    const request = fetchShareableTeams()
+      .then((teams) => {
+        shareableTeamsRef.current = teams;
+        return teams;
+      })
+      .finally(() => {
+        shareableTeamsRequestRef.current = null;
+      });
+    shareableTeamsRequestRef.current = request;
+    return request;
   }, []);
 
   const loadSharingInfo = useCallback(async () => {
@@ -137,6 +159,7 @@ export function ShareDialog({
             is_public: false,
             shared_with: sharing.shared_with,
             shared_with_teams: sharing.shared_with_teams,
+            team_permissions: sharing.team_permissions,
             share_link_enabled: sharing.share_link_enabled,
           });
         }
@@ -144,7 +167,7 @@ export function ShareDialog({
         // Load team names for display
         if (teamIds.length > 0) {
           try {
-            const allTeams = await fetchShareableTeams({ refs: teamIds });
+            const allTeams = await getShareableTeams();
             const namesMap: Record<string, string> = {};
             allTeams.forEach((team: Team) => {
               for (const alias of teamAliases(team)) {
@@ -177,7 +200,11 @@ export function ShareDialog({
       // Don't assume legacy on network errors — only on explicit 404 + localStorage mode
       setIsLegacyConversation(false);
     }
-  }, [conversationId, updateConversationSharing]);
+  }, [conversationId, getShareableTeams, updateConversationSharing]);
+
+  useEffect(() => {
+    initialSharingRef.current = initialSharing;
+  }, [initialSharing]);
 
   // Keep the latest snapshot without making prop identity a fetch dependency.
   // The previous effect fed each GET response into the chat store, received a
@@ -188,72 +215,100 @@ export function ShareDialog({
 
   // Load current sharing info once when the dialog opens or the conversation changes.
   useEffect(() => {
-    if (open) {
-      applySharingSnapshot(initialSharingRef.current);
-      void loadSharingInfo();
+    if (!open) {
+      setSharingInfoLoading(false);
+      return;
     }
-  }, [open, conversationId, applySharingSnapshot, loadSharingInfo]);
+
+    if (permissionsConversationIdRef.current !== conversationId) {
+      permissionsConversationIdRef.current = conversationId;
+      setUserPermissions({});
+      setTeamPermissions({});
+    }
+
+    let active = true;
+    setSharingInfoLoading(true);
+    applySharingSnapshot(initialSharingRef.current);
+    void loadSharingInfo().finally(() => {
+      if (active) setSharingInfoLoading(false);
+    });
+    if (canManageSharing) {
+      void getShareableTeams().catch((err) => {
+        console.error("Failed to load shareable teams:", err);
+      });
+    }
+
+    return () => {
+      active = false;
+    };
+  }, [open, conversationId, canManageSharing, applySharingSnapshot, getShareableTeams, loadSharingInfo]);
+
+  const sharedWithSearchKey = sharedWith.join('\u0000');
+  const sharedWithTeamsSearchKey = sharedWithTeams.join('\u0000');
 
   // Search users and teams as they type
   useEffect(() => {
     const query = searchInput.trim();
-    const controller = new AbortController();
-    const searchPeopleAndTeams = async () => {
-      if (!canManageSharing) {
-        setUserResults([]);
-        setTeamResults([]);
-        setNoResults(false);
-        return;
-      }
-
-      if (query.length < 2) {
-        setUserResults([]);
-        setTeamResults([]);
-        setNoResults(false);
-        return;
-      }
-
-      setSearching(true);
+    if (!canManageSharing || query.length < 2) {
+      setUserResults([]);
+      setTeamResults([]);
       setNoResults(false);
-      const [usersResult, teamsResult] = await Promise.allSettled([
-        apiClient.searchUsers(query, controller.signal),
-        fetchShareableTeams({ query, signal: controller.signal }),
-      ]);
-      if (controller.signal.aborted) return;
-
-      const users = usersResult.status === 'fulfilled' ? usersResult.value : [];
-      const teams = teamsResult.status === 'fulfilled' ? teamsResult.value : [];
-      if (usersResult.status === 'rejected') {
-        console.error("User search failed:", usersResult.reason);
-      }
-      if (teamsResult.status === 'rejected') {
-        console.error("Team search failed:", teamsResult.reason);
-      }
-
-      const filteredUsers = users.filter(u => !sharedWith.includes(u.email));
-      const matchingTeams = teams.filter((team) => !isTeamAlreadyShared(team, sharedWithTeams));
-      setUserResults(filteredUsers);
-      setTeamResults(matchingTeams);
-      setNoResults(filteredUsers.length === 0 && matchingTeams.length === 0);
       setSearching(false);
-    };
+      return;
+    }
+
+    let cancelled = false;
+    setUserResults([]);
+    setTeamResults([]);
+    setNoResults(false);
+    setSearching(true);
 
     const timer = setTimeout(() => {
-      void searchPeopleAndTeams().catch((err) => {
-        if (!controller.signal.aborted) {
-          console.error("Search failed:", err);
-          setUserResults([]);
-          setTeamResults([]);
-          setNoResults(true);
-          setSearching(false);
+      void (async () => {
+        const [usersResult, teamsResult] = await Promise.allSettled([
+          apiClient.searchUsers(query),
+          getShareableTeams(),
+        ]);
+        if (cancelled) return;
+
+        if (usersResult.status === 'rejected') {
+          console.error("User search failed:", usersResult.reason);
         }
-      });
+        if (teamsResult.status === 'rejected') {
+          console.error("Team search failed:", teamsResult.reason);
+        }
+
+        const sharedUserEmails = new Set(sharedWithSearchKey.split('\u0000').filter(Boolean));
+        const sharedTeamRefs = sharedWithTeamsSearchKey.split('\u0000').filter(Boolean);
+        const users = usersResult.status === 'fulfilled' ? usersResult.value : [];
+        const allTeams = teamsResult.status === 'fulfilled' ? teamsResult.value : [];
+        const filteredUsers = users.filter((user) => !sharedUserEmails.has(user.email));
+        const searchLower = query.toLowerCase();
+        const matchingTeams = allTeams.filter((team: Team) => {
+          const nameMatch = team.name.toLowerCase().includes(searchLower);
+          const slugMatch = team.slug?.toLowerCase().includes(searchLower);
+          const descMatch = team.description?.toLowerCase().includes(searchLower);
+          return (nameMatch || slugMatch || descMatch) && !isTeamAlreadyShared(team, sharedTeamRefs);
+        });
+
+        setUserResults(filteredUsers);
+        setTeamResults(matchingTeams);
+        setNoResults(filteredUsers.length === 0 && matchingTeams.length === 0);
+        setSearching(false);
+      })();
     }, 300);
+
     return () => {
+      cancelled = true;
       clearTimeout(timer);
-      controller.abort();
     };
-  }, [searchInput, sharedWith, sharedWithTeams, canManageSharing]);
+  }, [
+    searchInput,
+    sharedWithSearchKey,
+    sharedWithTeamsSearchKey,
+    canManageSharing,
+    getShareableTeams,
+  ]);
 
   const handleShareUser = async (email: string) => {
     if (!canManageSharing) return;
@@ -273,6 +328,7 @@ export function ShareDialog({
           is_public: false,
           shared_with: updatedConversation.sharing.shared_with,
           shared_with_teams: updatedConversation.sharing.shared_with_teams,
+          team_permissions: updatedConversation.sharing.team_permissions,
           share_link_enabled: updatedConversation.sharing.share_link_enabled,
         });
       }
@@ -311,6 +367,7 @@ export function ShareDialog({
           is_public: false,
           shared_with: updatedConversation.sharing.shared_with,
           shared_with_teams: updatedConversation.sharing.shared_with_teams,
+          team_permissions: updatedConversation.sharing.team_permissions,
           share_link_enabled: updatedConversation.sharing.share_link_enabled,
         });
       }
@@ -345,40 +402,85 @@ export function ShareDialog({
     newPermission: SharePermission
   ) => {
     if (!canManageSharing) return;
+    const targetKey = target.email ? `user:${target.email}` : `team:${target.team_id}`;
+    const previousPermission = target.email
+      ? userPermissions[target.email] || 'view'
+      : target.team_id
+        ? teamPermissions[target.team_id] || 'view'
+        : undefined;
+
+    if (target.email) {
+      setUserPermissions((prev) => ({ ...prev, [target.email!]: newPermission }));
+    }
+    if (target.team_id) {
+      setTeamPermissions((prev) => ({ ...prev, [target.team_id!]: newPermission }));
+    }
+    setPendingAccessAction(`permission:${targetKey}`);
     try {
-      await apiClient.updateConversationSharePermission(conversationId, target, newPermission);
-      if (target.email) {
-        setUserPermissions((prev) => ({ ...prev, [target.email!]: newPermission }));
+      const response = await fetch(`/api/chat/conversations/${conversationId}/share`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ...target, permission: newPermission }),
+      });
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null);
+        throw new Error(errorData?.error || errorData?.message || response.statusText || 'Failed to update permission');
       }
-      if (target.team_id) {
-        setTeamPermissions((prev) => ({ ...prev, [target.team_id!]: newPermission }));
+      const responseData = await response.json();
+      const updatedConversation = responseData.data;
+      if (updatedConversation?.sharing) {
+        updateConversationSharing(conversationId, {
+          is_public: false,
+          shared_with: updatedConversation.sharing.shared_with,
+          shared_with_teams: updatedConversation.sharing.shared_with_teams,
+          team_permissions: updatedConversation.sharing.team_permissions,
+          share_link_enabled: updatedConversation.sharing.share_link_enabled,
+        });
       }
     } catch (err) {
+      if (target.email && previousPermission) {
+        setUserPermissions((prev) => ({ ...prev, [target.email!]: previousPermission }));
+      }
+      if (target.team_id && previousPermission) {
+        setTeamPermissions((prev) => ({ ...prev, [target.team_id!]: previousPermission }));
+      }
       console.error('Failed to update permission:', err);
       alert(`Failed to update permission: ${getErrorMessage(err, "") || 'Unknown error'}`);
+    } finally {
+      setPendingAccessAction(null);
     }
   };
 
   const handleRemoveAccess = async (target: { email?: string; team_id?: string }) => {
     if (!canManageSharing) return;
-    setLoading(true);
+    const targetKey = target.email ? `user:${target.email}` : `team:${target.team_id}`;
+    setPendingAccessAction(`remove:${targetKey}`);
     try {
-      const updatedConversation = await apiClient.revokeConversationShare(conversationId, target);
+      const response = await fetch(`/api/chat/conversations/${conversationId}/share`, {
+        method: 'DELETE',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(target),
+      });
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null);
+        throw new Error(errorData?.error || errorData?.message || response.statusText || 'Failed to remove access');
+      }
+
+      const responseData = await response.json();
+      const updatedConversation = responseData.data;
       if (target.email) {
-        const email = target.email;
-        setSharedWith((current) => current.filter((item) => item !== email));
-        setUserPermissions((current) => {
-          const next = { ...current };
-          delete next[email];
+        setSharedWith((prev) => prev.filter((email) => email !== target.email));
+        setUserPermissions((prev) => {
+          const next = { ...prev };
+          delete next[target.email!];
           return next;
         });
       }
       if (target.team_id) {
-        const teamId = target.team_id;
-        setSharedWithTeams((current) => current.filter((item) => item !== teamId));
-        setTeamPermissions((current) => {
-          const next = { ...current };
-          delete next[teamId];
+        setSharedWithTeams((prev) => prev.filter((teamId) => teamId !== target.team_id));
+        setTeamPermissions((prev) => {
+          const next = { ...prev };
+          delete next[target.team_id!];
           return next;
         });
       }
@@ -387,6 +489,7 @@ export function ShareDialog({
           is_public: false,
           shared_with: updatedConversation.sharing.shared_with,
           shared_with_teams: updatedConversation.sharing.shared_with_teams,
+          team_permissions: updatedConversation.sharing.team_permissions,
           share_link_enabled: updatedConversation.sharing.share_link_enabled,
         });
       }
@@ -394,7 +497,7 @@ export function ShareDialog({
       console.error('Failed to remove access:', err);
       alert(`Failed to remove access: ${getErrorMessage(err, "") || 'Unknown error'}`);
     } finally {
-      setLoading(false);
+      setPendingAccessAction(null);
     }
   };
 
@@ -609,7 +712,12 @@ export function ShareDialog({
             </label>
             <div className="space-y-2 max-h-48 overflow-y-auto">
               {/* People */}
-              {sharedWith.map((email) => (
+              {sharedWith.map((email) => {
+                const targetKey = `user:${email}`;
+                const permissionPending = pendingAccessAction === `permission:${targetKey}`;
+                const removalPending = pendingAccessAction === `remove:${targetKey}`;
+                const permissionUnknown = sharingInfoLoading && userPermissions[email] === undefined;
+                return (
                 <div
                   key={email}
                   className="flex items-center justify-between py-2 px-3 bg-muted rounded-md"
@@ -623,20 +731,33 @@ export function ShareDialog({
                   {canManageSharing ? (
                   <div className="flex items-center gap-1.5 shrink-0">
                     <select
-                      value={userPermissions[email] || 'view'}
+                      value={permissionUnknown ? '' : userPermissions[email] || 'view'}
                       onChange={(e) => handlePermissionChange({ email }, e.target.value as SharePermission)}
-                      className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-muted-foreground hover:text-foreground cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/50"
+                      disabled={loading || pendingAccessAction !== null || permissionUnknown}
+                      aria-label={`Permission for ${email}`}
+                      className="min-w-[5.5rem] text-xs bg-transparent border border-border rounded px-1.5 py-1 text-muted-foreground hover:text-foreground cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/50 disabled:opacity-100 disabled:text-muted-foreground"
                     >
+                      {permissionUnknown && <option value="">Loading…</option>}
                       <option value="view">Can view</option>
                       <option value="comment">Can edit</option>
                     </select>
+                    <span
+                      className="inline-flex h-4 w-4 shrink-0 items-center justify-center"
+                      data-testid={`permission-status-${email}`}
+                      role="status"
+                      aria-label={permissionPending ? `Updating permission for ${email}` : undefined}
+                    >
+                      {permissionPending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+                    </span>
                     <button
                       className="text-muted-foreground hover:text-destructive"
                       onClick={() => void handleRemoveAccess({ email })}
-                      disabled={loading}
+                      disabled={loading || pendingAccessAction !== null}
                       aria-label={`Remove access for ${email}`}
                     >
-                      <Trash2 className="h-4 w-4" />
+                      {removalPending
+                        ? <Loader2 className="h-4 w-4 animate-spin" />
+                        : <Trash2 className="h-4 w-4" />}
                     </button>
                   </div>
                   ) : (
@@ -645,9 +766,15 @@ export function ShareDialog({
                     </span>
                   )}
                 </div>
-              ))}
+                );
+              })}
               {/* Teams */}
-              {sharedWithTeams.map((teamId) => (
+              {sharedWithTeams.map((teamId) => {
+                const targetKey = `team:${teamId}`;
+                const permissionPending = pendingAccessAction === `permission:${targetKey}`;
+                const removalPending = pendingAccessAction === `remove:${targetKey}`;
+                const permissionUnknown = sharingInfoLoading && teamPermissions[teamId] === undefined;
+                return (
                 <div
                   key={teamId}
                   className="flex items-center justify-between py-2 px-3 bg-muted rounded-md"
@@ -663,20 +790,33 @@ export function ShareDialog({
                   {canManageSharing ? (
                   <div className="flex items-center gap-1.5 shrink-0">
                     <select
-                      value={teamPermissions[teamId] || 'view'}
+                      value={permissionUnknown ? '' : teamPermissions[teamId] || 'view'}
                       onChange={(e) => handlePermissionChange({ team_id: teamId }, e.target.value as SharePermission)}
-                      className="text-xs bg-transparent border border-border rounded px-1.5 py-1 text-muted-foreground hover:text-foreground cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/50"
+                      disabled={loading || pendingAccessAction !== null || permissionUnknown}
+                      aria-label={`Permission for ${teamNames[teamId] || teamId}`}
+                      className="min-w-[5.5rem] text-xs bg-transparent border border-border rounded px-1.5 py-1 text-muted-foreground hover:text-foreground cursor-pointer focus:outline-none focus:ring-1 focus:ring-primary/50 disabled:opacity-100 disabled:text-muted-foreground"
                     >
+                      {permissionUnknown && <option value="">Loading…</option>}
                       <option value="view">Can view</option>
                       <option value="comment">Can edit</option>
                     </select>
+                    <span
+                      className="inline-flex h-4 w-4 shrink-0 items-center justify-center"
+                      data-testid={`permission-status-${teamId}`}
+                      role="status"
+                      aria-label={permissionPending ? `Updating permission for ${teamNames[teamId] || teamId}` : undefined}
+                    >
+                      {permissionPending && <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />}
+                    </span>
                     <button
                       className="text-muted-foreground hover:text-destructive"
                       onClick={() => void handleRemoveAccess({ team_id: teamId })}
-                      disabled={loading}
+                      disabled={loading || pendingAccessAction !== null}
                       aria-label={`Remove access for ${teamNames[teamId] || teamId}`}
                     >
-                      <Trash2 className="h-4 w-4" />
+                      {removalPending
+                        ? <Loader2 className="h-4 w-4 animate-spin" />
+                        : <Trash2 className="h-4 w-4" />}
                     </button>
                   </div>
                   ) : (
@@ -685,7 +825,8 @@ export function ShareDialog({
                     </span>
                   )}
                 </div>
-              ))}
+                );
+              })}
             </div>
           </div>
         )}

--- a/ui/src/components/chat/__tests__/ShareDialogPermissions.test.tsx
+++ b/ui/src/components/chat/__tests__/ShareDialogPermissions.test.tsx
@@ -1,8 +1,9 @@
 // assisted-by Codex Codex-sonnet-4-6
 
-import { render, screen, waitFor } from '@testing-library/react'
+import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 const mockUpdateConversationSharing = jest.fn()
+const mockRevokeConversationShare = jest.fn()
 
 jest.mock('@/store/chat-store', () => ({
   useChatStore: (selector: unknown) => selector({
@@ -14,6 +15,8 @@ jest.mock('@/lib/api-client', () => ({
   apiClient: {
     searchUsers: jest.fn().mockResolvedValue([]),
     shareConversation: jest.fn(),
+    updateConversationSharePermission: jest.fn(),
+    revokeConversationShare: (...args: unknown[]) => mockRevokeConversationShare(...args),
   },
 }))
 
@@ -70,5 +73,100 @@ describe('ShareDialog permissions', () => {
 
     expect(screen.getByText('Shared by')).toBeInTheDocument()
     expect(screen.queryByPlaceholderText('Search by email or team name...')).not.toBeInTheDocument()
+  })
+
+  it('loads sharing once even when initialSharing receives a new object identity', async () => {
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          sharing: {
+            is_public: false,
+            shared_with: ['recipient@example.com'],
+            shared_with_teams: [],
+            share_link_enabled: false,
+          },
+          access_list: [],
+        },
+      }),
+    })
+
+    const props = {
+      conversationId: 'conv-123',
+      conversationTitle: 'Stable sharing load',
+      open: true,
+      onOpenChange: jest.fn(),
+      initialSharing: {
+        is_public: false,
+        shared_with: ['recipient@example.com'],
+        shared_with_teams: [],
+        share_link_enabled: false,
+      },
+    }
+    const { rerender } = render(<ShareDialog {...props} />)
+    await waitFor(() => {
+      expect((global.fetch as jest.Mock).mock.calls.filter(([url]) => url.includes('/share'))).toHaveLength(1)
+    })
+
+    rerender(<ShareDialog {...props} initialSharing={{ ...props.initialSharing }} />)
+    await new Promise((resolve) => setTimeout(resolve, 25))
+
+    expect((global.fetch as jest.Mock).mock.calls.filter(([url]) => url.includes('/share'))).toHaveLength(1)
+  })
+
+  it('revokes user access when the trash button is clicked', async () => {
+    const updatedConversation = {
+      sharing: {
+        is_public: false,
+        shared_with: [],
+        shared_with_teams: [],
+        share_link_enabled: false,
+      },
+    }
+    mockRevokeConversationShare.mockResolvedValue(updatedConversation)
+    ;(global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        data: {
+          sharing: {
+            is_public: false,
+            shared_with: ['recipient@example.com'],
+            shared_with_teams: [],
+            share_link_enabled: false,
+          },
+          access_list: [{ granted_to: 'recipient@example.com', permission: 'view' }],
+        },
+      }),
+    })
+
+    render(
+      <ShareDialog
+        conversationId="conv-123"
+        conversationTitle="Remove sharing"
+        open
+        onOpenChange={jest.fn()}
+        initialSharing={{
+          is_public: false,
+          shared_with: ['recipient@example.com'],
+          shared_with_teams: [],
+          share_link_enabled: false,
+        }}
+      />,
+    )
+    await waitFor(() => {
+      expect(screen.getByLabelText('Remove access for recipient@example.com')).toBeInTheDocument()
+    })
+
+    fireEvent.click(screen.getByLabelText('Remove access for recipient@example.com'))
+
+    await waitFor(() => {
+      expect(mockRevokeConversationShare).toHaveBeenCalledWith(
+        'conv-123',
+        { email: 'recipient@example.com' },
+      )
+      expect(screen.queryByText('recipient@example.com')).not.toBeInTheDocument()
+    })
   })
 })

--- a/ui/src/components/chat/__tests__/ShareDialogPublicToggle.test.tsx
+++ b/ui/src/components/chat/__tests__/ShareDialogPublicToggle.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react'
 
 const mockUpdateConversationSharing = jest.fn()
+const mockShareConversation = jest.fn()
 jest.mock('@/store/chat-store', () => ({
   useChatStore: (selector: unknown) => selector({ updateConversationSharing: mockUpdateConversationSharing }),
 }))
@@ -8,7 +9,9 @@ jest.mock('@/store/chat-store', () => ({
 jest.mock('@/lib/api-client', () => ({
   apiClient: {
     searchUsers: jest.fn().mockResolvedValue([]),
-    shareConversation: jest.fn(),
+    shareConversation: (...args: unknown[]) => mockShareConversation(...args),
+    updateConversationSharePermission: jest.fn(),
+    revokeConversationShare: jest.fn(),
   },
 }))
 
@@ -24,6 +27,7 @@ describe('ShareDialog — public sharing removed', () => {
 
   beforeEach(() => {
     jest.clearAllMocks()
+    mockShareConversation.mockResolvedValue(undefined)
     ;(global.fetch as jest.Mock).mockImplementation((url: string, opts?: unknown) => {
       if (url.includes('/api/dynamic-agents/teams')) {
         return Promise.resolve({
@@ -79,6 +83,10 @@ describe('ShareDialog — public sharing removed', () => {
       shared_with_teams: [] as string[],
       share_link_enabled: false,
     }
+    mockShareConversation.mockImplementation(async (_conversationId, request) => {
+      sharing = { ...sharing, shared_with_teams: request.team_ids }
+      return { sharing }
+    })
 
     ;(global.fetch as jest.Mock).mockImplementation((url: string, opts?: unknown) => {
       if (url.includes('/api/dynamic-agents/teams')) {
@@ -105,14 +113,6 @@ describe('ShareDialog — public sharing removed', () => {
           json: async () => ({ data: { sharing } }),
         })
       }
-      if (url.includes('/share') && opts?.method === 'POST') {
-        sharing = { ...sharing, shared_with_teams: ['platform'] }
-        return Promise.resolve({
-          ok: true,
-          status: 200,
-          json: async () => ({ data: { sharing } }),
-        })
-      }
       return Promise.resolve({ ok: true, status: 200, json: async () => ({}) })
     })
 
@@ -133,12 +133,23 @@ describe('ShareDialog — public sharing removed', () => {
     fireEvent.click(screen.getByText('Platform Team'))
 
     await waitFor(() => {
-      const postCalls = (global.fetch as jest.Mock).mock.calls.filter(
-        ([url, opts]: [string, unknown]) => url.includes('/share') && opts?.method === 'POST',
+      expect(mockShareConversation).toHaveBeenCalledWith(
+        'conv-123',
+        { team_ids: ['platform'], permission: 'comment' },
       )
-      expect(postCalls.length).toBeGreaterThan(0)
-      const body = JSON.parse(postCalls[0][1].body)
-      expect(body).toEqual({ team_ids: ['platform'], permission: 'comment' })
     })
+  })
+
+  it('does not offer direct email sharing for an unprovisioned user', async () => {
+    render(<ShareDialog {...defaultProps} />)
+    const search = await screen.findByPlaceholderText('Search by email or team name...')
+
+    fireEvent.change(search, { target: { value: 'not-logged-in@example.com' } })
+
+    await waitFor(() => {
+      expect(screen.getByText('No people or teams found')).toBeInTheDocument()
+    })
+    expect(screen.queryByText('Share with not-logged-in@example.com')).not.toBeInTheDocument()
+    expect(screen.queryByText(/get access when they log in/i)).not.toBeInTheDocument()
   })
 })

--- a/ui/src/components/chat/__tests__/ShareDialogSearch.test.tsx
+++ b/ui/src/components/chat/__tests__/ShareDialogSearch.test.tsx
@@ -1,0 +1,367 @@
+import React, { useEffect, useState } from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const mockUpdateConversationSharing = jest.fn();
+const mockSearchUsers = jest.fn();
+
+jest.mock('@/store/chat-store', () => ({
+  useChatStore: (selector: unknown) => selector({
+    updateConversationSharing: mockUpdateConversationSharing,
+  }),
+}));
+
+jest.mock('@/lib/api-client', () => ({
+  apiClient: {
+    searchUsers: (...args: unknown[]) => mockSearchUsers(...args),
+    shareConversation: jest.fn(),
+  },
+}));
+
+import { ShareDialog } from '../ShareDialog';
+
+type SharingSnapshot = {
+  is_public?: boolean;
+  shared_with?: string[];
+  shared_with_teams?: string[];
+  team_permissions?: Record<string, 'view' | 'comment'>;
+  share_link_enabled?: boolean;
+};
+
+const initialSharing: SharingSnapshot = {
+  is_public: false,
+  shared_with: [],
+  shared_with_teams: [],
+  share_link_enabled: false,
+};
+
+function success(data: unknown) {
+  return Promise.resolve({
+    ok: true,
+    status: 200,
+    statusText: '',
+    json: async () => ({ success: true, data }),
+  });
+}
+
+describe('ShareDialog search performance', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchUsers.mockResolvedValue([]);
+  });
+
+  it('loads sharing metadata and team options only once when the store feeds sharing back as a new prop', async () => {
+    let shareGets = 0;
+    let teamGets = 0;
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/dynamic-agents/teams')) {
+        teamGets += 1;
+        return success([]);
+      }
+      if (url.includes('/share')) {
+        shareGets += 1;
+        return success({ sharing: initialSharing, access_list: [] });
+      }
+      return success({});
+    });
+
+    function Harness() {
+      const [sharing, setSharing] = useState<SharingSnapshot>(initialSharing);
+      useEffect(() => {
+        mockUpdateConversationSharing.mockImplementation((_id, nextSharing: SharingSnapshot) => {
+          setSharing({ ...nextSharing });
+        });
+      }, []);
+      return (
+        <ShareDialog
+          conversationId="conversation-1"
+          conversationTitle="Example conversation"
+          open
+          onOpenChange={jest.fn()}
+          initialSharing={sharing}
+        />
+      );
+    }
+
+    render(<Harness />);
+
+    await waitFor(() => expect(shareGets).toBe(1));
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+    });
+
+    expect(shareGets).toBe(1);
+    expect(teamGets).toBe(1);
+  });
+
+  it('caches teams and ignores results from an older query', async () => {
+    let teamGets = 0;
+    let resolveOld: ((value: Array<{ email: string; name: string }>) => void) | undefined;
+    let resolveNew: ((value: Array<{ email: string; name: string }>) => void) | undefined;
+
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/dynamic-agents/teams')) {
+        teamGets += 1;
+        return success([]);
+      }
+      if (url.includes('/share')) {
+        return success({ sharing: initialSharing, access_list: [] });
+      }
+      return success({});
+    });
+    mockSearchUsers.mockImplementation((query: string) => new Promise((resolve) => {
+      if (query === 'old') resolveOld = resolve;
+      if (query === 'new') resolveNew = resolve;
+    }));
+
+    render(
+      <ShareDialog
+        conversationId="conversation-1"
+        conversationTitle="Example conversation"
+        open
+        onOpenChange={jest.fn()}
+        initialSharing={initialSharing}
+      />,
+    );
+
+    const search = screen.getByPlaceholderText('Search by email or team name...');
+    fireEvent.change(search, { target: { value: 'old' } });
+    await waitFor(() => expect(mockSearchUsers).toHaveBeenCalledWith('old'));
+
+    fireEvent.change(search, { target: { value: 'new' } });
+    await waitFor(() => expect(mockSearchUsers).toHaveBeenCalledWith('new'));
+
+    await act(async () => {
+      resolveNew?.([{ email: 'new-user@example.com', name: 'New User' }]);
+    });
+    await waitFor(() => expect(screen.getByText('New User')).toBeInTheDocument());
+
+    await act(async () => {
+      resolveOld?.([{ email: 'old-user@example.com', name: 'Old User' }]);
+    });
+
+    expect(screen.queryByText('Old User')).not.toBeInTheDocument();
+    expect(screen.getByText('New User')).toBeInTheDocument();
+    expect(teamGets).toBe(1);
+  });
+});
+
+describe('ShareDialog access management', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchUsers.mockResolvedValue([]);
+  });
+
+  it('updates permission and removes direct access through the sharing API', async () => {
+    const recipient = 'recipient@example.com';
+    const shared: SharingSnapshot = {
+      ...initialSharing,
+      shared_with: [recipient],
+    };
+
+    ;(global.fetch as jest.Mock).mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/api/dynamic-agents/teams')) return success([]);
+      if (url.includes('/share') && options?.method === 'PATCH') {
+        return success({
+          sharing: shared,
+        });
+      }
+      if (url.includes('/share') && options?.method === 'DELETE') {
+        return success({
+          sharing: { ...initialSharing, shared_with: [] },
+        });
+      }
+      if (url.includes('/share')) {
+        return success({
+          sharing: shared,
+          access_list: [{ granted_to: recipient, permission: 'view' }],
+        });
+      }
+      return success({});
+    });
+
+    render(
+      <ShareDialog
+        conversationId="conversation-1"
+        conversationTitle="Example conversation"
+        open
+        onOpenChange={jest.fn()}
+        initialSharing={shared}
+      />,
+    );
+
+    const permission = await screen.findByRole('combobox', { name: `Permission for ${recipient}` });
+    await waitFor(() => expect(permission).toHaveValue('view'));
+
+    fireEvent.change(permission, { target: { value: 'comment' } });
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/chat/conversations/conversation-1/share',
+        expect.objectContaining({
+          method: 'PATCH',
+          body: JSON.stringify({ email: recipient, permission: 'comment' }),
+        }),
+      );
+    });
+    await waitFor(() => expect(permission).toHaveValue('comment'));
+
+    fireEvent.click(screen.getByRole('button', { name: `Remove access for ${recipient}` }));
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        '/api/chat/conversations/conversation-1/share',
+        expect.objectContaining({
+          method: 'DELETE',
+          body: JSON.stringify({ email: recipient }),
+        }),
+      );
+      expect(screen.queryByText(recipient)).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the permission controls the same width while an update is pending', async () => {
+    const recipient = 'recipient@example.com';
+    const shared: SharingSnapshot = {
+      ...initialSharing,
+      shared_with: [recipient],
+    };
+    let resolvePermissionUpdate: ((value: unknown) => void) | undefined;
+
+    ;(global.fetch as jest.Mock).mockImplementation((url: string, options?: RequestInit) => {
+      if (url.includes('/api/dynamic-agents/teams')) return success([]);
+      if (url.includes('/share') && options?.method === 'PATCH') {
+        return new Promise((resolve) => {
+          resolvePermissionUpdate = resolve;
+        });
+      }
+      if (url.includes('/share')) {
+        return success({
+          sharing: shared,
+          access_list: [{ granted_to: recipient, permission: 'comment' }],
+        });
+      }
+      return success({});
+    });
+
+    render(
+      <ShareDialog
+        conversationId="conversation-1"
+        conversationTitle="Example conversation"
+        open
+        onOpenChange={jest.fn()}
+        initialSharing={shared}
+      />,
+    );
+
+    const permission = await screen.findByRole('combobox', { name: `Permission for ${recipient}` });
+    await waitFor(() => expect(permission).toHaveValue('comment'));
+    const statusSlot = screen.getByTestId(`permission-status-${recipient}`);
+    const controls = statusSlot.parentElement;
+    expect(controls?.children).toHaveLength(3);
+    expect(statusSlot).toHaveClass('h-4', 'w-4');
+
+    fireEvent.change(permission, { target: { value: 'view' } });
+
+    await waitFor(() => expect(statusSlot.querySelector('.animate-spin')).toBeInTheDocument());
+    expect(permission).toHaveValue('view');
+    expect(controls?.children).toHaveLength(3);
+
+    await act(async () => {
+      resolvePermissionUpdate?.(await success({ sharing: shared }));
+    });
+    await waitFor(() => expect(statusSlot.querySelector('.animate-spin')).not.toBeInTheDocument());
+    expect(controls?.children).toHaveLength(3);
+  });
+
+  it('retains a known permission while sharing metadata refreshes', async () => {
+    const recipient = 'recipient@example.com';
+    const shared: SharingSnapshot = {
+      ...initialSharing,
+      shared_with: [recipient],
+    };
+    let shareGetCount = 0;
+    let resolveRefresh: ((value: unknown) => void) | undefined;
+
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/dynamic-agents/teams')) return success([]);
+      if (url.includes('/share')) {
+        shareGetCount += 1;
+        if (shareGetCount === 1) {
+          return success({
+            sharing: shared,
+            access_list: [{ granted_to: recipient, permission: 'comment' }],
+          });
+        }
+        return new Promise((resolve) => {
+          resolveRefresh = resolve;
+        });
+      }
+      return success({});
+    });
+
+    const props = {
+      conversationId: 'conversation-1',
+      conversationTitle: 'Example conversation',
+      onOpenChange: jest.fn(),
+      initialSharing: shared,
+    };
+    const { rerender } = render(<ShareDialog {...props} open />);
+
+    const permission = await screen.findByRole('combobox', { name: `Permission for ${recipient}` });
+    await waitFor(() => expect(permission).toHaveValue('comment'));
+
+    rerender(<ShareDialog {...props} open={false} />);
+    rerender(<ShareDialog {...props} open />);
+
+    expect(screen.getByRole('combobox', { name: `Permission for ${recipient}` })).toHaveValue('comment');
+
+    await act(async () => {
+      resolveRefresh?.(await success({
+        sharing: shared,
+        access_list: [{ granted_to: recipient, permission: 'comment' }],
+      }));
+    });
+  });
+
+  it('shows a neutral loading value instead of defaulting to Can view before permissions load', async () => {
+    const recipient = 'recipient@example.com';
+    const shared: SharingSnapshot = {
+      ...initialSharing,
+      shared_with: [recipient],
+    };
+    let resolveShareGet: ((value: unknown) => void) | undefined;
+
+    ;(global.fetch as jest.Mock).mockImplementation((url: string) => {
+      if (url.includes('/api/dynamic-agents/teams')) return success([]);
+      if (url.includes('/share')) {
+        return new Promise((resolve) => {
+          resolveShareGet = resolve;
+        });
+      }
+      return success({});
+    });
+
+    render(
+      <ShareDialog
+        conversationId="conversation-1"
+        conversationTitle="Example conversation"
+        open
+        onOpenChange={jest.fn()}
+        initialSharing={shared}
+      />,
+    );
+
+    const permission = await screen.findByRole('combobox', { name: `Permission for ${recipient}` });
+    expect(permission).toHaveValue('');
+    expect(permission).toBeDisabled();
+    expect(screen.getByRole('option', { name: 'Loading…' })).toBeInTheDocument();
+
+    await act(async () => {
+      resolveShareGet?.(await success({
+        sharing: shared,
+        access_list: [{ granted_to: recipient, permission: 'comment' }],
+      }));
+    });
+
+    await waitFor(() => expect(permission).toHaveValue('comment'));
+    expect(permission).toBeEnabled();
+  });
+});

--- a/ui/src/lib/__tests__/api-client.test.ts
+++ b/ui/src/lib/__tests__/api-client.test.ts
@@ -197,4 +197,28 @@ describe('APIClient — Archive methods', () => {
       await expect(apiClient.getTrash()).rejects.toThrow();
     });
   });
+
+  describe('conversation sharing', () => {
+    it('sends DELETE with the recipient when revoking access', async () => {
+      mockFetch.mockResolvedValue(mockSuccessResponse({ _id: 'conv-1', sharing: {} }));
+
+      await apiClient.revokeConversationShare('conv-1', { email: 'viewer@example.com' });
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('/api/chat/conversations/conv-1/share');
+      expect(options.method).toBe('DELETE');
+      expect(JSON.parse(options.body)).toEqual({ email: 'viewer@example.com' });
+    });
+
+    it('passes an AbortSignal to user directory search', async () => {
+      mockFetch.mockResolvedValue(mockSuccessResponse([]));
+      const controller = new AbortController();
+
+      await apiClient.searchUsers('shri', controller.signal);
+
+      const [url, options] = mockFetch.mock.calls[0];
+      expect(url).toBe('/api/users/search?q=shri');
+      expect(options.signal).toBe(controller.signal);
+    });
+  });
 });

--- a/ui/src/lib/api-client.ts
+++ b/ui/src/lib/api-client.ts
@@ -324,6 +324,27 @@ class APIClient {
     });
   }
 
+  async updateConversationSharePermission(
+    conversationId: string,
+    target: { email?: string; team_id?: string },
+    permission: 'view' | 'comment',
+  ): Promise<Conversation> {
+    return this.request(`/api/chat/conversations/${conversationId}/share`, {
+      method: 'PATCH',
+      body: JSON.stringify({ ...target, permission }),
+    });
+  }
+
+  async revokeConversationShare(
+    conversationId: string,
+    target: { email?: string; team_id?: string },
+  ): Promise<Conversation> {
+    return this.request(`/api/chat/conversations/${conversationId}/share`, {
+      method: 'DELETE',
+      body: JSON.stringify(target),
+    });
+  }
+
   async getSharedConversations(params?: {
     page?: number;
     page_size?: number;
@@ -391,9 +412,9 @@ class APIClient {
     });
   }
 
-  async searchUsers(query: string): Promise<UserPublicInfo[]> {
+  async searchUsers(query: string, signal?: AbortSignal): Promise<UserPublicInfo[]> {
     const searchParams = new URLSearchParams({ q: query });
-    return this.request(`/api/users/search?${searchParams}`);
+    return this.request(`/api/users/search?${searchParams}`, { signal });
   }
 
   async getUserStats(): Promise<UserStats> {

--- a/ui/src/lib/rbac/shareable-users.ts
+++ b/ui/src/lib/rbac/shareable-users.ts
@@ -1,0 +1,33 @@
+import type { Filter } from "mongodb";
+
+export interface ShareableUserDocument {
+  email?: string;
+  name?: string;
+  avatar_url?: string;
+  keycloak_sub?: string;
+  metadata?: {
+    keycloak_sub?: string;
+  };
+}
+
+export function stableKeycloakSubject(user: ShareableUserDocument): string | undefined {
+  const candidates = [
+    user.keycloak_sub,
+    user.metadata?.keycloak_sub,
+  ];
+  return candidates.find((candidate) => typeof candidate === "string" && candidate.trim())?.trim();
+}
+
+/**
+ * Conversation shares are enforced with OpenFGA subjects. A Mongo user
+ * without a Keycloak subject cannot receive a usable grant and must not be
+ * offered as a share recipient.
+ */
+export function shareableUserIdentityFilter(): Filter<ShareableUserDocument> {
+  return {
+    $or: [
+      { keycloak_sub: { $type: "string", $regex: "\\S" } },
+      { "metadata.keycloak_sub": { $type: "string", $regex: "\\S" } },
+    ],
+  };
+}

--- a/ui/src/store/__tests__/chat-store.test.ts
+++ b/ui/src/store/__tests__/chat-store.test.ts
@@ -107,6 +107,29 @@ describe('chat-store', () => {
     window.localStorage.clear();
   });
 
+  it('does not rewrite conversation state when sharing metadata is unchanged', () => {
+    const sharing = {
+      is_public: false,
+      shared_with: ['recipient@example.com'],
+      shared_with_teams: ['platform'],
+      team_permissions: { platform: 'view' as const },
+      share_link_enabled: false,
+    };
+    const conversation = makeConversation({ sharing });
+    useChatStore.setState({ conversations: [conversation] });
+    const before = useChatStore.getState();
+
+    before.updateConversationSharing(conversation.id, {
+      ...sharing,
+      shared_with: [...sharing.shared_with],
+      shared_with_teams: [...sharing.shared_with_teams],
+      team_permissions: { ...sharing.team_permissions },
+    });
+
+    expect(useChatStore.getState()).toBe(before);
+    expect(useChatStore.getState().conversations[0]).toBe(conversation);
+  });
+
 
   // --------------------------------------------------------------------------
   // last active conversation pointer

--- a/ui/src/store/chat-store.ts
+++ b/ui/src/store/chat-store.ts
@@ -50,6 +50,44 @@ function persistLastActiveConversationId(id: string | null): void {
   }
 }
 
+function stringArraysEqual(left?: string[], right?: string[]): boolean {
+  const normalizedLeft = left ?? [];
+  const normalizedRight = right ?? [];
+  return (
+    normalizedLeft.length === normalizedRight.length &&
+    normalizedLeft.every((value, index) => value === normalizedRight[index])
+  );
+}
+
+function recordsEqual(
+  left?: Record<string, "view" | "comment">,
+  right?: Record<string, "view" | "comment">,
+): boolean {
+  const leftEntries = Object.entries(left ?? {}).sort(([a], [b]) => a.localeCompare(b));
+  const rightEntries = Object.entries(right ?? {}).sort(([a], [b]) => a.localeCompare(b));
+  return (
+    leftEntries.length === rightEntries.length &&
+    leftEntries.every(
+      ([key, value], index) =>
+        key === rightEntries[index]?.[0] && value === rightEntries[index]?.[1],
+    )
+  );
+}
+
+function sharingEqual(
+  left: Conversation['sharing'],
+  right: Conversation['sharing'],
+): boolean {
+  return (
+    left?.is_public === right?.is_public &&
+    left?.public_permission === right?.public_permission &&
+    left?.share_link_enabled === right?.share_link_enabled &&
+    stringArraysEqual(left?.shared_with, right?.shared_with) &&
+    stringArraysEqual(left?.shared_with_teams, right?.shared_with_teams) &&
+    recordsEqual(left?.team_permissions, right?.team_permissions)
+  );
+}
+
 // Track streaming state per conversation
 interface StreamingState {
   conversationId: string;
@@ -607,18 +645,27 @@ const storeImplementation: StateCreator<ChatState> = (set, get) => ({
       },
 
       updateConversationSharing: (conversationId: string, sharing: Conversation['sharing']) => {
-        set((state: ChatState) => ({
-          conversations: state.conversations.map((conv: Conversation) =>
-            conv.id === conversationId
-              ? {
-                  ...conv,
-                  sharing,
-                  updatedAt: new Date(),
-                }
-              : conv
-          ),
-        }));
-        console.log('[ChatStore] Updated conversation sharing:', conversationId, sharing);
+        let didUpdate = false;
+        set((state: ChatState) => {
+          const conversation = state.conversations.find((conv) => conv.id === conversationId);
+          if (!conversation || sharingEqual(conversation.sharing, sharing)) return state;
+
+          didUpdate = true;
+          return {
+            conversations: state.conversations.map((conv: Conversation) =>
+              conv.id === conversationId
+                ? {
+                    ...conv,
+                    sharing,
+                    updatedAt: new Date(),
+                  }
+                : conv
+            ),
+          };
+        });
+        if (didUpdate) {
+          console.log('[ChatStore] Updated conversation sharing:', conversationId, sharing);
+        }
       },
 
       updateConversationTitle: async (conversationId: string, title: string) => {

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -301,6 +301,7 @@ export interface SharingAccess {
   granted_at: Date;
   accessed_at?: Date;
   revoked_at?: Date;
+  revoked_by?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Fix the connected conversation-sharing authorization, latency, and control-state defects:

- only show and accept recipients with a stable Keycloak subject
- make OpenFGA grant writes authoritative instead of best-effort
- add real user and team revocation from the share dialog
- reconcile reader/writer tuples on permission changes and removal
- stop the share-info refetch loop that repeatedly reset search debounce
- search users and teams concurrently, cancel stale requests, and cache bounded team results
- apply permission changes and removal optimistically with rollback
- keep spinner space stable so Can view / Can edit controls do not flicker
- ignore unchanged sharing snapshots in the chat store

## Root cause

The share route could persist Mongo sharing metadata without a matching authorization grant. The dialog sharing GET then updated the chat store with a new object identity, retriggering the same effect roughly 12–15 times per second and repeatedly canceling the 300 ms search debounce. Mutations refetched the entire share list, temporarily replacing permission controls with loading state and producing the visible flicker.

The trash buttons also lacked a complete revoke path for user and team access.

## Behavior

- Unprovisioned users are absent from search and direct API attempts return `SHARE_RECIPIENT_NOT_PROVISIONED`.
- A successful share means the required OpenFGA tuple diff completed before Mongo sharing state is persisted.
- Mixed user/team requests prevalidate all recipients and apply one authorization diff before persistence.
- DELETE revokes exact user/team reader and writer tuples and updates Mongo sharing/access records.
- Permission downgrades remove stale writer tuples.
- Search remains responsive while prior requests settle.
- Permission and removal mutations update immediately, roll back on failure, and keep control dimensions stable.
- Legacy unprovisioned or stale-team shares remain removable.

## Validation

- Latest focused run: 3 suites, 129 tests passed
- Targeted ESLint on all six follow-up TypeScript/TSX files
- `git diff --check`
- Earlier full branch run: 547 suites, 6,850 tests passed
- `npx tsc --noEmit`

The full Jest run emits existing post-test audit flush warnings but exits successfully.