### PR TITLE
fix(dynamic-agents): constrain curl request arguments

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
@@ -27,6 +27,55 @@ logger = logging.getLogger(__name__)
 
 _REDIRECT_STATUS_CODES = {301, 302, 303, 307, 308}
 _MAX_FETCH_REDIRECTS = 10
+_CURL_BOOLEAN_OPTIONS = {
+    "-f",
+    "--fail",
+    "--fail-with-body",
+    "-G",
+    "--get",
+    "-i",
+    "--include",
+    "-I",
+    "--head",
+    "-s",
+    "--silent",
+    "-S",
+    "--show-error",
+    "--compressed",
+}
+_CURL_VALUE_OPTIONS = {
+    "-A",
+    "--user-agent",
+    "--connect-timeout",
+    "-d",
+    "--data",
+    "--data-ascii",
+    "--data-binary",
+    "--data-raw",
+    "--data-urlencode",
+    "-e",
+    "--referer",
+    "-H",
+    "--header",
+    "--json",
+    "--max-time",
+    "--retry",
+    "--retry-delay",
+    "-u",
+    "--user",
+    "-X",
+    "--request",
+}
+_CURL_FILE_CAPABLE_OPTIONS = {
+    "-d",
+    "--data",
+    "--data-ascii",
+    "--data-binary",
+    "--data-urlencode",
+    "-H",
+    "--header",
+    "--json",
+}
 
 
 # assisted-by claude code claude-sonnet-4-6
@@ -90,6 +139,101 @@ def _validate_fetch_url(url: str, allowed_domains: str, allow_non_public_urls: b
         return False, error_msg, domain
 
     return True, "", domain
+
+
+def _validate_curl_option_value(option: str, value: str) -> str | None:
+    """Reject curl option values that can make curl read local files."""
+    if option not in _CURL_FILE_CAPABLE_OPTIONS:
+        return None
+
+    stripped_value = value.lstrip()
+    if stripped_value.startswith("@") or (option == "--data-urlencode" and "@" in value):
+        return f"Option '{option}' cannot read request data from a local file"
+    return None
+
+
+def _prepare_curl_args(
+    command: str,
+    allowed_domains: str,
+    https_only: bool,
+    allow_non_public_urls: bool,
+) -> tuple[list[str] | None, str | None]:
+    """Parse a curl command into a constrained argv and validate every URL."""
+    try:
+        parsed_args = shlex.split(command)
+    except ValueError as e:
+        return None, f"Failed to parse command: {e}"
+
+    if parsed_args and parsed_args[0] == "curl":
+        parsed_args = parsed_args[1:]
+
+    options: list[str] = []
+    urls: list[str] = []
+    index = 0
+    while index < len(parsed_args):
+        token = parsed_args[index]
+        if token == "--":
+            urls.extend(parsed_args[index + 1 :])
+            break
+        if not token.startswith("-") or token == "-":
+            urls.append(token)
+            index += 1
+            continue
+        if token in _CURL_BOOLEAN_OPTIONS:
+            options.append(token)
+            index += 1
+            continue
+        if token.startswith("-") and not token.startswith("--") and len(token) > 2:
+            short_option = token[:2]
+            if short_option in _CURL_VALUE_OPTIONS:
+                value = token[2:]
+                error = _validate_curl_option_value(short_option, value)
+                if error:
+                    return None, error
+                options.extend((short_option, value))
+                index += 1
+                continue
+            if all(f"-{flag}" in _CURL_BOOLEAN_OPTIONS for flag in token[1:]):
+                options.extend(f"-{flag}" for flag in token[1:])
+                index += 1
+                continue
+        option, separator, inline_value = token.partition("=")
+        if separator and option in _CURL_VALUE_OPTIONS:
+            error = _validate_curl_option_value(option, inline_value)
+            if error:
+                return None, error
+            options.extend((option, inline_value))
+            index += 1
+            continue
+        if token in _CURL_VALUE_OPTIONS:
+            if index + 1 >= len(parsed_args):
+                return None, f"Option '{token}' requires a value"
+            value = parsed_args[index + 1]
+            error = _validate_curl_option_value(token, value)
+            if error:
+                return None, error
+            options.extend((token, value))
+            index += 2
+            continue
+        return None, f"Curl option '{token}' is not supported"
+
+    if not urls:
+        return None, "A request URL is required"
+
+    for url in urls:
+        parsed_url = urlparse(url)
+        if parsed_url.scheme not in ("http", "https"):
+            return None, f"The URL scheme '{parsed_url.scheme or '(missing)'}://' is not supported"
+        if https_only and parsed_url.scheme != "https":
+            return None, "Only https:// URLs are allowed"
+        try:
+            is_valid, error_msg, _domain = _validate_fetch_url(url, allowed_domains, allow_non_public_urls)
+        except Exception as e:
+            return None, f"Failed to parse URL: {e}"
+        if not is_valid:
+            return None, error_msg
+
+    return ["curl", "--globoff", "--max-redirs", "0", *options, "--", *urls], None
 
 
 def get_builtin_tool_definitions() -> list[BuiltinToolDefinition]:
@@ -413,38 +557,15 @@ def create_curl_tool(allowed_domains: str = "*", https_only: bool = True, allow_
             # GET request (alternative to fetch_url)
             curl("curl -s https://api.example.com/data")
         """
-        try:
-            args = shlex.split(command)
-        except ValueError as e:
-            return f"ERROR: Failed to parse command: {e}"
-
-        if not args or args[0] != "curl":
-            args = ["curl"] + args
-
-        # Enforce https-only (configurable)
-        if https_only:
-            for token in args[1:]:
-                if "://" in token and not token.startswith("https://"):
-                    scheme = token.split("://")[0] + "://"
-                    msg = (
-                        f"The URL scheme '{scheme}' is not supported.\n\n"
-                        "**Only `https://` URLs are allowed.**\n\n"
-                        f"Please use an `https://` endpoint instead of `{token.split('?')[0]}`."
-                    )
-                    logger.warning(f"curl blocked non-https URL: {token.split('?')[0]}")
-                    return msg
-
-        # Check domain ACL and SSRF protection
-        for token in args[1:]:
-            if token.startswith("https://") or token.startswith("http://"):
-                try:
-                    is_valid, error_msg, domain = _validate_fetch_url(token, allowed_domains, allow_non_public_urls)
-                    if not is_valid:
-                        logger.warning(f"curl blocked: {domain} (patterns: {allowed_domains})")
-                        return f"ERROR: {error_msg}"
-                except Exception as e:
-                    return f"ERROR: Failed to parse URL: {e}"
-                break
+        args, validation_error = _prepare_curl_args(
+            command,
+            allowed_domains,
+            https_only,
+            allow_non_public_urls,
+        )
+        if validation_error or args is None:
+            logger.warning("curl command blocked: %s", validation_error)
+            return f"ERROR: {validation_error}"
 
         # Detect write method for post-execution warning
         write_method = None

--- a/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
@@ -1,6 +1,12 @@
 import importlib
+import json
+import shutil
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
+
+import pytest
 
 
 def test_self_identity_returns_agent_id() -> None:
@@ -110,6 +116,57 @@ def test_create_curl_tool_rejects_options_with_local_file_access() -> None:
     mock_run.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "curl -o response.txt https://api.example.com/status",
+        "curl -K settings.txt https://api.example.com/status",
+        "curl -T payload.txt https://api.example.com/status",
+        "curl -F document=@payload.txt https://api.example.com/status",
+        "curl --location https://api.example.com/status",
+        "curl --url https://api.example.com/status",
+        "curl --proxy http://proxy.example.test https://api.example.com/status",
+        "curl --data-urlencode name@payload.txt https://api.example.com/status",
+        "curl --json @payload.json https://api.example.com/status",
+        "curl --header=@headers.txt https://api.example.com/status",
+    ],
+)
+def test_create_curl_tool_rejects_unsupported_or_file_capable_forms(command: str) -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    curl_tool = getattr(builtin_tools, "create_curl_tool")(
+        allowed_domains="*", allow_non_public_urls=True
+    )
+
+    with patch("subprocess.run") as mock_run:
+        result = curl_tool.invoke({"command": command})
+
+    assert result.startswith("ERROR:")
+    mock_run.assert_not_called()
+
+
+def test_create_curl_tool_expands_only_allowlisted_combined_short_flags() -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    args, error = builtin_tools._prepare_curl_args(
+        "curl -sSf https://api.example.com/items/{one,two}",
+        "*",
+        True,
+        True,
+    )
+
+    assert error is None
+    assert args == [
+        "curl",
+        "--globoff",
+        "--max-redirs",
+        "0",
+        "-s",
+        "-S",
+        "-f",
+        "--",
+        "https://api.example.com/items/{one,two}",
+    ]
+
+
 def test_create_curl_tool_allows_inline_request_data() -> None:
     builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
     curl_tool = getattr(builtin_tools, "create_curl_tool")(allowed_domains="*")
@@ -131,6 +188,60 @@ def test_create_curl_tool_allows_inline_request_data() -> None:
     argv = mock_run.call_args.args[0]
     assert argv[-2:] == ["--", "https://api.example.com/items"]
     assert ["--globoff", "--max-redirs", "0"] == argv[1:4]
+
+
+@pytest.mark.skipif(shutil.which("curl") is None, reason="curl binary is not installed")
+def test_create_curl_tool_runs_constrained_post_against_local_http_server() -> None:
+    received: dict[str, object] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            content_length = int(self.headers.get("Content-Length", "0"))
+            received.update(
+                path=self.path,
+                content_type=self.headers.get("Content-Type"),
+                body=json.loads(self.rfile.read(content_length)),
+            )
+            payload = b'{"accepted":true}'
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, _format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        port = server.server_address[1]
+        builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+        curl_tool = getattr(builtin_tools, "create_curl_tool")(
+            allowed_domains="*",
+            https_only=False,
+            allow_non_public_urls=True,
+        )
+        result = curl_tool.invoke(
+            {
+                "command": (
+                    f"curl -sS -X POST -H 'Content-Type: application/json' "
+                    f"--data-raw '{{\"name\":\"example\"}}' http://127.0.0.1:{port}/items"
+                )
+            }
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert result == '{"accepted":true}'
+    assert received == {
+        "path": "/items",
+        "content_type": "application/json",
+        "body": {"name": "example"},
+    }
 
 
 def test_curl_tool_in_builtin_tool_definitions() -> None:

--- a/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
@@ -61,9 +61,76 @@ def test_create_curl_tool_success() -> None:
     mock_result.stderr = ""
     mock_result.returncode = 0
     with patch("dynamic_agents.services.builtin_tools.socket.getaddrinfo", return_value=public_ip_records), \
-         patch("subprocess.run", return_value=mock_result):
+         patch("subprocess.run", return_value=mock_result) as mock_run:
         result = curl_tool.invoke({"command": "curl -s https://api.example.com/status"})
     assert result == '{"status": "ok"}'
+    assert mock_run.call_args.args[0] == [
+        "curl",
+        "--globoff",
+        "--max-redirs",
+        "0",
+        "-s",
+        "--",
+        "https://api.example.com/status",
+    ]
+
+
+def test_create_curl_tool_validates_every_url() -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    curl_tool = getattr(builtin_tools, "create_curl_tool")(allowed_domains="*.example.com")
+    public_ip_records = [(2, 1, 6, "", ("93.184.216.34", 0))]
+
+    with patch("dynamic_agents.services.builtin_tools.socket.getaddrinfo", return_value=public_ip_records), \
+         patch("subprocess.run") as mock_run:
+        result = curl_tool.invoke(
+            {"command": "curl https://api.example.com/status https://outside.example.org/status"}
+        )
+
+    assert result == "ERROR: Domain 'outside.example.org' is not allowed. Allowed patterns: *.example.com"
+    mock_run.assert_not_called()
+
+
+def test_create_curl_tool_rejects_options_with_local_file_access() -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    curl_tool = getattr(builtin_tools, "create_curl_tool")(allowed_domains="*")
+    commands = [
+        "curl --output response.txt https://api.example.com/status",
+        "curl --config settings.txt https://api.example.com/status",
+        "curl --upload-file payload.txt https://api.example.com/status",
+        "curl --form document=@payload.txt https://api.example.com/status",
+        "curl --data-binary @payload.txt https://api.example.com/status",
+        "curl --header @headers.txt https://api.example.com/status",
+        "curl file:///etc/hosts",
+    ]
+
+    with patch("subprocess.run") as mock_run:
+        results = [curl_tool.invoke({"command": command}) for command in commands]
+
+    assert all(result.startswith("ERROR:") for result in results)
+    mock_run.assert_not_called()
+
+
+def test_create_curl_tool_allows_inline_request_data() -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    curl_tool = getattr(builtin_tools, "create_curl_tool")(allowed_domains="*")
+    public_ip_records = [(2, 1, 6, "", ("93.184.216.34", 0))]
+    mock_result = MagicMock(stdout='{"status":"ok"}', stderr="", returncode=0)
+
+    with patch("dynamic_agents.services.builtin_tools.socket.getaddrinfo", return_value=public_ip_records), \
+         patch("subprocess.run", return_value=mock_result) as mock_run:
+        result = curl_tool.invoke(
+            {
+                "command": (
+                    "curl -sS -X POST https://api.example.com/items "
+                    "-H 'Content-Type: application/json' --data-raw '{\"name\":\"test\"}'"
+                )
+            }
+        )
+
+    assert result == '{"status":"ok"}'
+    argv = mock_run.call_args.args[0]
+    assert argv[-2:] == ["--", "https://api.example.com/items"]
+    assert ["--globoff", "--max-redirs", "0"] == argv[1:4]
 
 
 def test_curl_tool_in_builtin_tool_definitions() -> None:


### PR DESCRIPTION
# Description

Make the built-in curl tool use a defined request interface instead of forwarding unrestricted command-line arguments.

- Validate every request URL against the configured domain and address rules.
- Allow only the HTTP method, header, inline body, timeout, and response flags used by the tool.
- Reject local-file input/output options and unsupported schemes.
- Disable URL glob expansion and automatic redirects.
- Preserve inline JSON requests and write-method result warnings.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

No chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests

## Validation

- 24 focused tests passed, including a real local curl subprocess and HTTP server
- Rejection cases verify no subprocess starts
- Ruff passed