### PR TITLE
feat(credentials): add MCP OAuth dynamic registration

### DIFF
--- a/charts/ai-platform-engineering/charts/caipe-ui/README.md
+++ b/charts/ai-platform-engineering/charts/caipe-ui/README.md
@@ -47,6 +47,27 @@ UI startup. Declarative entries override legacy fixed-provider environment
 bootstrap entries. Removing an entry does not delete or disable the connector
 already stored in MongoDB.
 
+Remote MCP servers that advertise OAuth and anonymous dynamic client
+registration can omit all client credentials and endpoints. GRID follows the
+MCP authorization challenge, RFC 9728 protected-resource metadata, and the
+authorization server metadata, then registers a public PKCE client. The
+generated client ID and registration access token are stored in the encrypted
+credential store, not in Helm values or Vault:
+
+```yaml
+caipe-ui:
+  oauthConnectors:
+    - provider: example-mcp
+      name: Example MCP
+      mcpUrl: https://mcp.example.com/api/mcp
+      # Optional. Defaults to the scopes advertised by the protected resource.
+      scopes:
+        - openid
+        - offline_access
+      # Optional. Defaults to ${NEXTAUTH_URL}/api/credentials/oauth/example-mcp/callback.
+      redirectUri: https://caipe.example.com/api/credentials/oauth/example-mcp/callback
+```
+
 ## Declarative credential secrets
 
 Use `credentialSecretRefs` to provision stable secret IDs for config-driven MCP

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/_validations.tpl
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/_validations.tpl
@@ -15,6 +15,18 @@
 {{- end -}}
 {{- $_ := set $oauthProviders $provider true -}}
 {{- $_ := required (printf "caipe-ui.oauthConnectors[%d].name is required" $index) $connector.name -}}
+{{- $mcpUrl := $connector.mcpUrl | default "" -}}
+{{- $isDcr := ne $mcpUrl "" -}}
+{{- if $isDcr -}}
+{{- range $field := list "clientId" "clientIdEnv" "clientSecretEnv" "authorizationUrl" "tokenUrl" "pkce" -}}
+{{- if hasKey $connector $field -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d].%s is not allowed when mcpUrl is used" $index $field) -}}
+{{- end -}}
+{{- end -}}
+{{- if and (hasKey $connector "scopes") (not (kindIs "slice" $connector.scopes)) -}}
+{{- fail (printf "caipe-ui.oauthConnectors[%d].scopes must be a list" $index) -}}
+{{- end -}}
+{{- else -}}
 {{- $_ := required (printf "caipe-ui.oauthConnectors[%d].authorizationUrl is required" $index) $connector.authorizationUrl -}}
 {{- $_ := required (printf "caipe-ui.oauthConnectors[%d].tokenUrl is required" $index) $connector.tokenUrl -}}
 {{- if not (hasKey $connector "scopes") -}}
@@ -40,6 +52,7 @@
 {{- $envName := index $connector $field | default "" -}}
 {{- if and $envName (not (regexMatch "^[A-Za-z_][A-Za-z0-9_]*$" $envName)) -}}
 {{- fail (printf "caipe-ui.oauthConnectors[%d].%s must be a valid environment variable name" $index $field) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -362,6 +362,12 @@ oauthConnectors: []
   #     - "meeting:schedules_read"
   #     - "meeting:transcripts_read"
   #   redirectUri: "https://caipe.example.com/api/credentials/oauth/webex_secondary/callback"
+  # - provider: "example-mcp"
+  #   name: "Example MCP"
+  #   # Anonymous DCR: GRID discovers the OAuth endpoints and registers a PKCE client.
+  #   mcpUrl: "https://mcp.example.com/api/mcp"
+  #   # scopes and redirectUri are optional.
+  #   scopes: ["openid", "offline_access"]
 
 # Declarative encrypted secrets to upsert into the credential store at UI
 # startup. `id` is stable and can be referenced by an MCP server's

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -899,6 +899,13 @@ caipe-ui:
     #     - "meeting:transcripts_read"
     #   # Defaults to ${NEXTAUTH_URL}/api/credentials/oauth/<provider>/callback.
     #   redirectUri: "https://caipe.example.com/api/credentials/oauth/webex_secondary/callback"
+    # - provider: "example-mcp"
+    #   name: "Example MCP"
+    #   # Discover OAuth metadata and perform anonymous public-client DCR.
+    #   # clientId, clientSecretEnv, authorizationUrl, tokenUrl, and pkce are omitted.
+    #   mcpUrl: "https://mcp.example.com/api/mcp"
+    #   # scopes and redirectUri are optional; discovery/NEXTAUTH_URL supply defaults.
+    #   scopes: ["openid", "offline_access"]
 
   # ── Okta directory sync (Identity Sync admin tab) ──────────────────────────
   # Structured config modeled after the Backstage Okta entity provider. The

--- a/deploy/agentgateway/config_bridge.py
+++ b/deploy/agentgateway/config_bridge.py
@@ -659,6 +659,47 @@ def apply_agentgateway_logging(config: dict[str, Any]) -> None:
     logging_config.setdefault("format", "json")
 
 
+def apply_agentgateway_jwt_auth_overrides(config: dict[str, Any]) -> None:
+    """Apply explicitly configured JWT auth values to every reconciled config.
+
+    AgentGateway's admin endpoint returns the current live config.  Reusing that
+    config as the next reconciliation baseline is intentional, but it also means
+    deployment-specific issuer/JWKS changes would otherwise only affect the
+    minimal first-start fallback.  Pin only values whose environment variables
+    are explicitly present so existing deployments retain their baseline.
+    """
+
+    issuer = os.getenv("AGENTGATEWAY_JWT_ISSUER")
+    jwks_url = os.getenv("AGENTGATEWAY_JWKS_URL")
+    audiences_value = os.getenv("AGENTGATEWAY_JWT_AUDIENCES")
+    if issuer is None and jwks_url is None and audiences_value is None:
+        return
+
+    listener = _first_http_listener(config)
+    policies = listener.setdefault("policies", {})
+    if not isinstance(policies, dict):
+        policies = {}
+        listener["policies"] = policies
+    jwt_auth = policies.setdefault("jwtAuth", {})
+    if not isinstance(jwt_auth, dict):
+        jwt_auth = {}
+        policies["jwtAuth"] = jwt_auth
+
+    jwt_auth.setdefault("mode", "strict")
+    if issuer is not None:
+        jwt_auth["issuer"] = issuer.strip()
+    if jwks_url is not None:
+        jwks = jwt_auth.setdefault("jwks", {})
+        if not isinstance(jwks, dict):
+            jwks = {}
+            jwt_auth["jwks"] = jwks
+        jwks["url"] = jwks_url.strip()
+    if audiences_value is not None:
+        jwt_auth["audiences"] = [
+            audience.strip() for audience in audiences_value.split(",") if audience.strip()
+        ]
+
+
 def write_config_atomically(path: Path, config: dict[str, Any]) -> bool:
     """Write config as JSON/YAML-compatible content; return true when changed."""
 
@@ -835,6 +876,7 @@ def reconcile_once(
         raise
     builtin_routes = load_builtin_mcp_routes(bootstrap_path)
     rendered = merge_agentgateway_mcp_routes(baseline, targets, builtin_routes=builtin_routes)
+    apply_agentgateway_jwt_auth_overrides(rendered)
     apply_agentgateway_logging(rendered)
     changed = write_config_atomically(config_path, rendered)
     result = {

--- a/deploy/agentgateway/tests/test_config_bridge.py
+++ b/deploy/agentgateway/tests/test_config_bridge.py
@@ -913,6 +913,43 @@ def test_apply_agentgateway_logging_honors_env(monkeypatch) -> None:
     assert config["config"]["logging"]["level"] == "warn"
 
 
+def test_apply_agentgateway_jwt_auth_overrides_preserves_baseline_without_env(
+    monkeypatch,
+) -> None:
+    monkeypatch.delenv("AGENTGATEWAY_JWT_ISSUER", raising=False)
+    monkeypatch.delenv("AGENTGATEWAY_JWKS_URL", raising=False)
+    monkeypatch.delenv("AGENTGATEWAY_JWT_AUDIENCES", raising=False)
+    config = _baseline_config()
+
+    bridge.apply_agentgateway_jwt_auth_overrides(config)
+
+    jwt_auth = config["binds"][0]["listeners"][0]["policies"]["jwtAuth"]
+    assert jwt_auth["issuer"] == "http://localhost:7080/realms/caipe"
+    assert jwt_auth["audiences"] == ["caipe-platform", "agentgateway"]
+
+
+def test_apply_agentgateway_jwt_auth_overrides_honors_explicit_env(monkeypatch) -> None:
+    monkeypatch.setenv("AGENTGATEWAY_JWT_ISSUER", "https://example.test/realms/primary")
+    monkeypatch.setenv(
+        "AGENTGATEWAY_JWKS_URL",
+        "http://identity:7080/realms/primary/protocol/openid-connect/certs",
+    )
+    monkeypatch.setenv("AGENTGATEWAY_JWT_AUDIENCES", "primary-api, agentgateway")
+    config = _baseline_config()
+
+    bridge.apply_agentgateway_jwt_auth_overrides(config)
+
+    jwt_auth = config["binds"][0]["listeners"][0]["policies"]["jwtAuth"]
+    assert jwt_auth == {
+        "mode": "strict",
+        "issuer": "https://example.test/realms/primary",
+        "audiences": ["primary-api", "agentgateway"],
+        "jwks": {
+            "url": "http://identity:7080/realms/primary/protocol/openid-connect/certs"
+        },
+    }
+
+
 def test_reconcile_once_enforces_logging_level(tmp_path: Path, monkeypatch) -> None:
     config_path = tmp_path / "generated" / "config.yaml"
     config_path.parent.mkdir()
@@ -929,3 +966,33 @@ def test_reconcile_once_enforces_logging_level(tmp_path: Path, monkeypatch) -> N
 
     rendered = yaml.safe_load(config_path.read_text(encoding="utf-8"))
     assert rendered["config"]["logging"]["level"] == "info"
+
+
+def test_reconcile_once_enforces_configured_jwt_issuer(tmp_path: Path, monkeypatch) -> None:
+    config_path = tmp_path / "generated" / "config.yaml"
+    config_path.parent.mkdir()
+    config_path.write_text("binds: []\n", encoding="utf-8")
+    monkeypatch.setenv("AGENTGATEWAY_JWT_ISSUER", "https://example.test/realms/primary")
+    monkeypatch.setenv(
+        "AGENTGATEWAY_JWKS_URL",
+        "http://identity:7080/realms/primary/protocol/openid-connect/certs",
+    )
+    monkeypatch.setattr(bridge, "_load_targets", lambda: [])
+    monkeypatch.setattr(
+        bridge,
+        "fetch_agentgateway_config",
+        lambda _admin_config_url: _baseline_config(),
+    )
+
+    bridge.reconcile_once(
+        config_path=config_path,
+        admin_config_url="http://agentgateway:15000/config",
+    )
+
+    rendered = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    jwt_auth = rendered["binds"][0]["listeners"][0]["policies"]["jwtAuth"]
+    assert jwt_auth["issuer"] == "https://example.test/realms/primary"
+    assert (
+        jwt_auth["jwks"]["url"]
+        == "http://identity:7080/realms/primary/protocol/openid-connect/certs"
+    )

--- a/tests/test_caipe_ui_oauth_connectors.py
+++ b/tests/test_caipe_ui_oauth_connectors.py
@@ -93,3 +93,45 @@ def test_rejects_inline_oauth_client_secrets() -> None:
     assert result.returncode != 0
     assert ".clientSecret is not allowed" in result.stderr
 
+
+def test_renders_mcp_dynamic_registration_connector() -> None:
+    connector = {
+        "provider": "example-mcp",
+        "name": "Example MCP",
+        "mcpUrl": "https://mcp.example.com/api/mcp",
+        "scopes": ["openid", "profile", "offline_access"],
+        "redirectUri": (
+            "https://grid.example.com/api/credentials/oauth/example-mcp/callback"
+        ),
+    }
+    result = _render({"oauthConnectors": [connector]})
+
+    assert result.returncode == 0, result.stderr
+    documents = _documents(result.stdout)
+    config_map = next(
+        document
+        for document in documents
+        if document["kind"] == "ConfigMap"
+        and document["metadata"]["name"].endswith("-caipe-ui-config")
+    )
+    assert json.loads(
+        config_map["data"]["CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON"]
+    ) == [connector]
+
+
+def test_rejects_static_client_fields_with_mcp_dynamic_registration() -> None:
+    result = _render(
+        {
+            "oauthConnectors": [
+                {
+                    "provider": "example-mcp",
+                    "name": "Example MCP",
+                    "mcpUrl": "https://mcp.example.com/api/mcp",
+                    "clientIdEnv": "EXAMPLE_MCP_CLIENT_ID",
+                }
+            ]
+        }
+    )
+
+    assert result.returncode != 0
+    assert ".clientIdEnv is not allowed when mcpUrl is used" in result.stderr

--- a/ui/e2e/rbac/remote-mcp-catalog.spec.ts
+++ b/ui/e2e/rbac/remote-mcp-catalog.spec.ts
@@ -186,11 +186,11 @@ test.describe("MCP server credential probe (Test Connection)", () => {
     await page.getByRole("button", { name: "Add Credential" }).click();
     await page.getByRole("button", { name: /Test Connection/i }).click();
 
-    // "Reachable but credentials not resolved" copy appears. Exact text — a
+    // Missing credentials are reported without implying endpoint reachability. Exact text — a
     // loose /credential/i regex also matches the "Add Credential" button and
     // "Credentials" section heading.
     await expect(
-      page.getByText("Reachable (HTTP 200) — credentials not resolved"),
+      page.getByText("Credentials not resolved"),
     ).toBeVisible({ timeout: 10_000 });
   });
 });

--- a/ui/src/app/api/admin/credentials/oauth-connectors/dcr/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/credentials/oauth-connectors/dcr/__tests__/route.test.ts
@@ -1,0 +1,85 @@
+const mockRegisterMcpDcrConnector = jest.fn();
+const mockConnectorService = {
+  createConnector: jest.fn(),
+  listConnectors: jest.fn(),
+};
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    statusCode: number;
+    code?: string;
+    constructor(message: string, statusCode = 500, code?: string) {
+      super(message);
+      this.statusCode = statusCode;
+      this.code = code;
+    }
+  }
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: jest.fn(async () => ({ session: { sub: "admin-sub" } })),
+    successResponse: (data: unknown, status = 200) => ({
+      status,
+      json: async () => ({ success: true, data }),
+    }),
+    withErrorHandler: (handler: unknown) => handler,
+  };
+});
+
+jest.mock("@/lib/rbac/require-openfga", () => ({
+  requireAdminSurfaceManage: jest.fn(async () => undefined),
+}));
+
+jest.mock("@/lib/credentials/oauth-service-factory", () => ({
+  getOAuthConnectorService: jest.fn(async () => mockConnectorService),
+}));
+
+jest.mock("@/lib/credentials/mcp-dcr", () => ({
+  registerMcpDcrConnector: mockRegisterMcpDcrConnector,
+}));
+
+function request(body: unknown) {
+  return {
+    json: async () => body,
+    url: "https://caipe.example.test/api/admin/credentials/oauth-connectors/dcr",
+  } as never;
+}
+
+describe("POST /api/admin/credentials/oauth-connectors/dcr", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.CAIPE_CREDENTIALS_ENABLED = "true";
+    process.env.NEXTAUTH_URL = "https://caipe.example.test";
+  });
+
+  it("uses the canonical GRID callback when the admin omits redirectUri", async () => {
+    const connector = {
+      id: "connector-1",
+      provider: "example-mcp",
+      source: "mcp_dcr",
+      pkce: true,
+    };
+    mockRegisterMcpDcrConnector.mockResolvedValue(connector);
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request({
+        name: "Example MCP",
+        provider: "example-mcp",
+        mcpUrl: "https://mcp.example.test/api/mcp",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockRegisterMcpDcrConnector).toHaveBeenCalledWith({
+      input: {
+        name: "Example MCP",
+        provider: "example-mcp",
+        mcpUrl: "https://mcp.example.test/api/mcp",
+        redirectUri:
+          "https://caipe.example.test/api/credentials/oauth/example-mcp/callback",
+      },
+      connectorService: mockConnectorService,
+    });
+    await expect(response.json()).resolves.toEqual({ success: true, data: connector });
+  });
+});

--- a/ui/src/app/api/admin/credentials/oauth-connectors/dcr/route.ts
+++ b/ui/src/app/api/admin/credentials/oauth-connectors/dcr/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from "next/server";
+
+import {
+  ApiError,
+  getAuthFromBearerOrSession,
+  successResponse,
+  withErrorHandler,
+} from "@/lib/api-middleware";
+import { registerMcpDcrConnector } from "@/lib/credentials/mcp-dcr";
+import { getOAuthConnectorService } from "@/lib/credentials/oauth-service-factory";
+import { getCredentialFeatureConfig } from "@/lib/feature-flags/credentials";
+import { requireAdminSurfaceManage } from "@/lib/rbac/require-openfga";
+
+function assertFeatureEnabled(): void {
+  if (!getCredentialFeatureConfig().enabled) {
+    throw new ApiError("Credential features are disabled", 404, "CREDENTIALS_DISABLED");
+  }
+}
+
+function defaultRedirectUri(provider: string): string {
+  const base = process.env.NEXTAUTH_URL?.trim();
+  if (!base) {
+    throw new ApiError(
+      "NEXTAUTH_URL is required for MCP dynamic client registration",
+      500,
+      "MCP_DCR_CALLBACK_UNAVAILABLE",
+    );
+  }
+  return `${base.replace(/\/$/, "")}/api/credentials/oauth/${encodeURIComponent(provider)}/callback`;
+}
+
+export const POST = withErrorHandler(async (request: NextRequest) => {
+  assertFeatureEnabled();
+  const { session } = await getAuthFromBearerOrSession(request);
+  await requireAdminSurfaceManage(session, "credentials");
+  const body = (await request.json()) as Record<string, unknown>;
+  const provider = String(body.provider ?? "").trim();
+  const scopes = Array.isArray(body.scopes)
+    ? body.scopes.map(String).map((scope) => scope.trim()).filter(Boolean)
+    : undefined;
+  const connector = await registerMcpDcrConnector({
+    input: {
+      name: String(body.name ?? ""),
+      provider,
+      mcpUrl: String(body.mcpUrl ?? ""),
+      redirectUri: String(body.redirectUri ?? "").trim() || defaultRedirectUri(provider),
+      ...(scopes && scopes.length > 0 ? { scopes } : {}),
+    },
+    connectorService: await getOAuthConnectorService(),
+  });
+  return successResponse(connector, 201);
+});

--- a/ui/src/app/api/mcp-servers/credential-probe/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/credential-probe/__tests__/route.test.ts
@@ -1,0 +1,187 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockRequireResourcePermission = jest.fn();
+const mockResolveMcpHeaderCredentials = jest.fn();
+const mockIsAgentGatewayEndpoint = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    status: number;
+    constructor(message: string, status = 500) {
+      super(message);
+      this.status = status;
+    }
+  }
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) =>
+      mockGetAuthFromBearerOrSession(...args),
+    successResponse: (data: unknown, status = 200) =>
+      Response.json({ success: true, data }, { status }),
+    withErrorHandler:
+      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      async (request: NextRequest) => {
+        try {
+          return await handler(request);
+        } catch (error) {
+          const typed = error as { status?: number; message: string };
+          return Response.json(
+            { success: false, error: typed.message },
+            { status: typed.status ?? 500 },
+          );
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+}));
+
+jest.mock("@/lib/mcp-credential-headers", () => ({
+  isMcpCredentialUnavailableError: () => false,
+  resolveMcpHeaderCredentials: (...args: unknown[]) =>
+    mockResolveMcpHeaderCredentials(...args),
+}));
+
+jest.mock("@/lib/mcp-http-server-client", () => ({
+  isAgentGatewayEndpoint: (...args: unknown[]) => mockIsAgentGatewayEndpoint(...args),
+}));
+
+function request(): NextRequest {
+  return new NextRequest("http://localhost:3000/api/mcp-servers/credential-probe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      url: "http://agentgateway:4000/mcp/example",
+      credential_sources: [
+        {
+          kind: "provider_connection",
+          target: "header",
+          name: "X-CAIPE-Provider-Token",
+          provider: "example",
+        },
+      ],
+    }),
+  });
+}
+
+describe("POST /api/mcp-servers/credential-probe", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({
+      session: { sub: "test-user", accessToken: "caller-token" },
+    });
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    mockIsAgentGatewayEndpoint.mockReturnValue(true);
+    mockResolveMcpHeaderCredentials.mockResolvedValue({
+      headers: {
+        Authorization: "Bearer caller-token",
+        "X-CAIPE-Provider-Token": "provider-token",
+      },
+      sources: [
+        {
+          name: "X-CAIPE-Provider-Token",
+          kind: "provider_connection",
+          origin: "provider_connection",
+          provider: "example",
+        },
+      ],
+    });
+  });
+
+  it("performs a real MCP initialize request through AgentGateway", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      Response.json({
+        jsonrpc: "2.0",
+        id: "credential-probe-initialize",
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          serverInfo: { name: "example", version: "1.0.0" },
+        },
+      }),
+    ) as unknown as typeof fetch;
+    const { POST } = await import("../route");
+
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(body.data).toMatchObject({ ok: true, status: 200, missingCredentials: [] });
+    expect(mockResolveMcpHeaderCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({ viaAgentGateway: true }),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      "http://agentgateway:4000/mcp/example",
+      expect.objectContaining({
+        method: "POST",
+        body: expect.stringContaining('"method":"initialize"'),
+      }),
+    );
+    const fetchHeaders = (global.fetch as jest.Mock).mock.calls[0][1].headers as Headers;
+    expect(fetchHeaders.get("authorization")).toBe("Bearer caller-token");
+    expect(fetchHeaders.get("x-caipe-provider-token")).toBe("provider-token");
+  });
+
+  it("does not treat an HTTP 405 response as connected", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      new Response("Method Not Allowed", { status: 405 }),
+    ) as unknown as typeof fetch;
+    const { POST } = await import("../route");
+
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(body.data).toMatchObject({
+      ok: false,
+      status: 405,
+      error: "MCP initialize failed with HTTP 405",
+    });
+  });
+
+  it("rejects a successful HTTP response without an initialize result", async () => {
+    global.fetch = jest.fn().mockResolvedValue(
+      Response.json({ jsonrpc: "2.0", id: "credential-probe-initialize" }),
+    ) as unknown as typeof fetch;
+    const { POST } = await import("../route");
+
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(body.data).toMatchObject({
+      ok: false,
+      status: 200,
+      error: "MCP initialize returned an invalid JSON-RPC response",
+    });
+  });
+
+  it("does not probe the network when a credential is unresolved", async () => {
+    mockResolveMcpHeaderCredentials.mockResolvedValue({
+      headers: { Authorization: "Bearer caller-token" },
+      sources: [
+        {
+          name: "X-CAIPE-Provider-Token",
+          kind: "provider_connection",
+          origin: "none",
+          provider: "example",
+        },
+      ],
+    });
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    const { POST } = await import("../route");
+
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(body.data).toMatchObject({
+      ok: false,
+      missingCredentials: ["X-CAIPE-Provider-Token"],
+    });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/mcp-servers/credential-probe/route.ts
+++ b/ui/src/app/api/mcp-servers/credential-probe/route.ts
@@ -13,6 +13,7 @@ import {
 import { caipeOrgKey } from "@/lib/rbac/organization";
 import { requireResourcePermission } from "@/lib/rbac/resource-authz";
 import { isMcpCredentialUnavailableError, resolveMcpHeaderCredentials } from "@/lib/mcp-credential-headers";
+import { isAgentGatewayEndpoint } from "@/lib/mcp-http-server-client";
 import type { McpCredentialResolution } from "@/lib/mcp-credential-headers";
 import type { MCPCredentialSource } from "@/types/dynamic-agent";
 import { NextRequest } from "next/server";
@@ -39,6 +40,45 @@ function normalizedUrl(value: unknown): string {
     throw new ApiError("Endpoint URL must use http or https", 400);
   }
   return parsed.toString().replace(/\/$/, "");
+}
+
+function parseSseJson(text: string): unknown | null {
+  for (const line of text.split(/\r?\n/)) {
+    if (!line.startsWith("data:")) continue;
+    const data = line.slice("data:".length).trim();
+    if (!data || data === "[DONE]") continue;
+    try {
+      return JSON.parse(data);
+    } catch {
+      continue;
+    }
+  }
+  return null;
+}
+
+async function readJsonOrSse(response: Response): Promise<unknown> {
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) return response.json();
+  const text = await response.text();
+  if (contentType.includes("text/event-stream")) {
+    const payload = parseSseJson(text);
+    if (payload !== null) return payload;
+  }
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+function initializeError(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") return "MCP initialize returned an invalid response";
+  const message = (payload as { error?: { message?: unknown } }).error?.message;
+  if (typeof message === "string" && message.trim()) return message.trim();
+  const result = (payload as { result?: unknown }).result;
+  return result && typeof result === "object"
+    ? null
+    : "MCP initialize returned an invalid JSON-RPC response";
 }
 
 export const POST = withErrorHandler(async (request: NextRequest) => {
@@ -71,7 +111,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       request,
       session,
       server: fakeServer,
-      viaAgentGateway: false,
+      viaAgentGateway: isAgentGatewayEndpoint(fakeServer),
       retrievalCaller: "mcp-credential-probe",
     });
   } catch (error) {
@@ -90,39 +130,67 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     .filter((s) => s.origin === "none")
     .map((s) => s.name);
 
-  // Make the probe request with resolved headers
+  const credentialOrigins = resolution.sources.map((s) => ({
+    name: s.name,
+    origin: s.origin,
+    ...(s.provider ? { provider: s.provider } : {}),
+  }));
+  if (missingCredentials.length > 0) {
+    return successResponse<CredentialProbeResult>({
+      ok: false,
+      error: "One or more credentials could not be resolved. Check that connected apps are authorized.",
+      credentialOrigins,
+      missingCredentials,
+    });
+  }
+
+  // A GET 405 is valid for Streamable HTTP servers that do not expose an SSE
+  // listener, so it cannot prove the MCP connection works. Perform the actual
+  // protocol initialize exchange with the same resolved headers instead.
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 8000);
   let probeResult: CredentialProbeResult;
   try {
-    const headers = new Headers({ accept: "application/json, text/event-stream;q=0.9, */*;q=0.1" });
+    const headers = new Headers({
+      accept: "application/json, text/event-stream;q=0.9, */*;q=0.1",
+      "content-type": "application/json",
+    });
     for (const [key, value] of Object.entries(resolution.headers)) {
       headers.set(key, value);
     }
     const response = await fetch(url, {
-      method: "GET",
+      method: "POST",
       signal: controller.signal,
       headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "credential-probe-initialize",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "caipe-ui-credential-probe", version: "1.0.0" },
+        },
+      }),
     });
+    const payload = await readJsonOrSse(response);
+    const protocolError = response.ok ? initializeError(payload) : null;
     probeResult = {
-      ok: response.status < 500 && response.status !== 404,
+      ok: response.ok && protocolError === null,
       status: response.status,
-      credentialOrigins: resolution.sources.map((s) => ({
-        name: s.name,
-        origin: s.origin,
-        ...(s.provider ? { provider: s.provider } : {}),
-      })),
+      ...(!response.ok
+        ? { error: `MCP initialize failed with HTTP ${response.status}` }
+        : protocolError
+          ? { error: protocolError }
+          : {}),
+      credentialOrigins,
       missingCredentials,
     };
   } catch (error) {
     probeResult = {
       ok: false,
       error: error instanceof Error ? error.message : "Could not connect",
-      credentialOrigins: resolution.sources.map((s) => ({
-        name: s.name,
-        origin: s.origin,
-        ...(s.provider ? { provider: s.provider } : {}),
-      })),
+      credentialOrigins,
       missingCredentials,
     };
   } finally {

--- a/ui/src/components/credentials/OAuthConnectorAdminPanel.tsx
+++ b/ui/src/components/credentials/OAuthConnectorAdminPanel.tsx
@@ -18,6 +18,8 @@ interface OAuthConnectorMetadata {
   enabled?: boolean;
   clientSecretConfigured?: boolean;
   pkce?: boolean;
+  source?: "manual" | "mcp_dcr";
+  resource?: string;
 }
 
 async function parseApiResponse<T>(response: Response): Promise<T> {
@@ -37,7 +39,9 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
     scopes: "",
     redirectUri: "",
     pkce: false,
+    mcpUrl: "",
   });
+  const [registrationMode, setRegistrationMode] = React.useState<"manual" | "mcp_dcr">("manual");
   const [createOpen, setCreateOpen] = React.useState(false);
   const [editingConnector, setEditingConnector] = React.useState<OAuthConnectorMetadata | null>(null);
   const [error, setError] = React.useState<string | null>(null);
@@ -90,7 +94,9 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
     };
     const url = editingConnector
       ? `/api/admin/credentials/oauth-connectors/${editingConnector.id}`
-      : "/api/admin/credentials/oauth-connectors";
+      : registrationMode === "mcp_dcr"
+        ? "/api/admin/credentials/oauth-connectors/dcr"
+        : "/api/admin/credentials/oauth-connectors";
     const method = editingConnector ? "PUT" : "POST";
     const response = await fetch(url, {
       method,
@@ -119,7 +125,9 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
       scopes: "",
       redirectUri: "",
       pkce: false,
+      mcpUrl: "",
     });
+    setRegistrationMode("manual");
     setEditingConnector(null);
     setCreateOpen(false);
   };
@@ -137,7 +145,9 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
       scopes: connector.scopes.join(" "),
       redirectUri: connector.redirectUri,
       pkce: connector.pkce ?? false,
+      mcpUrl: connector.resource ?? "",
     });
+    setRegistrationMode("manual");
     setCreateOpen(true);
   };
 
@@ -182,9 +192,29 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
             credential payloads and are never shown here.
           </p>
         </div>
-        <Button type="button" onClick={() => setCreateOpen(true)} disabled={readOnly}>
-          Add OAuth Provider
-        </Button>
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => {
+              setRegistrationMode("mcp_dcr");
+              setCreateOpen(true);
+            }}
+            disabled={readOnly}
+          >
+            Add MCP Provider
+          </Button>
+          <Button
+            type="button"
+            onClick={() => {
+              setRegistrationMode("manual");
+              setCreateOpen(true);
+            }}
+            disabled={readOnly}
+          >
+            Add OAuth Provider
+          </Button>
+        </div>
       </div>
 
       {createOpen && (
@@ -200,9 +230,17 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
           >
             <div className="flex items-start justify-between gap-4">
               <div>
-                <h2 className="text-lg font-medium">{editingConnector ? "Edit OAuth Provider" : "Add OAuth Provider"}</h2>
+                <h2 className="text-lg font-medium">
+                  {editingConnector
+                    ? "Edit OAuth Provider"
+                    : registrationMode === "mcp_dcr"
+                      ? "Add MCP OAuth Provider"
+                      : "Add OAuth Provider"}
+                </h2>
                 <p className="text-sm text-muted-foreground">
-                  Configure a standard authorization-code connector for user connections.
+                  {registrationMode === "mcp_dcr" && !editingConnector
+                    ? "Discover authorization metadata from a remote MCP server and register GRID as a public PKCE client."
+                    : "Configure a standard authorization-code connector for user connections."}
                 </p>
               </div>
               <button
@@ -214,6 +252,7 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
               </button>
             </div>
             <div className="grid gap-4 md:grid-cols-2">
+              {registrationMode === "manual" || editingConnector ? (
               <label className="space-y-1 text-sm md:col-span-2">
                 <span>Built-in template</span>
                 <select
@@ -229,6 +268,7 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
                   ))}
                 </select>
               </label>
+              ) : null}
               <label className="space-y-1 text-sm">
                 <span>Display name</span>
                 <input className="w-full rounded-md border border-input bg-background px-3 py-2" value={form.name} onChange={updateForm("name")} required />
@@ -237,6 +277,39 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
                 <span>Provider</span>
                 <input className="w-full rounded-md border border-input bg-background px-3 py-2" value={form.provider} onChange={updateForm("provider")} required />
               </label>
+              {registrationMode === "mcp_dcr" && !editingConnector ? (
+                <>
+                  <label className="space-y-1 text-sm md:col-span-2">
+                    <span>MCP server URL</span>
+                    <input
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono"
+                      value={form.mcpUrl}
+                      onChange={updateForm("mcpUrl")}
+                      placeholder="https://example.com/api/mcp"
+                      required
+                    />
+                  </label>
+                  <label className="space-y-1 text-sm md:col-span-2">
+                    <span>Scopes (optional)</span>
+                    <input
+                      className="w-full rounded-md border border-input bg-background px-3 py-2"
+                      value={form.scopes}
+                      onChange={updateForm("scopes")}
+                      placeholder="Leave empty to use discovered scopes"
+                    />
+                  </label>
+                  <label className="space-y-1 text-sm md:col-span-2">
+                    <span>Redirect URI (optional)</span>
+                    <input
+                      className="w-full rounded-md border border-input bg-background px-3 py-2 font-mono"
+                      value={form.redirectUri}
+                      onChange={updateForm("redirectUri")}
+                      placeholder="Defaults to this GRID instance's provider callback"
+                    />
+                  </label>
+                </>
+              ) : (
+              <>
               <label className="space-y-1 text-sm">
                 <span>Client ID</span>
                 <input className="w-full rounded-md border border-input bg-background px-3 py-2" value={form.clientId} onChange={updateForm("clientId")} required />
@@ -271,8 +344,18 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
                 <span>Redirect URI</span>
                 <input className="w-full rounded-md border border-input bg-background px-3 py-2" value={form.redirectUri} onChange={updateForm("redirectUri")} required />
               </label>
+              </>
+              )}
             </div>
-            <SaveButton type="submit" saving={false} ariaLabel="Save connector" />
+            <SaveButton
+              type="submit"
+              saving={false}
+              ariaLabel={
+                registrationMode === "mcp_dcr" && !editingConnector
+                  ? "Discover and register MCP provider"
+                  : "Save connector"
+              }
+            />
           </form>
         </div>
       )}
@@ -292,6 +375,11 @@ export function OAuthConnectorAdminPanel({ readOnly = false }: { readOnly?: bool
                     <span className="inline-block rounded bg-muted px-2 py-1 text-xs">
                       {connector.pkce ? "public client (PKCE)" : connector.clientSecretConfigured ? "client secret configured" : "client secret missing"}
                     </span>
+                    {connector.source === "mcp_dcr" ? (
+                      <span className="inline-block rounded bg-muted px-2 py-1 text-xs">
+                        MCP dynamic registration
+                      </span>
+                    ) : null}
                     <span className="inline-block rounded bg-muted px-2 py-1 text-xs">
                       {connector.enabled === false ? "disabled" : "enabled"}
                     </span>

--- a/ui/src/components/credentials/__tests__/OAuthConnectorAdminPanel.test.tsx
+++ b/ui/src/components/credentials/__tests__/OAuthConnectorAdminPanel.test.tsx
@@ -101,6 +101,38 @@ describe("OAuthConnectorAdminPanel", () => {
     );
   });
 
+  it("registers a remote MCP provider through discovery and DCR", async () => {
+    const user = userEvent.setup();
+    render(<OAuthConnectorAdminPanel />);
+
+    await screen.findByText("GitHub");
+    await user.click(screen.getByRole("button", { name: /add mcp provider/i }));
+    await user.type(screen.getByLabelText(/display name/i), "Example MCP");
+    await user.type(screen.getByLabelText(/^provider/i), "example-mcp");
+    await user.type(
+      screen.getByLabelText(/mcp server url/i),
+      "https://mcp.example.com/api/mcp",
+    );
+    await user.type(screen.getByLabelText(/scopes/i), "openid profile offline_access");
+    await user.click(screen.getByRole("button", { name: /discover and register/i }));
+
+    await waitFor(() =>
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/admin/credentials/oauth-connectors/dcr",
+        expect.objectContaining({
+          method: "POST",
+          body: expect.stringContaining('"mcpUrl":"https://mcp.example.com/api/mcp"'),
+        }),
+      ),
+    );
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/admin/credentials/oauth-connectors/dcr",
+      expect.objectContaining({
+        body: expect.stringContaining('"scopes":["openid","profile","offline_access"]'),
+      }),
+    );
+  });
+
   it("prefills GitLab.com connector defaults from the built-in provider template", async () => {
     const user = userEvent.setup();
     render(<OAuthConnectorAdminPanel />);

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -1190,16 +1190,15 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
                 {credentialProbe && (() => {
                   const hasMissing = credentialProbe.missingCredentials.length > 0;
                   const fullyOk = credentialProbe.ok && !hasMissing;
-                  const reachableButAuth = credentialProbe.ok && hasMissing;
                   const colorClass = fullyOk
                     ? "text-green-600 dark:text-green-400"
-                    : reachableButAuth
+                    : hasMissing
                       ? "text-yellow-600 dark:text-yellow-400"
                       : "text-destructive";
                   const label = fullyOk
                     ? `Connected (HTTP ${credentialProbe.status})`
-                    : reachableButAuth
-                      ? `Reachable (HTTP ${credentialProbe.status}) — credentials not resolved`
+                    : hasMissing
+                      ? "Credentials not resolved"
                       : credentialProbe.error
                         ? credentialProbe.error
                         : `Failed (HTTP ${credentialProbe.status})`;

--- a/ui/src/lib/credentials/__tests__/mcp-dcr.test.ts
+++ b/ui/src/lib/credentials/__tests__/mcp-dcr.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, jest } from "@jest/globals";
+
+import { discoverMcpOAuth, registerMcpDcrConnector } from "../mcp-dcr";
+import type { OAuthConnectorMetadata } from "../oauth-service";
+
+function mockResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
+  const normalizedHeaders = new Map(
+    Object.entries(headers).map(([key, value]) => [key.toLowerCase(), value]),
+  );
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: {
+      get: (name: string) => normalizedHeaders.get(name.toLowerCase()) ?? null,
+    },
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const resourceMetadata = {
+  resource: "https://grid.example.test/api/tome/mcp",
+  authorization_servers: ["https://grid.example.test/realms/example"],
+  scopes_supported: ["openid", "profile", "offline_access"],
+};
+
+const authorizationMetadata = {
+  issuer: "https://grid.example.test/realms/example",
+  authorization_endpoint: "https://grid.example.test/realms/example/protocol/openid-connect/auth",
+  token_endpoint: "https://grid.example.test/realms/example/protocol/openid-connect/token",
+  registration_endpoint: "https://grid.example.test/realms/example/clients-registrations/openid-connect",
+  scopes_supported: ["openid", "profile", "offline_access"],
+  code_challenge_methods_supported: ["S256"],
+};
+
+describe("MCP OAuth dynamic client registration", () => {
+  it("discovers protected-resource and authorization-server metadata from the MCP challenge", async () => {
+    const fetchImpl = jest.fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        mockResponse(null, 401, {
+          "www-authenticate":
+            'Bearer resource_metadata="https://grid.example.test/.well-known/oauth-protected-resource/api/tome/mcp"',
+        }),
+      )
+      .mockResolvedValueOnce(mockResponse(resourceMetadata))
+      .mockResolvedValueOnce(mockResponse(authorizationMetadata));
+
+    await expect(
+      discoverMcpOAuth(
+        { mcpUrl: "https://grid.example.test/api/tome/mcp" },
+        fetchImpl,
+      ),
+    ).resolves.toEqual({
+      resource: "https://grid.example.test/api/tome/mcp",
+      resourceMetadataUrl:
+        "https://grid.example.test/.well-known/oauth-protected-resource/api/tome/mcp",
+      issuer: "https://grid.example.test/realms/example",
+      authorizationEndpoint:
+        "https://grid.example.test/realms/example/protocol/openid-connect/auth",
+      tokenEndpoint:
+        "https://grid.example.test/realms/example/protocol/openid-connect/token",
+      registrationEndpoint:
+        "https://grid.example.test/realms/example/clients-registrations/openid-connect",
+      scopes: ["openid", "profile", "offline_access"],
+    });
+  });
+
+  it("registers a public PKCE client and persists a resource-bound connector", async () => {
+    const fetchImpl = jest.fn<typeof fetch>()
+      .mockResolvedValueOnce(mockResponse(null, 401))
+      .mockResolvedValueOnce(mockResponse(resourceMetadata))
+      .mockResolvedValueOnce(mockResponse(authorizationMetadata))
+      .mockResolvedValueOnce(
+        mockResponse(
+          {
+            client_id: "generated-client",
+            registration_access_token: "registration-token",
+            registration_client_uri:
+              "https://grid.example.test/realms/example/clients-registrations/openid-connect/generated-client",
+          },
+          201,
+        ),
+      );
+    const metadata: OAuthConnectorMetadata = {
+      id: "connector-1",
+      name: "Tome MCP",
+      provider: "tome-mcp",
+      clientId: "generated-client",
+      authorizationUrl: authorizationMetadata.authorization_endpoint,
+      tokenUrl: authorizationMetadata.token_endpoint,
+      scopes: resourceMetadata.scopes_supported,
+      redirectUri: "https://grid-client.example.test/api/credentials/oauth/tome-mcp/callback",
+      resource: resourceMetadata.resource,
+      source: "mcp_dcr",
+      registrationEndpoint: authorizationMetadata.registration_endpoint,
+      registrationClientUri:
+        "https://grid.example.test/realms/example/clients-registrations/openid-connect/generated-client",
+      enabled: true,
+      pkce: true,
+      createdAt: new Date("2026-08-08T00:00:00Z"),
+      updatedAt: new Date("2026-08-08T00:00:00Z"),
+      clientSecretConfigured: false,
+    };
+    const connectorService = {
+      listConnectors: jest.fn(async () => [] as OAuthConnectorMetadata[]),
+      createConnector: jest.fn(async () => metadata),
+    };
+
+    await expect(
+      registerMcpDcrConnector({
+        input: {
+          name: "Tome MCP",
+          provider: "tome-mcp",
+          mcpUrl: "https://grid.example.test/api/tome/mcp",
+          redirectUri:
+            "https://grid-client.example.test/api/credentials/oauth/tome-mcp/callback",
+        },
+        connectorService,
+        fetchImpl,
+      }),
+    ).resolves.toEqual(metadata);
+
+    expect(connectorService.createConnector).toHaveBeenCalledWith(
+      expect.objectContaining({
+        clientId: "generated-client",
+        pkce: true,
+        resource: "https://grid.example.test/api/tome/mcp",
+        source: "mcp_dcr",
+        registrationAccessToken: "registration-token",
+      }),
+    );
+    const registrationRequest = fetchImpl.mock.calls[3];
+    expect(registrationRequest[0]).toBe(authorizationMetadata.registration_endpoint);
+    expect(JSON.parse(String(registrationRequest[1]?.body))).toMatchObject({
+      token_endpoint_auth_method: "none",
+      grant_types: ["authorization_code", "refresh_token"],
+      redirect_uris: [
+        "https://grid-client.example.test/api/credentials/oauth/tome-mcp/callback",
+      ],
+    });
+  });
+
+  it("rejects an authorization server that does not support PKCE S256", async () => {
+    const fetchImpl = jest.fn<typeof fetch>()
+      .mockResolvedValueOnce(mockResponse(null, 401))
+      .mockResolvedValueOnce(mockResponse(resourceMetadata))
+      .mockResolvedValueOnce(
+        mockResponse({
+          ...authorizationMetadata,
+          code_challenge_methods_supported: ["plain"],
+        }),
+      );
+
+    await expect(
+      discoverMcpOAuth(
+        { mcpUrl: "https://grid.example.test/api/tome/mcp" },
+        fetchImpl,
+      ),
+    ).rejects.toMatchObject({ code: "MCP_OAUTH_PKCE_UNSUPPORTED" });
+  });
+});

--- a/ui/src/lib/credentials/__tests__/mcp-dcr.test.ts
+++ b/ui/src/lib/credentials/__tests__/mcp-dcr.test.ts
@@ -22,7 +22,7 @@ function mockResponse(
 }
 
 const resourceMetadata = {
-  resource: "https://grid.example.test/api/tome/mcp",
+  resource: "https://grid.example.test/api/example/mcp",
   authorization_servers: ["https://grid.example.test/realms/example"],
   scopes_supported: ["openid", "profile", "offline_access"],
 };
@@ -42,7 +42,7 @@ describe("MCP OAuth dynamic client registration", () => {
       .mockResolvedValueOnce(
         mockResponse(null, 401, {
           "www-authenticate":
-            'Bearer resource_metadata="https://grid.example.test/.well-known/oauth-protected-resource/api/tome/mcp"',
+            'Bearer resource_metadata="https://grid.example.test/.well-known/oauth-protected-resource/api/example/mcp"',
         }),
       )
       .mockResolvedValueOnce(mockResponse(resourceMetadata))
@@ -50,13 +50,13 @@ describe("MCP OAuth dynamic client registration", () => {
 
     await expect(
       discoverMcpOAuth(
-        { mcpUrl: "https://grid.example.test/api/tome/mcp" },
+        { mcpUrl: "https://grid.example.test/api/example/mcp" },
         fetchImpl,
       ),
     ).resolves.toEqual({
-      resource: "https://grid.example.test/api/tome/mcp",
+      resource: "https://grid.example.test/api/example/mcp",
       resourceMetadataUrl:
-        "https://grid.example.test/.well-known/oauth-protected-resource/api/tome/mcp",
+        "https://grid.example.test/.well-known/oauth-protected-resource/api/example/mcp",
       issuer: "https://grid.example.test/realms/example",
       authorizationEndpoint:
         "https://grid.example.test/realms/example/protocol/openid-connect/auth",
@@ -86,13 +86,13 @@ describe("MCP OAuth dynamic client registration", () => {
       );
     const metadata: OAuthConnectorMetadata = {
       id: "connector-1",
-      name: "Tome MCP",
-      provider: "tome-mcp",
+      name: "Example MCP",
+      provider: "example-mcp",
       clientId: "generated-client",
       authorizationUrl: authorizationMetadata.authorization_endpoint,
       tokenUrl: authorizationMetadata.token_endpoint,
       scopes: resourceMetadata.scopes_supported,
-      redirectUri: "https://grid-client.example.test/api/credentials/oauth/tome-mcp/callback",
+      redirectUri: "https://grid-client.example.test/api/credentials/oauth/example-mcp/callback",
       resource: resourceMetadata.resource,
       source: "mcp_dcr",
       registrationEndpoint: authorizationMetadata.registration_endpoint,
@@ -112,11 +112,11 @@ describe("MCP OAuth dynamic client registration", () => {
     await expect(
       registerMcpDcrConnector({
         input: {
-          name: "Tome MCP",
-          provider: "tome-mcp",
-          mcpUrl: "https://grid.example.test/api/tome/mcp",
+          name: "Example MCP",
+          provider: "example-mcp",
+          mcpUrl: "https://grid.example.test/api/example/mcp",
           redirectUri:
-            "https://grid-client.example.test/api/credentials/oauth/tome-mcp/callback",
+            "https://grid-client.example.test/api/credentials/oauth/example-mcp/callback",
         },
         connectorService,
         fetchImpl,
@@ -127,7 +127,7 @@ describe("MCP OAuth dynamic client registration", () => {
       expect.objectContaining({
         clientId: "generated-client",
         pkce: true,
-        resource: "https://grid.example.test/api/tome/mcp",
+        resource: "https://grid.example.test/api/example/mcp",
         source: "mcp_dcr",
         registrationAccessToken: "registration-token",
       }),
@@ -138,7 +138,7 @@ describe("MCP OAuth dynamic client registration", () => {
       token_endpoint_auth_method: "none",
       grant_types: ["authorization_code", "refresh_token"],
       redirect_uris: [
-        "https://grid-client.example.test/api/credentials/oauth/tome-mcp/callback",
+        "https://grid-client.example.test/api/credentials/oauth/example-mcp/callback",
       ],
     });
   });
@@ -156,7 +156,7 @@ describe("MCP OAuth dynamic client registration", () => {
 
     await expect(
       discoverMcpOAuth(
-        { mcpUrl: "https://grid.example.test/api/tome/mcp" },
+        { mcpUrl: "https://grid.example.test/api/example/mcp" },
         fetchImpl,
       ),
     ).rejects.toMatchObject({ code: "MCP_OAUTH_PKCE_UNSUPPORTED" });

--- a/ui/src/lib/credentials/__tests__/oauth-bootstrap.test.ts
+++ b/ui/src/lib/credentials/__tests__/oauth-bootstrap.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it, jest } from "@jest/globals";
 
-import { buildOAuthConnectorBootstrapInputs, bootstrapOAuthConnectorsFromEnv } from "../oauth-bootstrap";
+import {
+  buildMcpDcrConnectorBootstrapInputs,
+  buildOAuthConnectorBootstrapInputs,
+  bootstrapOAuthConnectorsFromEnv,
+} from "../oauth-bootstrap";
 import type { CreateConnectorInput, OAuthConnectorMetadata, OAuthConnectorService } from "../oauth-service";
 
 type UpsertConnector = OAuthConnectorService["upsertConnector"];
@@ -192,6 +196,66 @@ describe("OAuth connector env bootstrap", () => {
         redirectUri: "https://caipe.example.com/custom/callback",
       },
     ]);
+  });
+
+  it("builds an MCP DCR connector without a client ID or OAuth endpoint configuration", () => {
+    const env = {
+      NEXTAUTH_URL: "https://caipe.example.com",
+      CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON: JSON.stringify([
+        {
+          provider: "example-mcp",
+          name: "Example MCP",
+          mcpUrl: "https://mcp.example.com/api/mcp",
+          scopes: ["openid", "offline_access"],
+        },
+      ]),
+    };
+
+    expect(buildOAuthConnectorBootstrapInputs(env)).toEqual([]);
+    expect(buildMcpDcrConnectorBootstrapInputs(env)).toEqual([
+      {
+        provider: "example-mcp",
+        name: "Example MCP",
+        mcpUrl: "https://mcp.example.com/api/mcp",
+        scopes: ["openid", "offline_access"],
+        redirectUri: "https://caipe.example.com/api/credentials/oauth/example-mcp/callback",
+      },
+    ]);
+  });
+
+  it("treats an existing deployment-managed MCP DCR connector as idempotently applied", async () => {
+    const existing = connectorMetadata({
+      provider: "example-mcp",
+      name: "Example MCP",
+      clientId: "generated-client",
+      pkce: true,
+    });
+    const service = {
+      upsertConnector: jest.fn<UpsertConnector>(),
+      listConnectors: jest.fn(async () => [existing]),
+      createConnector: jest.fn(async () => existing),
+    };
+    const fetchImpl = jest.fn<typeof fetch>();
+
+    await expect(
+      bootstrapOAuthConnectorsFromEnv({
+        env: {
+          NEXTAUTH_URL: "https://caipe.example.com",
+          CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON: JSON.stringify([
+            {
+              provider: "example-mcp",
+              name: "Example MCP",
+              mcpUrl: "https://mcp.example.com/api/mcp",
+            },
+          ]),
+        },
+        service,
+        fetchImpl,
+      }),
+    ).resolves.toBe(1);
+
+    expect(service.createConnector).not.toHaveBeenCalled();
+    expect(fetchImpl).not.toHaveBeenCalled();
   });
 
   it("lets deploy-configured connectors override legacy bootstrap for the same provider", () => {

--- a/ui/src/lib/credentials/__tests__/oauth-bootstrap.test.ts
+++ b/ui/src/lib/credentials/__tests__/oauth-bootstrap.test.ts
@@ -258,6 +258,81 @@ describe("OAuth connector env bootstrap", () => {
     expect(fetchImpl).not.toHaveBeenCalled();
   });
 
+  it("preserves connector service method context during MCP DCR bootstrap", async () => {
+    const service = {
+      connectors: [] as OAuthConnectorMetadata[],
+      upsertConnector: jest.fn<UpsertConnector>(),
+      async listConnectors() {
+        return this.connectors;
+      },
+      async createConnector(input: CreateConnectorInput) {
+        const connector = connectorMetadata(input);
+        this.connectors.push(connector);
+        return connector;
+      },
+    };
+    const response = (
+      body: unknown,
+      status = 200,
+      headers: Record<string, string> = {},
+    ): Response => ({
+      ok: status >= 200 && status < 300,
+      status,
+      headers: {
+        get: (name: string) => headers[name.toLowerCase()] ?? null,
+      } as Headers,
+      json: async () => body,
+    }) as Response;
+    const fetchImpl = jest
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce(
+        response(null, 401, {
+          "www-authenticate":
+            'Bearer resource_metadata="https://mcp.example.com/.well-known/oauth-protected-resource/api/mcp"',
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          resource: "https://mcp.example.com/api/mcp",
+          authorization_servers: ["https://identity.example.com"],
+          scopes_supported: ["openid", "offline_access"],
+        }),
+      )
+      .mockResolvedValueOnce(
+        response({
+          issuer: "https://identity.example.com",
+          authorization_endpoint: "https://identity.example.com/oauth/authorize",
+          token_endpoint: "https://identity.example.com/oauth/token",
+          registration_endpoint: "https://identity.example.com/oauth/register",
+          scopes_supported: ["openid", "offline_access"],
+          code_challenge_methods_supported: ["S256"],
+        }),
+      )
+      .mockResolvedValueOnce(response({ client_id: "generated-client" }));
+
+    await expect(
+      bootstrapOAuthConnectorsFromEnv({
+        env: {
+          NEXTAUTH_URL: "https://caipe.example.com",
+          CREDENTIAL_BOOTSTRAP_OAUTH_CONNECTORS_JSON: JSON.stringify([
+            {
+              provider: "example-mcp",
+              name: "Example MCP",
+              mcpUrl: "https://mcp.example.com/api/mcp",
+            },
+          ]),
+        },
+        service,
+        fetchImpl,
+      }),
+    ).resolves.toBe(1);
+
+    expect(service.connectors).toEqual([
+      expect.objectContaining({ provider: "example-mcp", clientId: "generated-client" }),
+    ]);
+    expect(fetchImpl).toHaveBeenCalledTimes(4);
+  });
+
   it("lets deploy-configured connectors override legacy bootstrap for the same provider", () => {
     const inputs = buildOAuthConnectorBootstrapInputs({
       WEBEX_CLIENT_ID: "legacy-webex-client",

--- a/ui/src/lib/credentials/__tests__/oauth-service.test.ts
+++ b/ui/src/lib/credentials/__tests__/oauth-service.test.ts
@@ -946,6 +946,85 @@ describe("ProviderConnectionService", () => {
     });
   });
 
+  it("sends an MCP resource indicator during authorization, token exchange, and refresh", async () => {
+    const connectors = new MemoryCollection<OAuthConnectorDocument>();
+    const connections = new MemoryCollection<ProviderConnectionDocument>();
+    const secrets = new Map<string, string>();
+    const payloadStore = {
+      getSecret: jest.fn(async (ref: string) => {
+        const value = secrets.get(ref);
+        if (!value) throw new Error("missing secret");
+        return value;
+      }),
+      putSecret: jest.fn(async ({ secretRefId, plaintext }: { secretRefId: string; plaintext: string }) => {
+        secrets.set(secretRefId, plaintext);
+      }),
+    };
+    connectors.docs.push({
+      id: "connector-1",
+      name: "Example MCP",
+      provider: "example-mcp",
+      clientId: "dcr-client-id",
+      clientSecretRef: "oauth_connector:connector-1:client_secret",
+      authorizationUrl: "https://idp.example.com/oauth/authorize",
+      tokenUrl: "https://idp.example.com/oauth/token",
+      scopes: ["openid", "offline_access"],
+      redirectUri: "https://grid.example.com/api/credentials/oauth/example-mcp/callback",
+      resource: "https://mcp.example.com/api/mcp",
+      source: "mcp_dcr",
+      enabled: true,
+      pkce: true,
+      createdAt: new Date("2026-08-08T00:00:00Z"),
+      updatedAt: new Date("2026-08-08T00:00:00Z"),
+    });
+    const tokenClient = jest.fn<ProviderConnectionServiceOptions["tokenClient"]>()
+      .mockResolvedValueOnce({
+        access_token: "initial-access-token",
+        refresh_token: "refresh-token",
+        expires_in: 1,
+      })
+      .mockResolvedValueOnce({ access_token: "refreshed-access-token", expires_in: 3600 });
+    const service = new ProviderConnectionService({
+      providerConnectionsCollection: connections,
+      connectorsCollection: connectors,
+      payloadStore,
+      tokenClient,
+      idGenerator: () => "provider-connection-1",
+      now: () => new Date("2026-08-08T00:00:00Z"),
+    });
+
+    const start = await service.startConnection({
+      providerKey: "example-mcp",
+      owner: { type: "user", id: "user-1" },
+      state: "state-1",
+      codeChallenge: "challenge-1",
+    });
+    expect(new URL(start.authorizationUrl).searchParams.get("resource")).toBe(
+      "https://mcp.example.com/api/mcp",
+    );
+
+    const connection = await service.completeConnection({
+      providerKey: "example-mcp",
+      owner: { type: "user", id: "user-1" },
+      code: "authorization-code",
+      codeVerifier: "verifier-1",
+    });
+    expect(tokenClient.mock.calls[0][1]).toMatchObject({
+      client_id: "dcr-client-id",
+      code_verifier: "verifier-1",
+      resource: "https://mcp.example.com/api/mcp",
+    });
+    expect(tokenClient.mock.calls[0][1]).not.toHaveProperty("client_secret");
+
+    await service.refreshConnection(connection.id);
+    expect(tokenClient.mock.calls[1][1]).toMatchObject({
+      client_id: "dcr-client-id",
+      refresh_token: "refresh-token",
+      resource: "https://mcp.example.com/api/mcp",
+    });
+    expect(tokenClient.mock.calls[1][1]).not.toHaveProperty("client_secret");
+  });
+
   it("requests only the user's chosen subset and persists requested + granted scopes", async () => {
     const connectors = new MemoryCollection<OAuthConnectorDocument>();
     const connections = new MemoryCollection<ProviderConnectionDocument>();

--- a/ui/src/lib/credentials/mcp-dcr.ts
+++ b/ui/src/lib/credentials/mcp-dcr.ts
@@ -1,0 +1,341 @@
+import { ApiError } from "@/lib/api-error";
+
+import type {
+  CreateConnectorInput,
+  OAuthConnectorMetadata,
+  OAuthConnectorService,
+} from "./oauth-service";
+
+type FetchLike = typeof fetch;
+
+interface ProtectedResourceMetadata {
+  resource: string;
+  authorization_servers: string[];
+  scopes_supported?: string[];
+}
+
+interface AuthorizationServerMetadata {
+  issuer: string;
+  authorization_endpoint: string;
+  token_endpoint: string;
+  registration_endpoint: string;
+  scopes_supported?: string[];
+  code_challenge_methods_supported?: string[];
+}
+
+interface DynamicClientRegistrationResponse {
+  client_id: string;
+  registration_access_token?: string;
+  registration_client_uri?: string;
+}
+
+export interface RegisterMcpDcrConnectorInput {
+  name: string;
+  provider: string;
+  mcpUrl: string;
+  redirectUri: string;
+  scopes?: string[];
+}
+
+export interface McpDcrDiscovery {
+  resource: string;
+  resourceMetadataUrl: string;
+  issuer: string;
+  authorizationEndpoint: string;
+  tokenEndpoint: string;
+  registrationEndpoint: string;
+  scopes: string[];
+}
+
+function nonEmpty(value: unknown, field: string): string {
+  const trimmed = typeof value === "string" ? value.trim() : "";
+  if (!trimmed) {
+    throw new ApiError(`${field} is required`, 400, "VALIDATION_ERROR");
+  }
+  return trimmed;
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const parts = hostname.split(".").map(Number);
+  if (parts.length !== 4 || parts.some((part) => !Number.isInteger(part) || part < 0 || part > 255)) {
+    return false;
+  }
+  return (
+    parts[0] === 10 ||
+    parts[0] === 127 ||
+    (parts[0] === 169 && parts[1] === 254) ||
+    (parts[0] === 172 && parts[1] >= 16 && parts[1] <= 31) ||
+    (parts[0] === 192 && parts[1] === 168)
+  );
+}
+
+function validateRemoteUrl(value: unknown, field: string): string {
+  let url: URL;
+  try {
+    url = new URL(nonEmpty(value, field));
+  } catch {
+    throw new ApiError(`${field} must be a valid URL`, 400, "VALIDATION_ERROR");
+  }
+  const hostname = url.hostname.toLowerCase();
+  const localhost = hostname === "localhost" || hostname === "127.0.0.1" || hostname === "::1";
+  const localDevelopment = process.env.NODE_ENV !== "production" && localhost;
+  if (
+    (url.protocol !== "https:" && !(url.protocol === "http:" && localDevelopment)) ||
+    hostname.endsWith(".local") ||
+    (isPrivateIpv4(hostname) && !localDevelopment)
+  ) {
+    throw new ApiError(`${field} must be a public HTTPS URL`, 400, "VALIDATION_ERROR");
+  }
+  url.hash = "";
+  return url.toString();
+}
+
+function derivedResourceMetadataUrl(mcpUrl: string): string {
+  const resource = new URL(mcpUrl);
+  return `${resource.origin}/.well-known/oauth-protected-resource${resource.pathname}`;
+}
+
+function resourceMetadataFromChallenge(header: string | null): string | null {
+  if (!header) return null;
+  const match = /(?:^|[,\s])resource_metadata\s*=\s*"([^"]+)"/i.exec(header);
+  return match?.[1] ?? null;
+}
+
+async function fetchJson<T>(fetchImpl: FetchLike, url: string, init?: RequestInit): Promise<T> {
+  const timeoutSignal =
+    typeof AbortSignal.timeout === "function" ? AbortSignal.timeout(10_000) : undefined;
+  const response = await fetchImpl(url, {
+    ...init,
+    headers: {
+      accept: "application/json",
+      ...(init?.headers ?? {}),
+    },
+    signal: init?.signal ?? timeoutSignal,
+  });
+  if (!response.ok) {
+    throw new ApiError(
+      `OAuth discovery request failed with HTTP ${response.status}`,
+      400,
+      "MCP_OAUTH_DISCOVERY_FAILED",
+    );
+  }
+  try {
+    return (await response.json()) as T;
+  } catch {
+    throw new ApiError(
+      "OAuth discovery endpoint did not return JSON",
+      400,
+      "MCP_OAUTH_DISCOVERY_FAILED",
+    );
+  }
+}
+
+async function discoverResourceMetadataUrl(fetchImpl: FetchLike, mcpUrl: string): Promise<string> {
+  try {
+    const response = await fetchImpl(mcpUrl, {
+      method: "POST",
+      headers: {
+        accept: "application/json, text/event-stream",
+        "content-type": "application/json",
+        "mcp-protocol-version": "2025-06-18",
+      },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: "grid-oauth-discovery",
+        method: "initialize",
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "GRID", version: "1" },
+        },
+      }),
+      redirect: "error",
+      signal:
+        typeof AbortSignal.timeout === "function" ? AbortSignal.timeout(10_000) : undefined,
+    });
+    const challenged = resourceMetadataFromChallenge(response.headers.get("www-authenticate"));
+    if (challenged) return validateRemoteUrl(challenged, "resourceMetadataUrl");
+  } catch {
+    // RFC 9728 defines a deterministic well-known fallback. A network or
+    // method error on the MCP endpoint must not prevent standards discovery.
+  }
+  return validateRemoteUrl(derivedResourceMetadataUrl(mcpUrl), "resourceMetadataUrl");
+}
+
+function authorizationMetadataUrls(issuer: string): string[] {
+  const url = new URL(issuer);
+  const issuerPath = url.pathname.replace(/\/$/, "");
+  return [
+    `${issuer.replace(/\/$/, "")}/.well-known/openid-configuration`,
+    `${url.origin}/.well-known/oauth-authorization-server${issuerPath}`,
+  ];
+}
+
+async function fetchAuthorizationMetadata(
+  fetchImpl: FetchLike,
+  issuer: string,
+): Promise<AuthorizationServerMetadata> {
+  let lastError: unknown;
+  for (const candidate of authorizationMetadataUrls(issuer)) {
+    try {
+      const metadata = await fetchJson<AuthorizationServerMetadata>(
+        fetchImpl,
+        validateRemoteUrl(candidate, "authorizationServerMetadataUrl"),
+      );
+      if (metadata.issuer.replace(/\/$/, "") !== issuer.replace(/\/$/, "")) {
+        throw new ApiError(
+          "Authorization server metadata issuer does not match the advertised issuer",
+          400,
+          "MCP_OAUTH_ISSUER_MISMATCH",
+        );
+      }
+      return metadata;
+    } catch (error) {
+      lastError = error;
+    }
+  }
+  throw lastError instanceof Error
+    ? lastError
+    : new ApiError(
+        "Authorization server metadata could not be discovered",
+        400,
+        "MCP_OAUTH_DISCOVERY_FAILED",
+      );
+}
+
+function selectScopes(
+  requested: string[] | undefined,
+  resourceScopes: string[] | undefined,
+  authorizationScopes: string[] | undefined,
+): string[] {
+  const resourceAllowed = new Set((resourceScopes ?? []).map((scope) => scope.trim()).filter(Boolean));
+  const authorizationAllowed = new Set(
+    (authorizationScopes ?? []).map((scope) => scope.trim()).filter(Boolean),
+  );
+  const defaults = resourceAllowed.size > 0
+    ? Array.from(resourceAllowed)
+    : authorizationAllowed.size > 0
+      ? Array.from(authorizationAllowed)
+      : ["openid"];
+  const selected = Array.from(
+    new Set((requested ?? defaults).map((scope) => scope.trim()).filter(Boolean)),
+  );
+  const unsupported = selected.filter(
+    (scope) =>
+      (resourceAllowed.size > 0 && !resourceAllowed.has(scope)) ||
+      (authorizationAllowed.size > 0 && !authorizationAllowed.has(scope)),
+  );
+  if (unsupported.length > 0) {
+    throw new ApiError(
+      `Requested scopes are not supported by the MCP OAuth provider: ${unsupported.join(", ")}`,
+      400,
+      "VALIDATION_ERROR",
+    );
+  }
+  return selected;
+}
+
+export async function discoverMcpOAuth(
+  input: Pick<RegisterMcpDcrConnectorInput, "mcpUrl" | "scopes">,
+  fetchImpl: FetchLike = fetch,
+): Promise<McpDcrDiscovery> {
+  const mcpUrl = validateRemoteUrl(input.mcpUrl, "mcpUrl");
+  const resourceMetadataUrl = await discoverResourceMetadataUrl(fetchImpl, mcpUrl);
+  const resourceMetadata = await fetchJson<ProtectedResourceMetadata>(
+    fetchImpl,
+    resourceMetadataUrl,
+  );
+  const resource = validateRemoteUrl(resourceMetadata.resource, "resource");
+  const issuer = validateRemoteUrl(
+    resourceMetadata.authorization_servers?.[0] ?? "",
+    "authorizationServer",
+  ).replace(/\/$/, "");
+  const authorizationMetadata = await fetchAuthorizationMetadata(fetchImpl, issuer);
+  const pkceMethods = authorizationMetadata.code_challenge_methods_supported;
+  if (pkceMethods && !pkceMethods.includes("S256")) {
+    throw new ApiError(
+      "The MCP authorization server does not support PKCE S256",
+      400,
+      "MCP_OAUTH_PKCE_UNSUPPORTED",
+    );
+  }
+  return {
+    resource,
+    resourceMetadataUrl,
+    issuer,
+    authorizationEndpoint: validateRemoteUrl(
+      authorizationMetadata.authorization_endpoint,
+      "authorizationEndpoint",
+    ),
+    tokenEndpoint: validateRemoteUrl(authorizationMetadata.token_endpoint, "tokenEndpoint"),
+    registrationEndpoint: validateRemoteUrl(
+      authorizationMetadata.registration_endpoint,
+      "registrationEndpoint",
+    ),
+    scopes: selectScopes(
+      input.scopes,
+      resourceMetadata.scopes_supported,
+      authorizationMetadata.scopes_supported,
+    ),
+  };
+}
+
+export async function registerMcpDcrConnector(options: {
+  input: RegisterMcpDcrConnectorInput;
+  connectorService: Pick<OAuthConnectorService, "createConnector" | "listConnectors">;
+  fetchImpl?: FetchLike;
+}): Promise<OAuthConnectorMetadata> {
+  const provider = nonEmpty(options.input.provider, "provider");
+  const name = nonEmpty(options.input.name, "name");
+  const redirectUri = validateRemoteUrl(options.input.redirectUri, "redirectUri");
+  const existing = (await options.connectorService.listConnectors()).find(
+    (connector) => connector.provider === provider,
+  );
+  if (existing) {
+    throw new ApiError(
+      `OAuth provider ${provider} is already configured`,
+      409,
+      "CREDENTIAL_ALREADY_EXISTS",
+    );
+  }
+
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const discovery = await discoverMcpOAuth(options.input, fetchImpl);
+  const registration = await fetchJson<DynamicClientRegistrationResponse>(
+    fetchImpl,
+    discovery.registrationEndpoint,
+    {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        client_name: name,
+        redirect_uris: [redirectUri],
+        token_endpoint_auth_method: "none",
+        grant_types: ["authorization_code", "refresh_token"],
+        response_types: ["code"],
+        scope: discovery.scopes.join(" "),
+      }),
+    },
+  );
+  const clientId = nonEmpty(registration.client_id, "client_id");
+  const connectorInput: CreateConnectorInput = {
+    name,
+    provider,
+    clientId,
+    authorizationUrl: discovery.authorizationEndpoint,
+    tokenUrl: discovery.tokenEndpoint,
+    scopes: discovery.scopes,
+    redirectUri,
+    pkce: true,
+    resource: discovery.resource,
+    source: "mcp_dcr",
+    registrationEndpoint: discovery.registrationEndpoint,
+    ...(registration.registration_client_uri
+      ? { registrationClientUri: registration.registration_client_uri }
+      : {}),
+    ...(registration.registration_access_token
+      ? { registrationAccessToken: registration.registration_access_token }
+      : {}),
+  };
+  return options.connectorService.createConnector(connectorInput);
+}

--- a/ui/src/lib/credentials/oauth-bootstrap.ts
+++ b/ui/src/lib/credentials/oauth-bootstrap.ts
@@ -1,4 +1,8 @@
 import { BUILT_IN_OAUTH_CONNECTORS } from "./built-in-oauth-connectors";
+import {
+  registerMcpDcrConnector,
+  type RegisterMcpDcrConnectorInput,
+} from "./mcp-dcr";
 import type { CreateConnectorInput, OAuthConnectorService } from "./oauth-service";
 
 type Env = Record<string, string | undefined>;
@@ -191,7 +195,7 @@ function configuredScopes(connector: ConfiguredConnector, index: number): string
   });
 }
 
-function buildConfiguredOAuthConnectorBootstrapInputs(env: Env): CreateConnectorInput[] {
+function configuredConnectorArray(env: Env): ConfiguredConnector[] {
   const serialized = value(env, CONFIGURED_CONNECTORS_ENV);
   if (!serialized) {
     return [];
@@ -218,6 +222,16 @@ function buildConfiguredOAuthConnectorBootstrapInputs(env: Env): CreateConnector
       throw new Error(`OAuth connector provider ${provider} is configured more than once`);
     }
     providers.add(provider);
+    return connector;
+  });
+}
+
+function buildConfiguredOAuthConnectorBootstrapInputs(env: Env): CreateConnectorInput[] {
+  return configuredConnectorArray(env).flatMap((connector, index) => {
+    if (configuredString(connector, "mcpUrl", index)) {
+      return [];
+    }
+    const provider = configuredString(connector, "provider", index, { required: true })!;
 
     const pkceValue = connector.pkce;
     if (pkceValue !== undefined && typeof pkceValue !== "boolean") {
@@ -240,7 +254,7 @@ function buildConfiguredOAuthConnectorBootstrapInputs(env: Env): CreateConnector
 
     const redirectUri = configuredString(connector, "redirectUri", index)
       ?? canonicalProviderCallback(provider, env);
-    return {
+    return [{
       name: configuredString(connector, "name", index, { required: true })!,
       provider,
       clientId: configuredEnvValue(connector, "clientId", "clientIdEnv", env, index),
@@ -250,7 +264,43 @@ function buildConfiguredOAuthConnectorBootstrapInputs(env: Env): CreateConnector
       scopes: configuredScopes(connector, index),
       redirectUri: normalizeRedirectUri(provider, redirectUri, env),
       ...(pkce ? { pkce: true } : {}),
-    };
+    }];
+  });
+}
+
+export function buildMcpDcrConnectorBootstrapInputs(
+  env: Env = process.env,
+): RegisterMcpDcrConnectorInput[] {
+  return configuredConnectorArray(env).flatMap((connector, index) => {
+    const mcpUrl = configuredString(connector, "mcpUrl", index);
+    if (!mcpUrl) return [];
+    for (const incompatible of [
+      "clientId",
+      "clientIdEnv",
+      "clientSecretEnv",
+      "authorizationUrl",
+      "tokenUrl",
+      "pkce",
+    ]) {
+      if (connector[incompatible] !== undefined) {
+        throw new Error(
+          `OAuth connector at index ${index} must not set ${incompatible} when mcpUrl is used`,
+        );
+      }
+    }
+    const provider = configuredString(connector, "provider", index, { required: true })!;
+    const scopes = connector.scopes === undefined
+      ? undefined
+      : configuredScopes(connector, index);
+    return [{
+      name: configuredString(connector, "name", index, { required: true })!,
+      provider,
+      mcpUrl,
+      redirectUri:
+        configuredString(connector, "redirectUri", index) ??
+        canonicalProviderCallback(provider, env),
+      ...(scopes ? { scopes } : {}),
+    }];
   });
 }
 
@@ -280,7 +330,11 @@ export function buildOAuthConnectorBootstrapInputs(env: Env = process.env): Crea
     });
   }
   const configuredInputs = buildConfiguredOAuthConnectorBootstrapInputs(env);
-  const configuredProviders = new Set(configuredInputs.map((input) => input.provider));
+  const configuredProviders = new Set(
+    configuredConnectorArray(env).map((connector, index) =>
+      configuredString(connector, "provider", index, { required: true })!,
+    ),
+  );
   return [
     ...legacyInputs.filter((input) => !configuredProviders.has(input.provider)),
     ...configuredInputs,
@@ -289,7 +343,9 @@ export function buildOAuthConnectorBootstrapInputs(env: Env = process.env): Crea
 
 export async function bootstrapOAuthConnectorsFromEnv(options?: {
   env?: Env;
-  service?: Pick<OAuthConnectorService, "upsertConnector">;
+  service?: Pick<OAuthConnectorService, "upsertConnector"> &
+    Partial<Pick<OAuthConnectorService, "createConnector" | "listConnectors">>;
+  fetchImpl?: typeof fetch;
 }): Promise<number> {
   const env = options?.env ?? process.env;
   const hasConfiguredConnectors = Boolean(value(env, CONFIGURED_CONNECTORS_ENV));
@@ -297,7 +353,8 @@ export async function bootstrapOAuthConnectorsFromEnv(options?: {
     return 0;
   }
   const inputs = buildOAuthConnectorBootstrapInputs(env);
-  if (inputs.length === 0) {
+  const dcrInputs = buildMcpDcrConnectorBootstrapInputs(env);
+  if (inputs.length === 0 && dcrInputs.length === 0) {
     return 0;
   }
   const service = options?.service ?? await (async () => {
@@ -312,6 +369,30 @@ export async function bootstrapOAuthConnectorsFromEnv(options?: {
     } catch (err) {
       const message = err instanceof Error ? err.message : "unknown error";
       console.error(`[credentials] Skipped OAuth connector bootstrap for ${input.provider}: ${message}`);
+    }
+  }
+  if (dcrInputs.length > 0 && (!service.listConnectors || !service.createConnector)) {
+    throw new Error("MCP DCR bootstrap requires connector list and create support");
+  }
+  for (const input of dcrInputs) {
+    try {
+      const existing = (await service.listConnectors!()).find(
+        (connector) => connector.provider === input.provider,
+      );
+      if (!existing) {
+        await registerMcpDcrConnector({
+          input,
+          connectorService: {
+            listConnectors: service.listConnectors!,
+            createConnector: service.createConnector!,
+          },
+          fetchImpl: options?.fetchImpl,
+        });
+      }
+      applied++;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "unknown error";
+      console.error(`[credentials] Skipped MCP DCR connector bootstrap for ${input.provider}: ${message}`);
     }
   }
   if (applied > 0) {

--- a/ui/src/lib/credentials/oauth-bootstrap.ts
+++ b/ui/src/lib/credentials/oauth-bootstrap.ts
@@ -383,8 +383,8 @@ export async function bootstrapOAuthConnectorsFromEnv(options?: {
         await registerMcpDcrConnector({
           input,
           connectorService: {
-            listConnectors: service.listConnectors!,
-            createConnector: service.createConnector!,
+            listConnectors: service.listConnectors!.bind(service),
+            createConnector: service.createConnector!.bind(service),
           },
           fetchImpl: options?.fetchImpl,
         });

--- a/ui/src/lib/credentials/oauth-service.ts
+++ b/ui/src/lib/credentials/oauth-service.ts
@@ -30,13 +30,24 @@ export interface OAuthConnectorDocument {
   tokenUrl: string;
   scopes: string[];
   redirectUri: string;
+  /** RFC 8707 resource indicator used by MCP OAuth providers. */
+  resource?: string;
+  /** How the OAuth client was provisioned. */
+  source?: "manual" | "mcp_dcr";
+  /** RFC 7591/7592 metadata retained for DCR lifecycle management. */
+  registrationEndpoint?: string;
+  registrationClientUri?: string;
+  registrationAccessTokenRef?: string;
   enabled: boolean;
   pkce?: boolean;
   createdAt: Date;
   updatedAt: Date;
 }
 
-export type OAuthConnectorMetadata = Omit<OAuthConnectorDocument, "clientSecretRef"> & {
+export type OAuthConnectorMetadata = Omit<
+  OAuthConnectorDocument,
+  "clientSecretRef" | "registrationAccessTokenRef"
+> & {
   clientSecretConfigured: boolean;
 };
 
@@ -104,6 +115,11 @@ export interface CreateConnectorInput {
   scopes: string[];
   redirectUri: string;
   pkce?: boolean;
+  resource?: string;
+  source?: "manual" | "mcp_dcr";
+  registrationEndpoint?: string;
+  registrationClientUri?: string;
+  registrationAccessToken?: string;
 }
 
 export interface TokenClientResponse {
@@ -185,6 +201,10 @@ function toConnectorMetadata(doc: OAuthConnectorDocument): OAuthConnectorMetadat
     tokenUrl: doc.tokenUrl,
     scopes: doc.scopes,
     redirectUri: doc.redirectUri,
+    ...(doc.resource ? { resource: doc.resource } : {}),
+    ...(doc.source ? { source: doc.source } : {}),
+    ...(doc.registrationEndpoint ? { registrationEndpoint: doc.registrationEndpoint } : {}),
+    ...(doc.registrationClientUri ? { registrationClientUri: doc.registrationClientUri } : {}),
     enabled: doc.enabled,
     pkce: doc.pkce,
     createdAt: doc.createdAt,
@@ -240,6 +260,7 @@ function authorizationCodeTokenBody(input: {
   codeVerifier: string;
   redirectUri: string;
   pkce?: boolean;
+  resource?: string;
 }): Record<string, string> {
   const body: Record<string, string> = {
     grant_type: "authorization_code",
@@ -252,6 +273,9 @@ function authorizationCodeTokenBody(input: {
   if (!omitSecret) {
     body.client_secret = input.clientSecret;
   }
+  if (input.resource) {
+    body.resource = input.resource;
+  }
   return body;
 }
 
@@ -261,6 +285,7 @@ function refreshTokenBody(input: {
   clientSecret: string;
   refreshToken: string;
   pkce?: boolean;
+  resource?: string;
 }): Record<string, string> {
   const body: Record<string, string> = {
     grant_type: "refresh_token",
@@ -270,6 +295,9 @@ function refreshTokenBody(input: {
   const omitSecret = input.pkce === true || input.provider.toLowerCase() === "pagerduty";
   if (!omitSecret) {
     body.client_secret = input.clientSecret;
+  }
+  if (input.resource) {
+    body.resource = input.resource;
   }
   return body;
 }
@@ -290,6 +318,7 @@ export class OAuthConnectorService {
   async createConnector(input: CreateConnectorInput): Promise<OAuthConnectorMetadata> {
     const id = this.idGenerator();
     const clientSecretRef = `oauth_connector:${id}:client_secret`;
+    const registrationAccessTokenRef = `oauth_connector:${id}:registration_access_token`;
     const now = this.now();
     const doc: OAuthConnectorDocument = {
       id,
@@ -301,6 +330,27 @@ export class OAuthConnectorService {
       tokenUrl: validateExternalHttpsUrl(input.tokenUrl, "tokenUrl"),
       scopes: input.scopes.map((scope) => scope.trim()).filter(Boolean),
       redirectUri: validateRedirectUri(input.redirectUri),
+      ...(input.resource
+        ? { resource: validateExternalHttpsUrl(input.resource, "resource") }
+        : {}),
+      ...(input.source ? { source: input.source } : { source: "manual" as const }),
+      ...(input.registrationEndpoint
+        ? {
+            registrationEndpoint: validateExternalHttpsUrl(
+              input.registrationEndpoint,
+              "registrationEndpoint",
+            ),
+          }
+        : {}),
+      ...(input.registrationClientUri
+        ? {
+            registrationClientUri: validateExternalHttpsUrl(
+              input.registrationClientUri,
+              "registrationClientUri",
+            ),
+          }
+        : {}),
+      ...(input.registrationAccessToken ? { registrationAccessTokenRef } : {}),
       enabled: true,
       ...(input.pkce ? { pkce: true } : {}),
       createdAt: now,
@@ -309,6 +359,12 @@ export class OAuthConnectorService {
 
     if (!input.pkce) {
       await this.payloadStore.putSecret({ secretRefId: clientSecretRef, plaintext: nonEmpty(input.clientSecret ?? "", "clientSecret") });
+    }
+    if (input.registrationAccessToken) {
+      await this.payloadStore.putSecret({
+        secretRefId: registrationAccessTokenRef,
+        plaintext: nonEmpty(input.registrationAccessToken, "registrationAccessToken"),
+      });
     }
     await this.connectorsCollection.insertOne(doc);
     return toConnectorMetadata(doc);
@@ -330,6 +386,26 @@ export class OAuthConnectorService {
       tokenUrl: validateExternalHttpsUrl(input.tokenUrl, "tokenUrl"),
       scopes: input.scopes.map((scope) => scope.trim()).filter(Boolean),
       redirectUri: validateRedirectUri(input.redirectUri),
+      ...(input.resource
+        ? { resource: validateExternalHttpsUrl(input.resource, "resource") }
+        : {}),
+      ...(input.source ? { source: input.source } : {}),
+      ...(input.registrationEndpoint
+        ? {
+            registrationEndpoint: validateExternalHttpsUrl(
+              input.registrationEndpoint,
+              "registrationEndpoint",
+            ),
+          }
+        : {}),
+      ...(input.registrationClientUri
+        ? {
+            registrationClientUri: validateExternalHttpsUrl(
+              input.registrationClientUri,
+              "registrationClientUri",
+            ),
+          }
+        : {}),
       enabled: true,
       ...(input.pkce ? { pkce: true } : {}),
       updatedAt: now,
@@ -339,6 +415,16 @@ export class OAuthConnectorService {
         secretRefId: existing.clientSecretRef,
         plaintext: nonEmpty(input.clientSecret ?? "", "clientSecret"),
       });
+    }
+    if (input.registrationAccessToken) {
+      const registrationAccessTokenRef =
+        existing.registrationAccessTokenRef ??
+        `oauth_connector:${existing.id}:registration_access_token`;
+      await this.payloadStore.putSecret({
+        secretRefId: registrationAccessTokenRef,
+        plaintext: nonEmpty(input.registrationAccessToken, "registrationAccessToken"),
+      });
+      update.registrationAccessTokenRef = registrationAccessTokenRef;
     }
     // `$set: { pkce: undefined }` is a no-op in MongoDB, so a PKCE→confidential
     // switch must explicitly `$unset` the flag to clear it (mirrors
@@ -475,6 +561,9 @@ export class ProviderConnectionService {
     url.searchParams.set("state", nonEmpty(input.state, "state"));
     url.searchParams.set("code_challenge", nonEmpty(input.codeChallenge, "codeChallenge"));
     url.searchParams.set("code_challenge_method", "S256");
+    if (connector.resource) {
+      url.searchParams.set("resource", connector.resource);
+    }
     return { authorizationUrl: url.toString(), connectorId: connector.id, requestedScopes };
   }
 
@@ -616,6 +705,7 @@ export class ProviderConnectionService {
         codeVerifier: input.codeVerifier,
         redirectUri: connector.redirectUri,
         pkce: connector.pkce,
+        resource: connector.resource,
       }),
     );
 
@@ -848,6 +938,7 @@ export class ProviderConnectionService {
           clientSecret,
           refreshToken,
           pkce: connector.pkce,
+          resource: connector.resource,
         }),
       );
     } catch (error) {


### PR DESCRIPTION
# Description

Add first-class OAuth Dynamic Client Registration (DCR) for generic remote MCP servers in the credential provider admin flow.

- Discover the protected-resource and authorization-server metadata advertised by an MCP endpoint.
- Register a public OAuth client with PKCE through RFC 7591.
- Preserve the RFC 8707 `resource` parameter across authorization, token exchange, and refresh.
- Store registration credentials encrypted and bootstrap the connector without a pre-provisioned client ID.
- Add Helm values and validation for declarative DCR providers.
- Keep the existing static OAuth client flow unchanged.

The implementation is provider-neutral and uses only reserved example domains in reusable source and tests.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Please add the `helm-prerelease` label if a pre-release chart is desired for fork-based validation.

## Validation

- `npm test -- --runInBand ...` — 69 focused UI tests passed
- `uv run pytest -q tests/test_caipe_ui_oauth_connectors.py` — 4 passed
- `npm run lint` — passed
- `npm run build` — passed
- Deployed and smoke-tested on a private development environment against an MCP endpoint advertising OAuth authorization-server metadata and anonymous public-client DCR

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable (none)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All relevant tests pass
