### PR TITLE
refactor(dynamic-agents): use immutable prompt rendering

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -29,7 +29,7 @@ from deepagents.backends.store import StoreBackend
 from deepagents.middleware.skills import SkillsMiddleware
 from deepagents.middleware.subagents import GENERAL_PURPOSE_SUBAGENT
 from jinja2 import ChainableUndefined, TemplateSyntaxError
-from jinja2.sandbox import SandboxedEnvironment, SecurityError
+from jinja2.sandbox import ImmutableSandboxedEnvironment, SecurityError
 from langgraph.checkpoint.memory import MemorySaver
 from langgraph.checkpoint.mongodb.saver import MongoDBSaver
 from langgraph.store.memory import InMemoryStore
@@ -151,7 +151,7 @@ def _with_general_purpose_tool_result_recovery(
 # - ChainableUndefined: missing/nested keys return "" instead of raising.
 # - Built-in globals stripped: agent prompts only need conditionals and
 #   variable interpolation, not lipsum(), cycler(), namespace(), etc.
-_jinja_env = SandboxedEnvironment(undefined=ChainableUndefined)
+_jinja_env = ImmutableSandboxedEnvironment(undefined=ChainableUndefined)
 _jinja_env.globals = {}
 
 

--- a/ai_platform_engineering/dynamic_agents/tests/test_render_system_prompt.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_render_system_prompt.py
@@ -148,6 +148,12 @@ class TestSandboxSecurity:
         with pytest.raises(SystemPromptRenderError, match="dict"):
             _render_system_prompt("{{ dict(a=1) }}", None)
 
+    def test_context_mutation_is_blocked(self):
+        """Templates cannot mutate list values supplied in render context."""
+        user = UserContext(email="user@example.com", groups=["primary"])
+        with pytest.raises(SystemPromptRenderError, match="unsafe"):
+            _render_system_prompt("{{ user.groups.append('secondary') }}", None, user=user)
+
 
 class TestTemplateErrorHandling:
     """Tests that template failures raise SystemPromptRenderError."""

--- a/ai_platform_engineering/dynamic_agents/tests/test_render_system_prompt.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_render_system_prompt.py
@@ -154,6 +154,46 @@ class TestSandboxSecurity:
         with pytest.raises(SystemPromptRenderError, match="unsafe"):
             _render_system_prompt("{{ user.groups.append('secondary') }}", None, user=user)
 
+    @pytest.mark.parametrize(
+        "expression",
+        [
+            "user.groups.append('secondary')",
+            "user.groups.clear()",
+            "user.groups.extend(['secondary'])",
+            "user.groups.insert(0, 'secondary')",
+            "user.groups.pop()",
+            "user.groups.remove('primary')",
+            "user.groups.reverse()",
+            "user.groups.sort()",
+            "client_context.labels.clear()",
+            "client_context.labels.pop('primary')",
+            "client_context.labels.popitem()",
+            "client_context.labels.setdefault('secondary', 'value')",
+            "client_context.labels.update({'secondary': 'value'})",
+        ],
+    )
+    def test_known_list_and_mapping_mutators_are_blocked(self, expression: str) -> None:
+        user = UserContext(email="user@example.com", groups=["primary"])
+        ctx = ClientContext(source="test", labels={"primary": "value"})
+
+        with pytest.raises(SystemPromptRenderError, match="unsafe"):
+            _render_system_prompt(f"{{{{ {expression} }}}}", ctx, user=user)
+
+        assert user.groups == ["primary"]
+        assert ctx.model_dump()["labels"] == {"primary": "value"}
+
+    def test_read_only_iteration_and_mapping_access_still_render(self) -> None:
+        user = UserContext(email="user@example.com", groups=["primary", "secondary"])
+        ctx = ClientContext(source="test", labels={"tier": "example"})
+
+        result = _render_system_prompt(
+            "{% for group in user.groups %}{{ group }};{% endfor %} {{ client_context.labels.tier }}",
+            ctx,
+            user=user,
+        )
+
+        assert result == "primary;secondary; example"
+
 
 class TestTemplateErrorHandling:
     """Tests that template failures raise SystemPromptRenderError."""


### PR DESCRIPTION
# Description

Use Jinja's immutable sandbox for system-prompt rendering.

- Retain the existing strict undefined handling and cleared globals.
- Prevent templates from mutating list and dictionary values supplied in render context.
- Add a regression test for attempted context mutation.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

No chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests

## Validation

- 41 prompt-rendering tests passed
- List and mapping mutator table plus read-only rendering covered
- Ruff passed