### PR TITLE
fix(dynamic-agents): pin validated fetch addresses

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/builtin_tools.py
@@ -13,13 +13,14 @@ import socket
 import subprocess
 import time
 from datetime import datetime, timezone
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from urllib.parse import quote, urljoin, urlparse
 
 import requests
 from bs4 import BeautifulSoup
 from langchain_core.tools import tool
 from langgraph.store.base import GetOp, PutOp
+from requests.adapters import HTTPAdapter
 
 from dynamic_agents.models import BuiltinToolConfigField, BuiltinToolDefinition, InputField, UserContext
 
@@ -52,44 +53,122 @@ def _resolve_host_addresses(hostname: str) -> list[str]:
     return [sockaddr[0] for _family, _type, _proto, _canonname, sockaddr in results]
 
 
-def _is_publicly_routable_host(hostname: str) -> tuple[bool, str]:
+def _publicly_routable_addresses(hostname: str) -> tuple[list[str], str]:
     if not hostname:
-        return False, "missing hostname"
+        return [], "missing hostname"
 
     try:
         addresses = _resolve_host_addresses(hostname)
     except (socket.gaierror, OSError) as e:
-        return False, f"hostname could not be resolved: {e}"
+        return [], f"hostname could not be resolved: {e}"
 
     if not addresses:
-        return False, "hostname did not resolve to any address"
+        return [], "hostname did not resolve to any address"
 
     for address in addresses:
         try:
             if not _is_publicly_routable_ip(address):
-                return False, f"{address} is not publicly routable"
+                return [], f"{address} is not publicly routable"
         except ValueError:
-            return False, f"{address} is not a valid IP address"
+            return [], f"{address} is not a valid IP address"
 
-    return True, ""
+    return addresses, ""
+
+
+def _is_publicly_routable_host(hostname: str) -> tuple[bool, str]:
+    addresses, error = _publicly_routable_addresses(hostname)
+    return bool(addresses), error
+
+
+def _validate_and_resolve_fetch_url(
+    url: str,
+    allowed_domains: str,
+    allow_non_public_urls: bool = False,
+) -> tuple[bool, str, str, str]:
+    """Validate a URL and return the exact address approved for the connection."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https"):
+        return False, "Invalid URL - must start with http:// or https://", "", ""
+
+    domain = (parsed.hostname or "").lower()
+    is_allowed, error_msg = is_domain_allowed(domain, allowed_domains)
+    if not is_allowed:
+        return False, error_msg, domain, ""
+
+    try:
+        addresses = _resolve_host_addresses(domain)
+    except (socket.gaierror, OSError) as e:
+        return False, f"URL hostname could not be resolved: {e}", domain, ""
+    if not addresses:
+        return False, "URL hostname did not resolve to any address", domain, ""
+
+    if not allow_non_public_urls:
+        for address in addresses:
+            try:
+                if not _is_publicly_routable_ip(address):
+                    error = f"{address} is not publicly routable"
+                    return False, f"URL host must resolve only to publicly routable IP addresses: {error}", domain, ""
+            except ValueError:
+                error = f"{address} is not a valid IP address"
+                return False, f"URL host must resolve only to publicly routable IP addresses: {error}", domain, ""
+
+    return True, "", domain, addresses[0]
 
 
 def _validate_fetch_url(url: str, allowed_domains: str, allow_non_public_urls: bool = False) -> tuple[bool, str, str]:
+    is_valid, error_msg, domain, _address = _validate_and_resolve_fetch_url(
+        url,
+        allowed_domains,
+        allow_non_public_urls,
+    )
+    return is_valid, error_msg, domain
+
+
+class _PinnedAddressAdapter(HTTPAdapter):
+    """Connect to one validated address while preserving the URL's TLS identity."""
+
+    def __init__(self, hostname: str, address: str) -> None:
+        self._hostname = hostname
+        self._address = address
+        super().__init__()
+
+    def get_connection_with_tls_context(
+        self,
+        request: requests.PreparedRequest,
+        verify: bool | str,
+        proxies: dict[str, str] | None = None,
+        cert: Any = None,
+    ) -> Any:
+        host_params, pool_kwargs = self.build_connection_pool_key_attributes(request, verify, cert)
+        host_params["host"] = self._address
+        if host_params["scheme"] == "https":
+            pool_kwargs["assert_hostname"] = self._hostname
+            pool_kwargs["server_hostname"] = self._hostname
+        return self.poolmanager.connection_from_host(**host_params, pool_kwargs=pool_kwargs)
+
+
+def _host_header(url: str) -> str:
     parsed = urlparse(url)
