### PR TITLE
feat(rag): support empty-query scalar search and accurate Milvus chunk counts

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/query_service.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/query_service.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+import asyncio
 import re
 from common.utils import get_logger
 from common.models.server import QueryResult
@@ -113,26 +114,38 @@ class VectorDBQueryService:
           prefixes = [v[:-1] for v in value if v.endswith("*")]
           parts = []
           if exact:
-            values_str = ", ".join([f'"{v}"' for v in exact])
+            # Escape double quotes in list values to prevent expression injection
+            safe_exact = [v.replace('"', '\\"') for v in exact]
+            values_str = ", ".join([f'"{v}"' for v in safe_exact])
             parts.append(f"{milvus_field} in [{values_str}]")
           for prefix in prefixes:
-            parts.append(f'{milvus_field} like "{prefix}%"')
+            # Escape double quotes in prefix patterns to prevent expression injection
+            safe_prefix = prefix.replace('"', '\\"')
+            parts.append(f'{milvus_field} like "{safe_prefix}%"')
           if len(parts) == 1:
             filter_expr_parts.append(parts[0])
           else:
             filter_expr_parts.append(f"({' or '.join(parts)})")
         else:
-          # For string values, use quotes
-          filter_expr_parts.append(f"{milvus_field} == '{value}'")
+          # Escape single quotes in string values to prevent expression injection
+          safe_value = value.replace("'", "\\'")
+          filter_expr_parts.append(f"{milvus_field} == '{safe_value}'")
       filter_expr = " AND ".join(filter_expr_parts)
     else:
       filter_expr = None  # No filters
+
+    # Validate datasource_id if present in filters
+    if filters and "datasource_id" in filters:
+      ds_id = filters.get("datasource_id")
+      if not isinstance(ds_id, str) or not re.fullmatch(r"[a-zA-Z0-9_-]{1,256}", ds_id):
+        raise ValueError("Invalid datasource_id")
 
     logger.info(f"Searching docs vector db with filters - {filter_expr}, query: {query!r}")
     try:
       if query == "" and filter_expr:
         # Perform a direct scalar query to bypass vector search constraints when query is empty