-    if parsed.scheme not in ("http", "https"):
-        return False, "Invalid URL - must start with http:// or https://", ""
+    hostname = parsed.hostname or ""
+    if ":" in hostname:
+        hostname = f"[{hostname}]"
+    default_port = 443 if parsed.scheme == "https" else 80
+    return f"{hostname}:{parsed.port}" if parsed.port and parsed.port != default_port else hostname
 
-    domain = (parsed.hostname or "").lower()
-    if not allow_non_public_urls:
-        is_routable, route_error = _is_publicly_routable_host(domain)
-        if not is_routable:
-            return False, f"URL host must resolve only to publicly routable IP addresses: {route_error}", domain
 
-    is_allowed, error_msg = is_domain_allowed(domain, allowed_domains)
-    if not is_allowed:
-        return False, error_msg, domain
-
-    return True, "", domain
+def _request_pinned_url(url: str, address: str, timeout: int) -> requests.Response:
+    """Make one request without allowing DNS or environment proxies to change the destination."""
+    parsed = urlparse(url)
+    adapter = _PinnedAddressAdapter(parsed.hostname or "", address)
+    with requests.Session() as session:
+        session.trust_env = False
+        session.mount(f"{parsed.scheme}://", adapter)
+        return session.get(
+            url,
+            headers={"Host": _host_header(url)},
+            timeout=timeout,
+            allow_redirects=False,
+        )
 
 
 def get_builtin_tool_definitions() -> list[BuiltinToolDefinition]:
@@ -259,11 +338,14 @@ def _fetch_url_content(url: str, format: Literal["text", "raw"], timeout: int, a
         current_url = url
         response = None
         for _redirect_count in range(_MAX_FETCH_REDIRECTS + 1):
-            is_valid, error_msg, _domain = _validate_fetch_url(current_url, allowed_domains)
+            is_valid, error_msg, _domain, address = _validate_and_resolve_fetch_url(
+                current_url,
+                allowed_domains,
+            )
             if not is_valid:
                 return f"ERROR: {error_msg}"
 
-            response = requests.get(current_url, timeout=timeout, allow_redirects=False)
+            response = _request_pinned_url(current_url, address, timeout)
             if getattr(response, "status_code", None) not in _REDIRECT_STATUS_CODES:
                 break
 

--- a/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
@@ -1,6 +1,10 @@
 import importlib
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from types import SimpleNamespace
-from unittest.mock import MagicMock, Mock, patch
+from unittest.mock import MagicMock, Mock, call, patch
+
+import pytest
 
 
 def test_self_identity_returns_agent_id() -> None:
@@ -205,3 +209,140 @@ def test_pinned_adapter_preserves_https_server_identity() -> None:
     assert call.kwargs["scheme"] == "https"
     assert call.kwargs["pool_kwargs"]["assert_hostname"] == "docs.example.com"
     assert call.kwargs["pool_kwargs"]["server_hostname"] == "docs.example.com"
+
+
+def test_pinned_request_uses_validated_address_and_original_host_header() -> None:
+    received: dict[str, str] = {}
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802 - BaseHTTPRequestHandler API
+            received["host"] = self.headers.get("Host", "")
+            received["path"] = self.path
+            payload = b"pinned response"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def log_message(self, _format: str, *args: object) -> None:
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+        port = server.server_address[1]
+        original_getaddrinfo = builtin_tools.socket.getaddrinfo
+        resolved_hosts: list[str] = []
+
+        def recording_getaddrinfo(host: str, *args: object, **kwargs: object):
+            resolved_hosts.append(host)
+            if host == "rebind.example.test":
+                raise AssertionError("the original hostname must not be resolved during the request")
+            return original_getaddrinfo(host, *args, **kwargs)
+
+        with patch(
+            "dynamic_agents.services.builtin_tools.socket.getaddrinfo",
+            side_effect=recording_getaddrinfo,
+        ):
+            response = builtin_tools._request_pinned_url(
+                f"http://rebind.example.test:{port}/report",
+                "127.0.0.1",
+                5,
+            )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+    assert response.text == "pinned response"
+    assert "rebind.example.test" not in resolved_hosts
+    assert received == {
+        "host": f"rebind.example.test:{port}",
+        "path": "/report",
+    }
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("http://[2001:db8::10]/", "[2001:db8::10]"),
+        ("http://[2001:db8::10]:8080/", "[2001:db8::10]:8080"),
+        ("https://docs.example.com:443/", "docs.example.com"),
+        ("https://docs.example.com:8443/", "docs.example.com:8443"),
+    ],
+)
+def test_host_header_preserves_ipv6_brackets_and_non_default_ports(
+    url: str,
+    expected: str,
+) -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    assert builtin_tools._host_header(url) == expected
+
+
+def test_fetch_url_revalidates_and_repins_every_redirect() -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    redirect = Mock(
+        status_code=302,
+        headers={"location": "https://cdn.example.com/final"},
+    )
+    final = Mock(
+        status_code=200,
+        headers={"content-type": "text/plain"},
+        text="final response",
+    )
+    final.raise_for_status = Mock()
+
+    with patch(
+        "dynamic_agents.services.builtin_tools._validate_and_resolve_fetch_url",
+        side_effect=[
+            (True, "", "docs.example.com", "93.184.216.34"),
+            (True, "", "cdn.example.com", "93.184.216.35"),
+        ],
+    ) as mock_validate, patch(
+        "dynamic_agents.services.builtin_tools._request_pinned_url",
+        side_effect=[redirect, final],
+    ) as mock_request:
+        result = builtin_tools._fetch_url_content(
+            "https://docs.example.com/start",
+            "text",
+            30,
+            "*.example.com",
+        )
+
+    assert result == "final response"
+    assert mock_validate.call_args_list == [
+        call("https://docs.example.com/start", "*.example.com"),
+        call("https://cdn.example.com/final", "*.example.com"),
+    ]
+    assert mock_request.call_args_list == [
+        call("https://docs.example.com/start", "93.184.216.34", 30),
+        call("https://cdn.example.com/final", "93.184.216.35", 30),
+    ]
+
+
+def test_fetch_url_connection_failure_does_not_resolve_or_retry_a_fallback() -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    with patch(
+        "dynamic_agents.services.builtin_tools._resolve_host_addresses",
+        return_value=["93.184.216.34", "93.184.216.35"],
+    ) as mock_resolve, patch(
+        "dynamic_agents.services.builtin_tools._request_pinned_url",
+        side_effect=builtin_tools.requests.exceptions.ConnectionError("connection failed"),
+    ) as mock_request:
+        result = builtin_tools._fetch_url_content(
+            "https://docs.example.com/report",
+            "text",
+            30,
+            "*.example.com",
+        )
+
+    assert result == "ERROR: Network error: connection failed"
+    mock_resolve.assert_called_once_with("docs.example.com")
+    mock_request.assert_called_once_with(
+        "https://docs.example.com/report",
+        "93.184.216.34",
+        30,
+    )

--- a/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_builtin_tools.py
@@ -90,7 +90,7 @@ def test_fetch_url_blocks_private_resolved_addresses(monkeypatch) -> None:
 
     fetch_url = builtin_tools.create_fetch_url_tool(allowed_domains="*")
 
-    with patch("dynamic_agents.services.builtin_tools.requests.get") as mock_get:
+    with patch("dynamic_agents.services.builtin_tools._request_pinned_url") as mock_get:
         mock_response = Mock()
         mock_response.text = "metadata"
         mock_response.headers = {"content-type": "text/plain"}
@@ -132,7 +132,7 @@ def test_fetch_url_blocks_redirect_to_private_ip() -> None:
     redirect_response.headers = {"location": "https://redirect.example.com/secret"}
 
     with patch("dynamic_agents.services.builtin_tools.socket.getaddrinfo", side_effect=fake_getaddrinfo), \
-         patch("dynamic_agents.services.builtin_tools.requests.get", return_value=redirect_response):
+         patch("dynamic_agents.services.builtin_tools._request_pinned_url", return_value=redirect_response):
         result = fetch_url.invoke({"url": "https://docs.example.com/"})
 
     assert result.startswith("ERROR:")
@@ -150,8 +150,58 @@ def test_fetch_url_blocks_too_many_redirects() -> None:
 
     with patch("dynamic_agents.services.builtin_tools.socket.getaddrinfo",
                return_value=[(2, 1, 6, "", ("93.184.216.34", 0))]), \
-         patch("dynamic_agents.services.builtin_tools.requests.get", return_value=redirect_response):
+         patch("dynamic_agents.services.builtin_tools._request_pinned_url", return_value=redirect_response):
         result = fetch_url.invoke({"url": "https://docs.example.com/"})
 
     assert result.startswith("ERROR:")
     assert "Too many redirects" in result
+
+
+def test_fetch_url_connects_to_the_validated_address() -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    response = Mock(
+        status_code=200,
+        headers={"content-type": "text/plain"},
+        text="example response",
+    )
+    response.raise_for_status = Mock()
+
+    with patch(
+        "dynamic_agents.services.builtin_tools._resolve_host_addresses",
+        return_value=["93.184.216.34"],
+    ) as mock_resolve, patch(
+        "dynamic_agents.services.builtin_tools._request_pinned_url",
+        return_value=response,
+    ) as mock_request:
+        result = builtin_tools._fetch_url_content(
+            "https://docs.example.com/guide",
+            "text",
+            30,
+            "*.example.com",
+        )
+
+    assert result == "example response"
+    mock_resolve.assert_called_once_with("docs.example.com")
+    mock_request.assert_called_once_with(
+        "https://docs.example.com/guide",
+        "93.184.216.34",
+        30,
+    )
+
+
+def test_pinned_adapter_preserves_https_server_identity() -> None:
+    builtin_tools = importlib.import_module("dynamic_agents.services.builtin_tools")
+    adapter = builtin_tools._PinnedAddressAdapter("docs.example.com", "93.184.216.34")
+    adapter.poolmanager = Mock()
+    prepared_request = builtin_tools.requests.Request(
+        "GET",
+        "https://docs.example.com/guide",
+    ).prepare()
+
+    adapter.get_connection_with_tls_context(prepared_request, True)
+
+    call = adapter.poolmanager.connection_from_host.call_args
+    assert call.kwargs["host"] == "93.184.216.34"
+    assert call.kwargs["scheme"] == "https"
+    assert call.kwargs["pool_kwargs"]["assert_hostname"] == "docs.example.com"
+    assert call.kwargs["pool_kwargs"]["server_hostname"] == "docs.example.com"


### PR DESCRIPTION
# Description

Keep fetch connections aligned with the address approved during URL validation.

- Resolve and validate all addresses once per request hop.
- Connect to the selected validated address.
- Preserve the original Host header, TLS server name, and certificate hostname check.
- Disable environment-proxy inheritance for these direct requests.
- Re-resolve, revalidate, and repin each redirect hop.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

No chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests

## Validation

- 18 focused tests passed, including a real pinned local socket request
- Redirect repinning, Host preservation, IPv6 formatting, and no-fallback behavior covered
- Ruff passed