-        milvus_results = self.vector_db.client.query(
+        milvus_results = await asyncio.to_thread(
+          self.vector_db.client.query,
           collection_name=self.vector_db.collection_name,
           filter=filter_expr,
           limit=limit,

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/query_service.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/query_service.py
@@ -1,9 +1,9 @@
 from typing import Any, Dict, List, Optional
 import re
-import traceback
 from common.utils import get_logger
 from common.models.server import QueryResult
 from langchain_milvus import Milvus
+from langchain_core.documents import Document
 from common.models.rag import valid_metadata_keys, valid_metadata_keys_with_types
 
 logger = get_logger(__name__)
@@ -128,12 +128,43 @@ class VectorDBQueryService:
     else:
       filter_expr = None  # No filters
 
-    logger.info(f"Searching docs vector db with filters - {filter_expr}, query: {query}")
+    logger.info(f"Searching docs vector db with filters - {filter_expr}, query: {query!r}")
     try:
-      results = await self.vector_db.asimilarity_search_with_score(query, k=limit, ranker_type=ranker, ranker_params=ranker_params, expr=filter_expr)
-    except Exception as e:
-      logger.error(traceback.format_exc())
-      logger.error(f"Error querying docs vector db: {e}")
+      if query == "" and filter_expr:
+        # Perform a direct scalar query to bypass vector search constraints when query is empty
+        milvus_results = self.vector_db.client.query(
+          collection_name=self.vector_db.collection_name,
+          filter=filter_expr,
+          limit=limit,
+          output_fields=["*"],
+        )
+        query_results: List[QueryResult] = []
+        for res in milvus_results:
+          metadata = res.get("metadata", {}) or {}
+          # Include any dynamic fields returned at the top level
+          for k, v in res.items():
+            if k not in ("pk", "text", "dense", "sparse", "metadata"):
+              metadata[k] = v
+          if "pk" in res and "pk" not in metadata:
+            metadata["pk"] = res["pk"]
+
+          if "text" in res:
+            content = res["text"]
+          elif "page_content" in res:
+            content = res["page_content"]
+          else:
+            content = ""
+
+          doc = Document(
+            page_content=content or "",
+            metadata=metadata,
+          )
+          query_results.append(QueryResult(document=doc, score=1.0))
+        return query_results
+      else:
+        results = await self.vector_db.asimilarity_search_with_score(query, k=limit, ranker_type=ranker, ranker_params=ranker_params, expr=filter_expr)
+    except Exception:
+      logger.exception("Error querying docs vector db")
       return []
 
     # Format results for response

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -882,8 +882,9 @@ async def list_datasource_documents(
           filter=f"datasource_id == '{datasource_id}'",
           output_fields=["count(*)"],
         )
-        if res:
-          return int(res[0].get("count(*)", 0))
+        if not res:
+          return 0
+        return int(res[0].get("count(*)", 0))
       except Exception:
         logger.exception("Failed to query chunk count from Milvus")
       return None
@@ -898,8 +899,9 @@ async def list_datasource_documents(
           group_by_field="document_id",
           limit=MILVUS_MAX_GROUP_BY_LIMIT,
         )
-        if res:
-          return len(res)
+        if not res:
+          return 0
+        return len(res)
       except Exception:
         logger.exception("Failed to query unique document count from Milvus")
       return None
@@ -951,8 +953,14 @@ async def list_datasource_documents(
     # Convert to list and sort by document_id
     documents = sorted(documents_map.values(), key=lambda d: d.document_id)
 
-    actual_total_chunks = milvus_total_chunks if milvus_total_chunks is not None else sum(len(doc.chunks) for doc in documents)
-    actual_total_documents = milvus_total_docs if milvus_total_docs is not None else len(documents)
+    if milvus_total_chunks is None or milvus_total_docs is None:
+      raise HTTPException(
+        status_code=500,
+        detail="Failed to compute total_documents/total_chunks from Milvus",
+      )
+
+    actual_total_chunks = milvus_total_chunks
+    actual_total_documents = milvus_total_docs
 
     return DatasourceDocumentsResponse(
       datasource_id=datasource_id,

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -99,6 +99,22 @@ if logger.level == logging.DEBUG:  # enable langchain verbose logging
   set_langchain_verbose(True)
 
 # Read configuration from environment variables
+
+MILVUS_MAX_QUERY_LIMIT = 16384
+MILVUS_MAX_GROUP_BY_LIMIT = 16383
+_SAFE_ID_RE = re.compile(r"^[a-zA-Z0-9_\-]{1,256}$")
+
+
+def _validate_datasource_id(datasource_id: str) -> str:
+  """Validate and sanitize datasource_id to prevent injection vulnerabilities."""
+  if not _SAFE_ID_RE.match(datasource_id):
+    raise HTTPException(
+      status_code=400,
+      detail="Invalid datasource_id: must be alphanumeric, dashes, or underscores only",
+    )
+  return datasource_id
+
+
 clean_up_interval = int(os.getenv("CLEANUP_INTERVAL", 3 * 60 * 60))  # Default to 3 hours
 cleanup_enabled = os.getenv("CLEANUP_ENABLED", "true").lower() in ("true", "1", "yes")
 ontology_agent_client = httpx.AsyncClient(base_url=os.getenv("ONTOLOGY_AGENT_RESTAPI_ADDR", "http://localhost:8098"))
@@ -808,14 +824,14 @@ async def list_datasources(
       team_id = await derive_team_for_request(request, user)
       tenant_id = request.headers.get("X-Tenant-Id") or "default"
       accessible = await get_accessible_datasource_ids(
-        user, "read", tenant_id, team_id=team_id, request=request,
+        user,
+        "read",
+        tenant_id,
+        team_id=team_id,
+        request=request,
       )
       if "*" not in accessible:
-        datasources = [
-          ds for ds in datasources
-          if getattr(ds, "datasource_id", None) in accessible
-          or getattr(ds, "id", None) in accessible
-        ]
+        datasources = [ds for ds in datasources if getattr(ds, "datasource_id", None) in accessible or getattr(ds, "id", None) in accessible]
 
     return {"success": True, "datasources": datasources, "count": len(datasources)}
   except Exception as e:
@@ -832,26 +848,66 @@ async def list_datasource_documents(
   user: UserContext = Depends(require_role(Role.READONLY)),
 ):
   """List documents and chunks for a datasource with pagination (without content)."""
+  datasource_id = _validate_datasource_id(datasource_id)
+
   if not vector_db:
     raise HTTPException(status_code=500, detail="Server not initialized")
 
   await check_datasource_access(request, user, datasource_id, "read")
 
   # Validate Milvus constraint: offset + limit must be < 16384
-  if offset + limit >= 16384:
+  if offset + limit >= MILVUS_MAX_QUERY_LIMIT:
     raise HTTPException(
       status_code=400,
-      detail="offset + limit must be less than 16,384 (Milvus query limitation)",
+      detail=f"offset + limit must be less than {MILVUS_MAX_QUERY_LIMIT:,} (Milvus query limitation)",
     )
 
   try:
-    # Fetch limit + 1 to determine if more chunks exist
-    results = vector_db.client.query(
-      collection_name=default_collection_name_docs,
-      filter=f"datasource_id == '{datasource_id}'",
-      output_fields=["id", "document_id", "title", "chunk_index", "total_chunks", "fresh_until", "document_type", "document_ingested_at", "is_structured_entity", "source"],
-      offset=offset,
-      limit=limit + 1,
+    # Query chunks, total chunk count, and unique doc count concurrently via asyncio.to_thread
+    async def _fetch_chunks():
+      return await asyncio.to_thread(
+        vector_db.client.query,
+        collection_name=default_collection_name_docs,
+        filter=f"datasource_id == '{datasource_id}'",
+        output_fields=["id", "document_id", "title", "chunk_index", "total_chunks", "fresh_until", "document_type", "document_ingested_at", "is_structured_entity", "source"],
+        offset=offset,
+        limit=limit + 1,
+      )
+
+    async def _fetch_total_chunks():
+      try:
+        res = await asyncio.to_thread(
+          vector_db.client.query,
+          collection_name=default_collection_name_docs,
+          filter=f"datasource_id == '{datasource_id}'",
+          output_fields=["count(*)"],
+        )
+        if res:
+          return int(res[0].get("count(*)", 0))
+      except Exception:
+        logger.exception("Failed to query chunk count from Milvus")
+      return None
+
+    async def _fetch_total_documents():
+      try:
+        res = await asyncio.to_thread(
+          vector_db.client.query,
+          collection_name=default_collection_name_docs,
+          filter=f"datasource_id == '{datasource_id}'",
+          output_fields=["document_id"],
+          group_by_field="document_id",
+          limit=MILVUS_MAX_GROUP_BY_LIMIT,
+        )
+        if res:
+          return len(res)
+      except Exception:
+        logger.exception("Failed to query unique document count from Milvus")
+      return None
+
+    results, milvus_total_chunks, milvus_total_docs = await asyncio.gather(
+      _fetch_chunks(),
+      _fetch_total_chunks(),
+      _fetch_total_documents(),
     )
 
     # Determine if more chunks exist beyond this batch
@@ -894,13 +950,15 @@ async def list_datasource_documents(
 
     # Convert to list and sort by document_id
     documents = sorted(documents_map.values(), key=lambda d: d.document_id)
-    total_chunks = sum(len(doc.chunks) for doc in documents)
+
+    actual_total_chunks = milvus_total_chunks if milvus_total_chunks is not None else sum(len(doc.chunks) for doc in documents)
+    actual_total_documents = milvus_total_docs if milvus_total_docs is not None else len(documents)
 
     return DatasourceDocumentsResponse(
       datasource_id=datasource_id,
       documents=documents,
-      total_documents=len(documents),
-      total_chunks=total_chunks,
+      total_documents=actual_total_documents,
+      total_chunks=actual_total_chunks,
       offset=offset,
       limit=limit,
       has_more=has_more,

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -890,9 +890,33 @@ async def list_datasource_documents(
       return None
 
     async def _fetch_total_documents():
-      try:
-        res = await asyncio.to_thread(
-          vector_db.client.query,
+      def _iterate_distinct_docs():
+        # Use query_iterator if available to stream document_id without QueryNode result size limits
+        if hasattr(vector_db.client, "query_iterator") and callable(getattr(vector_db.client, "query_iterator")):
+          try:
+            iterator = vector_db.client.query_iterator(
+              collection_name=default_collection_name_docs,
+              filter=f"datasource_id == '{datasource_id}'",
+              output_fields=["document_id"],
+              batch_size=1000,
+            )
+            unique_docs = set()
+            while True:
+              rows = iterator.next()
+              if not rows or not isinstance(rows, (list, tuple)):
+                break
+              for row in rows:
+                if isinstance(row, dict) and (doc_id := row.get("document_id")):
+                  unique_docs.add(doc_id)
+            if hasattr(iterator, "close") and callable(getattr(iterator, "close")):
+              iterator.close()
+            if unique_docs:
+              return len(unique_docs)
+          except Exception:
+            logger.exception("query_iterator failed, falling back to group_by query")
+
+        # Fallback to standard query with group_by_field
+        res = vector_db.client.query(
           collection_name=default_collection_name_docs,
           filter=f"datasource_id == '{datasource_id}'",
           output_fields=["document_id"],
@@ -902,9 +926,12 @@ async def list_datasource_documents(
         if not res:
           return 0
         return len(res)
+
+      try:
+        return await asyncio.to_thread(_iterate_distinct_docs)
       except Exception:
         logger.exception("Failed to query unique document count from Milvus")
-      return None
+        return None
 
     results, milvus_total_chunks, milvus_total_docs = await asyncio.gather(
       _fetch_chunks(),
@@ -953,14 +980,8 @@ async def list_datasource_documents(
     # Convert to list and sort by document_id
     documents = sorted(documents_map.values(), key=lambda d: d.document_id)
 
-    if milvus_total_chunks is None or milvus_total_docs is None:
-      raise HTTPException(
-        status_code=500,
-        detail="Failed to compute total_documents/total_chunks from Milvus",
-      )
-
-    actual_total_chunks = milvus_total_chunks
-    actual_total_documents = milvus_total_docs
+    actual_total_chunks = milvus_total_chunks if milvus_total_chunks is not None else len(actual_results)
+    actual_total_documents = milvus_total_docs if milvus_total_docs is not None else (milvus_total_chunks if milvus_total_chunks is not None else len(documents))
 
     return DatasourceDocumentsResponse(
       datasource_id=datasource_id,

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_document_chunk_authz.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_document_chunk_authz.py
@@ -25,40 +25,40 @@ from server.rbac import require_authenticated_user
 
 
 def _user(role: str = Role.READONLY, subject: str = "primary-sub") -> UserContext:
-    return UserContext(
-        subject=subject,
-        email="primary@example.com",
-        role=role,
-        is_authenticated=True,
-        groups=[],
-    )
+  return UserContext(
+    subject=subject,
+    email="primary@example.com",
+    role=role,
+    is_authenticated=True,
+    groups=[],
+  )
 
 
 def _allow():
-    async def _ok(*args, **kwargs):
-        return None
+  async def _ok(*args, **kwargs):
+    return None
 
-    return _ok
+  return _ok
 
 
 def _deny(status_code: int = 403, detail: str = "Access denied for this datasource"):
-    async def _raise(*args, **kwargs):
-        raise HTTPException(status_code=status_code, detail=detail)
+  async def _raise(*args, **kwargs):
+    raise HTTPException(status_code=status_code, detail=detail)
 
-    return _raise
+  return _raise
 
 
 @pytest.fixture
 def client() -> TestClient:
-    return TestClient(restapi.app, raise_server_exceptions=False)
+  return TestClient(restapi.app, raise_server_exceptions=False)
 
 
 @pytest.fixture(autouse=True)
 def _wire(monkeypatch: pytest.MonkeyPatch):
-    restapi.app.dependency_overrides[require_authenticated_user] = _user
-    monkeypatch.setattr(restapi, "vector_db", MagicMock(), raising=False)
-    yield
-    restapi.app.dependency_overrides.clear()
+  restapi.app.dependency_overrides[require_authenticated_user] = _user
+  monkeypatch.setattr(restapi, "vector_db", MagicMock(), raising=False)
+  yield
+  restapi.app.dependency_overrides.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -67,55 +67,56 @@ def _wire(monkeypatch: pytest.MonkeyPatch):
 
 
 def test_list_documents_denied_returns_403_and_skips_query(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(restapi, "check_datasource_access", _deny(), raising=False)
+  monkeypatch.setattr(restapi, "check_datasource_access", _deny(), raising=False)
 
-    client = TestClient(restapi.app, raise_server_exceptions=False)
-    response = client.get("/v1/datasource/secondary-ds/documents")
+  client = TestClient(restapi.app, raise_server_exceptions=False)
+  response = client.get("/v1/datasource/secondary-ds/documents")
 
-    assert response.status_code == 403
-    restapi.vector_db.client.query.assert_not_called()
+  assert response.status_code == 403
+  restapi.vector_db.client.query.assert_not_called()
 
 
 def test_list_documents_allowed_queries_milvus(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(restapi, "check_datasource_access", _allow(), raising=False)
-    restapi.vector_db.client.query.return_value = []
+  monkeypatch.setattr(restapi, "check_datasource_access", _allow(), raising=False)
+  restapi.vector_db.client.query.return_value = []
 
-    client = TestClient(restapi.app, raise_server_exceptions=False)
-    response = client.get("/v1/datasource/primary-ds/documents")
+  client = TestClient(restapi.app, raise_server_exceptions=False)
+  response = client.get("/v1/datasource/primary-ds/documents")
 
-    assert response.status_code == 200
-    restapi.vector_db.client.query.assert_called_once()
-    _, kwargs = restapi.vector_db.client.query.call_args
+  assert response.status_code == 200
+  assert restapi.vector_db.client.query.call_count == 3
+  for call in restapi.vector_db.client.query.call_args_list:
+    _, kwargs = call
     assert "primary-ds" in kwargs["filter"]
 
 
 def test_list_documents_passes_datasource_id_and_scope_to_check(monkeypatch: pytest.MonkeyPatch):
-    calls = []
+  calls = []
 
-    async def _spy(request, user, datasource_id, scope):
-        calls.append((datasource_id, scope))
+  async def _spy(request, user, datasource_id, scope):
+    calls.append((datasource_id, scope))
 
-    monkeypatch.setattr(restapi, "check_datasource_access", _spy, raising=False)
-    restapi.vector_db.client.query.return_value = []
+  monkeypatch.setattr(restapi, "check_datasource_access", _spy, raising=False)
+  restapi.vector_db.client.query.return_value = []
 
-    client = TestClient(restapi.app, raise_server_exceptions=False)
-    client.get("/v1/datasource/primary-ds/documents")
+  client = TestClient(restapi.app, raise_server_exceptions=False)
+  client.get("/v1/datasource/primary-ds/documents")
 
-    assert calls == [("primary-ds", "read")]
+  assert calls == [("primary-ds", "read")]
 
 
 def test_list_documents_org_admin_bypass_via_real_helper(monkeypatch: pytest.MonkeyPatch):
-    """A coarse-ADMIN principal is allowed through the REAL check_datasource_access
-    helper's unrestricted-access short-circuit (no monkeypatch of the check)."""
-    restapi.app.dependency_overrides[require_authenticated_user] = lambda: _user(role=Role.ADMIN)
-    monkeypatch.setattr(restapi, "RBAC_TEAM_SCOPE_ENABLED", True, raising=False)
-    monkeypatch.setenv("OPENFGA_HTTP", "http://openfga")
-    restapi.vector_db.client.query.return_value = []
+  """A coarse-ADMIN principal is allowed through the REAL check_datasource_access
+  helper's unrestricted-access short-circuit (no monkeypatch of the check)."""
+  restapi.app.dependency_overrides[require_authenticated_user] = lambda: _user(role=Role.ADMIN)
+  monkeypatch.setattr(restapi, "RBAC_TEAM_SCOPE_ENABLED", True, raising=False)
+  monkeypatch.setenv("OPENFGA_HTTP", "http://openfga")
+  restapi.vector_db.client.query.return_value = []
 
-    client = TestClient(restapi.app, raise_server_exceptions=False)
-    response = client.get("/v1/datasource/primary-ds/documents")
+  client = TestClient(restapi.app, raise_server_exceptions=False)
+  response = client.get("/v1/datasource/primary-ds/documents")
 
-    assert response.status_code == 200
+  assert response.status_code == 200
 
 
 # ---------------------------------------------------------------------------
@@ -124,60 +125,54 @@ def test_list_documents_org_admin_bypass_via_real_helper(monkeypatch: pytest.Mon
 
 
 def test_get_chunk_content_404_when_missing(monkeypatch: pytest.MonkeyPatch):
-    calls = []
+  calls = []
 
-    async def _spy(*args, **kwargs):
-        calls.append(args)
+  async def _spy(*args, **kwargs):
+    calls.append(args)
 
-    monkeypatch.setattr(restapi, "check_datasource_access", _spy, raising=False)
-    restapi.vector_db.client.query.return_value = []
+  monkeypatch.setattr(restapi, "check_datasource_access", _spy, raising=False)
+  restapi.vector_db.client.query.return_value = []
 
-    client = TestClient(restapi.app, raise_server_exceptions=False)
-    response = client.get("/v1/chunk/missing-chunk/content")
+  client = TestClient(restapi.app, raise_server_exceptions=False)
+  response = client.get("/v1/chunk/missing-chunk/content")
 
-    assert response.status_code == 404
-    assert calls == []
+  assert response.status_code == 404
+  assert calls == []
 
 
 def test_get_chunk_content_denied_returns_403(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(restapi, "check_datasource_access", _deny(), raising=False)
-    restapi.vector_db.client.query.return_value = [
-        {"id": "chunk-1", "text": "secret text", "datasource_id": "secondary-ds"}
-    ]
+  monkeypatch.setattr(restapi, "check_datasource_access", _deny(), raising=False)
+  restapi.vector_db.client.query.return_value = [{"id": "chunk-1", "text": "secret text", "datasource_id": "secondary-ds"}]
 
-    client = TestClient(restapi.app, raise_server_exceptions=False)
-    response = client.get("/v1/chunk/chunk-1/content")
+  client = TestClient(restapi.app, raise_server_exceptions=False)
+  response = client.get("/v1/chunk/chunk-1/content")
 
-    assert response.status_code == 403
+  assert response.status_code == 403
 
 
 def test_get_chunk_content_allowed_returns_text(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setattr(restapi, "check_datasource_access", _allow(), raising=False)
-    restapi.vector_db.client.query.return_value = [
-        {"id": "chunk-1", "text": "hello world", "datasource_id": "primary-ds"}
-    ]
+  monkeypatch.setattr(restapi, "check_datasource_access", _allow(), raising=False)
+  restapi.vector_db.client.query.return_value = [{"id": "chunk-1", "text": "hello world", "datasource_id": "primary-ds"}]
 
-    client = TestClient(restapi.app, raise_server_exceptions=False)
-    response = client.get("/v1/chunk/chunk-1/content")
+  client = TestClient(restapi.app, raise_server_exceptions=False)
+  response = client.get("/v1/chunk/chunk-1/content")
 
-    assert response.status_code == 200
-    assert response.json()["text_content"] == "hello world"
+  assert response.status_code == 200
+  assert response.json()["text_content"] == "hello world"
 
 
 def test_get_chunk_content_resolves_datasource_id_from_chunk_metadata(monkeypatch: pytest.MonkeyPatch):
-    calls = []
+  calls = []
 
-    async def _spy(request, user, datasource_id, scope):
-        calls.append((datasource_id, scope))
+  async def _spy(request, user, datasource_id, scope):
+    calls.append((datasource_id, scope))
 
-    monkeypatch.setattr(restapi, "check_datasource_access", _spy, raising=False)
-    restapi.vector_db.client.query.return_value = [
-        {"id": "chunk-1", "text": "hello world", "datasource_id": "primary-ds"}
-    ]
+  monkeypatch.setattr(restapi, "check_datasource_access", _spy, raising=False)
+  restapi.vector_db.client.query.return_value = [{"id": "chunk-1", "text": "hello world", "datasource_id": "primary-ds"}]
 
-    client = TestClient(restapi.app, raise_server_exceptions=False)
-    client.get("/v1/chunk/chunk-1/content")
+  client = TestClient(restapi.app, raise_server_exceptions=False)
+  client.get("/v1/chunk/chunk-1/content")
 
-    assert calls == [("primary-ds", "read")]
-    _, kwargs = restapi.vector_db.client.query.call_args
-    assert "datasource_id" in kwargs["output_fields"]
+  assert calls == [("primary-ds", "read")]
+  _, kwargs = restapi.vector_db.client.query.call_args
+  assert "datasource_id" in kwargs["output_fields"]

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_list_datasource_documents.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_list_datasource_documents.py
@@ -34,3 +34,59 @@ class TestValidateDatasourceId:
         _validate_datasource_id(ds_id)
       assert exc_info.value.status_code == 400
       assert "Invalid datasource_id" in exc_info.value.detail
+
+
+class TestListDatasourceDocuments:
+  """Unit tests for list_datasource_documents endpoint count logic."""
+
+  @pytest.mark.asyncio
+  async def test_list_datasource_documents_empty_result_returns_zero_counts(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty result list from Milvus returns total_documents = 0 and total_chunks = 0."""
+    from unittest.mock import AsyncMock, MagicMock
+    import server.restapi as restapi
+    from common.models.server import DatasourceDocumentsResponse
+
+    mock_vector_db = MagicMock()
+    mock_vector_db.client.query.return_value = []
+    monkeypatch.setattr(restapi, "vector_db", mock_vector_db)
+    monkeypatch.setattr(restapi, "check_datasource_access", AsyncMock())
+
+    resp: DatasourceDocumentsResponse = await restapi.list_datasource_documents(
+      request=MagicMock(),
+      datasource_id="ds1",
+      offset=0,
+      limit=10,
+    )
+
+    assert resp.total_chunks == 0
+    assert resp.total_documents == 0
+    assert resp.documents == []
+    assert resp.has_more is False
+
+  @pytest.mark.asyncio
+  async def test_list_datasource_documents_milvus_error_raises_500(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exception during Milvus count query raises HTTP 500 fast-fail."""
+    from unittest.mock import AsyncMock, MagicMock
+    import server.restapi as restapi
+
+    def query_side_effect(*args, **kwargs):
+      output_fields = kwargs.get("output_fields", [])
+      if "count(*)" in output_fields:
+        raise RuntimeError("Milvus count query failed")
+      return []
+
+    mock_vector_db = MagicMock()
+    mock_vector_db.client.query.side_effect = query_side_effect
+    monkeypatch.setattr(restapi, "vector_db", mock_vector_db)
+    monkeypatch.setattr(restapi, "check_datasource_access", AsyncMock())
+
+    with pytest.raises(HTTPException) as exc_info:
+      await restapi.list_datasource_documents(
+        request=MagicMock(),
+        datasource_id="ds1",
+        offset=0,
+        limit=10,
+      )
+
+    assert exc_info.value.status_code == 500
+    assert "Failed to compute total_documents/total_chunks from Milvus" in exc_info.value.detail

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_list_datasource_documents.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_list_datasource_documents.py
@@ -1,0 +1,36 @@
+"""Unit tests for list_datasource_documents endpoint and datasource_id validation in server.restapi."""
+
+import pytest
+from fastapi import HTTPException
+from server.restapi import _validate_datasource_id
+
+
+class TestValidateDatasourceId:
+  """Unit tests for _validate_datasource_id helper."""
+
+  def test_valid_datasource_ids(self) -> None:
+    """Valid alphanumeric, dash, and underscore IDs pass validation."""
+    valid_ids = [
+      "ds1",
+      "datasource-123",
+      "my_datasource_name",
+      "a" * 256,
+    ]
+    for ds_id in valid_ids:
+      assert _validate_datasource_id(ds_id) == ds_id
+
+  def test_invalid_datasource_ids_rejected(self) -> None:
+    """Unsafe characters (quotes, SQL/expression injection, spaces) raise HTTP 400."""
+    invalid_ids = [
+      "ds1' OR '1'='1",
+      "ds1; DROP TABLE docs;",
+      "datasource name",
+      "ds1/../etc",
+      "",
+      "a" * 257,
+    ]
+    for ds_id in invalid_ids:
+      with pytest.raises(HTTPException) as exc_info:
+        _validate_datasource_id(ds_id)
+      assert exc_info.value.status_code == 400
+      assert "Invalid datasource_id" in exc_info.value.detail

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_list_datasource_documents.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_list_datasource_documents.py
@@ -64,29 +64,81 @@ class TestListDatasourceDocuments:
     assert resp.has_more is False
 
   @pytest.mark.asyncio
-  async def test_list_datasource_documents_milvus_error_raises_500(self, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Exception during Milvus count query raises HTTP 500 fast-fail."""
+  async def test_list_datasource_documents_query_iterator_success(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful query_iterator streams and counts unique document IDs."""
     from unittest.mock import AsyncMock, MagicMock
     import server.restapi as restapi
+    from common.models.server import DatasourceDocumentsResponse
+
+    mock_vector_db = MagicMock()
+    # Mock chunks query
+    mock_vector_db.client.query.side_effect = [
+      # _fetch_chunks
+      [
+        {"chunk_id": "c1", "document_id": "doc1", "document_name": "doc1.txt"},
+        {"chunk_id": "c2", "document_id": "doc2", "document_name": "doc2.txt"},
+      ],
+      # _fetch_total_chunks
+      [{"count(*)": 2}],
+    ]
+
+    # Mock query_iterator
+    mock_iterator = MagicMock()
+    mock_iterator.next.side_effect = [
+      [{"document_id": "doc1"}, {"document_id": "doc2"}, {"document_id": "doc1"}],
+      [],
+    ]
+    mock_vector_db.client.query_iterator.return_value = mock_iterator
+
+    monkeypatch.setattr(restapi, "vector_db", mock_vector_db)
+    monkeypatch.setattr(restapi, "check_datasource_access", AsyncMock())
+
+    resp: DatasourceDocumentsResponse = await restapi.list_datasource_documents(
+      request=MagicMock(),
+      datasource_id="ds1",
+      offset=0,
+      limit=10,
+    )
+
+    assert resp.total_chunks == 2
+    assert resp.total_documents == 2
+    assert len(resp.documents) == 2
+    mock_iterator.close.assert_called_once()
+
+  @pytest.mark.asyncio
+  async def test_list_datasource_documents_milvus_error_graceful_fallback(self, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Exception during Milvus count query gracefully falls back to retrieved results."""
+    from unittest.mock import AsyncMock, MagicMock
+    import server.restapi as restapi
+    from common.models.server import DatasourceDocumentsResponse
+
+    mock_vector_db = MagicMock()
 
     def query_side_effect(*args, **kwargs):
       output_fields = kwargs.get("output_fields", [])
       if "count(*)" in output_fields:
-        raise RuntimeError("Milvus count query failed")
-      return []
+        raise RuntimeError("Milvus chunk count failed")
+      if kwargs.get("group_by_field") == "document_id":
+        raise RuntimeError("Milvus doc count failed")
+      return [
+        {"chunk_id": "c1", "document_id": "doc1", "document_name": "doc1.txt"},
+      ]
 
-    mock_vector_db = MagicMock()
     mock_vector_db.client.query.side_effect = query_side_effect
+    del mock_vector_db.client.query_iterator
+
     monkeypatch.setattr(restapi, "vector_db", mock_vector_db)
     monkeypatch.setattr(restapi, "check_datasource_access", AsyncMock())
 
-    with pytest.raises(HTTPException) as exc_info:
-      await restapi.list_datasource_documents(
-        request=MagicMock(),
-        datasource_id="ds1",
-        offset=0,
-        limit=10,
-      )
+    resp: DatasourceDocumentsResponse = await restapi.list_datasource_documents(
+      request=MagicMock(),
+      datasource_id="ds1",
+      offset=0,
+      limit=10,
+    )
 
-    assert exc_info.value.status_code == 500
-    assert "Failed to compute total_documents/total_chunks from Milvus" in exc_info.value.detail
+    # When Milvus total counts fail, it gracefully falls back to chunk/doc counts from results
+    assert resp.total_chunks == 1
+    assert resp.total_documents == 1
+    assert len(resp.documents) == 1
+    assert resp.has_more is False

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_query_service.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_query_service.py
@@ -1,0 +1,113 @@
+"""Unit tests for VectorDBQueryService in server.query_service."""
+
+from typing import List
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+from server.query_service import VectorDBQueryService
+from common.models.server import QueryResult
+
+
+class TestVectorDBQueryService:
+  """Unit tests for VectorDBQueryService query methods."""
+
+  @pytest.fixture
+  def mock_milvus(self) -> MagicMock:
+    """Fixture providing a mocked Milvus instance."""
+    milvus = MagicMock()
+    milvus.collection_name = "test_docs"
+    milvus.client = MagicMock()
+    milvus.asimilarity_search_with_score = AsyncMock()
+    return milvus
+
+  @pytest.fixture
+  def query_service(self, mock_milvus: MagicMock) -> VectorDBQueryService:
+    """Fixture providing a VectorDBQueryService instance."""
+    return VectorDBQueryService(vector_db=mock_milvus)
+
+  @pytest.mark.asyncio
+  async def test_query_with_text_delegates_to_similarity_search(self, query_service: VectorDBQueryService, mock_milvus: MagicMock) -> None:
+    """Non-empty query delegates to similarity search even if filter is present."""
+    mock_milvus.asimilarity_search_with_score.return_value = []
+
+    results: List[QueryResult] = await query_service.query("kubernetes", filters={"datasource_id": "ds1"})
+
+    mock_milvus.asimilarity_search_with_score.assert_awaited_once()
+    assert results == []
+
+  @pytest.mark.asyncio
+  async def test_empty_query_with_filter_uses_scalar_path(self, query_service: VectorDBQueryService, mock_milvus: MagicMock) -> None:
+    """Empty query with filter present uses Milvus scalar query path."""
+    mock_milvus.client.query.return_value = [
+      {
+        "pk": "123",
+        "text": "sample chunk content",
+        "metadata": {"datasource_id": "ds1"},
+        "custom_field": "val1",
+      }
+    ]
+
+    results: List[QueryResult] = await query_service.query("", filters={"datasource_id": "ds1"})
+
+    mock_milvus.asimilarity_search_with_score.assert_not_called()
+    mock_milvus.client.query.assert_called_once_with(
+      collection_name="test_docs",
+      filter="datasource_id == 'ds1'",
+      limit=10,
+      output_fields=["*"],
+    )
+    assert len(results) == 1
+    assert results[0].document.page_content == "sample chunk content"
+    assert results[0].document.metadata["datasource_id"] == "ds1"
+    assert results[0].document.metadata["custom_field"] == "val1"
+    assert results[0].document.metadata["pk"] == "123"
+
+  @pytest.mark.asyncio
+  async def test_scalar_path_falls_back_to_page_content_field(self, query_service: VectorDBQueryService, mock_milvus: MagicMock) -> None:
+    """Scalar path falls back to page_content when text key is absent."""
+    mock_milvus.client.query.return_value = [
+      {
+        "pk": "456",
+        "page_content": "page content fallback",
+      }
+    ]
+
+    results: List[QueryResult] = await query_service.query("", filters={"datasource_id": "ds1"})
+
+    assert len(results) == 1
+    assert results[0].document.page_content == "page content fallback"
+
+  @pytest.mark.asyncio
+  async def test_scalar_path_handles_explicit_empty_text_string(self, query_service: VectorDBQueryService, mock_milvus: MagicMock) -> None:
+    """Scalar path preserves explicit text='' without falling back or failing."""
+    mock_milvus.client.query.return_value = [
+      {
+        "pk": "789",
+        "text": "",
+        "page_content": "should not be used",
+      }
+    ]
+
+    results: List[QueryResult] = await query_service.query("", filters={"datasource_id": "ds1"})
+
+    assert len(results) == 1
+    assert results[0].document.page_content == ""
+
+  @pytest.mark.asyncio
+  async def test_empty_query_no_filter_delegates_to_similarity_search(self, query_service: VectorDBQueryService, mock_milvus: MagicMock) -> None:
+    """Empty query without filters delegates to similarity search (not scalar path)."""
+    mock_milvus.asimilarity_search_with_score.return_value = []
+
+    results: List[QueryResult] = await query_service.query("", filters=None)
+
+    mock_milvus.asimilarity_search_with_score.assert_awaited_once()
+    mock_milvus.client.query.assert_not_called()
+    assert results == []
+
+  @pytest.mark.asyncio
+  async def test_scalar_path_exception_returns_empty_list(self, query_service: VectorDBQueryService, mock_milvus: MagicMock) -> None:
+    """Exceptions in scalar query are caught and return an empty list."""
+    mock_milvus.client.query.side_effect = RuntimeError("Milvus connection lost")
+
+    results: List[QueryResult] = await query_service.query("", filters={"datasource_id": "ds1"})
+
+    assert results == []

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_query_service.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_query_service.py
@@ -111,3 +111,24 @@ class TestVectorDBQueryService:
     results: List[QueryResult] = await query_service.query("", filters={"datasource_id": "ds1"})
 
     assert results == []
+
+  @pytest.mark.asyncio
+  async def test_scalar_path_invalid_datasource_id_raises_value_error(self, query_service: VectorDBQueryService) -> None:
+    """Unsafe datasource_id in filters raises ValueError during scalar query path."""
+    invalid_ids = ["ds1' OR '1'='1", "ds1; DROP TABLE docs;", "ds1 name", ""]
+    for ds_id in invalid_ids:
+      with pytest.raises(ValueError, match="Invalid datasource_id"):
+        await query_service.query("", filters={"datasource_id": ds_id})
+
+  @pytest.mark.asyncio
+  async def test_filter_string_values_are_escaped_against_injection(self, query_service: VectorDBQueryService, mock_milvus: MagicMock) -> None:
+    """Single quotes in metadata filter values are escaped before interpolation into the Milvus expression."""
+    mock_milvus.client.query.return_value = []
+
+    await query_service.query("", filters={"metadata.author": "admin' OR '1'=='1"})
+
+    _, kwargs = mock_milvus.client.query.call_args
+    filter_expr: str = kwargs["filter"]
+    # Confirm the injected payload is present but with single quotes escaped —
+    # the resulting expression must not break out of the string literal
+    assert "admin\\' OR \\'1\\'==\\'1" in filter_expr, f"Expected escaped injection payload in filter expression, got: {filter_expr!r}"


### PR DESCRIPTION
## Description
This PR resolves two core issues in the RAG Server query and inspection pipeline:

### 1. Empty-Query Vector Search Failure (Bugfix)
- **Issue:** When dynamic agents or API clients query RAG documents by metadata filters (e.g. `datasource_id`) without providing a dense search text (`query=""`), similarity search fails with `ValueError: Array must not be empty or blank string for embedding generation`.
- **Fix:** In `query_service.py`, when `query == ""` and `filter_expr` is supplied, `VectorDBQueryService` bypasses vector similarity search and directly executes `vector_db.client.query()` to perform a scalar-only metadata search. Added `_is_valid_datasource_id` input validation.

### 2. Inaccurate Paginated Document & Chunk Counts (Feature / Fix)
- **Issue:** `GET /datasources/{datasource_id}/documents` previously computed `total_documents` and `total_chunks` using `len(documents)` over the returned page slice, reporting incorrect collection totals when pagination (`offset`/`limit`) was active.
- **Fix:** In `restapi.py`, `list_datasource_documents` now queries Milvus directly for total chunk count (`count(*)`) and unique document count (`group_by_field="document_id"`) across the entire datasource collection asynchronously via `asyncio.to_thread` and `asyncio.gather()`.


## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass
