### PR TITLE
feat(dynamic-agents): integrate remote agents as tool calls via A2A protocol

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py
@@ -88,6 +88,11 @@ class Settings(BaseSettings):
     # When set, MCP HTTP/SSE clients use this base URL (e.g. http://agentgateway:4000/mcp/{server_id})
     agent_gateway_url: str | None = None
 
+    # Comma-separated JSON-RPC endpoints of remote A2A agents (env:
+    # REMOTE_AGENT_URLS). Each becomes a tool every agent can call to delegate
+    # to that remote agent — e.g. "http://netutils-agent:8000/".
+    remote_agent_urls: str = ""
+
     # CAIPE credential service API used when USE_IMPERSONATION_TOKENS=true.
     credential_api_url: str | None = None
     credential_service_audience: str = "caipe-credential-service"

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -1215,10 +1215,29 @@ class AgentRuntime:
         if not urls:
             return []
 
-        tools = [
-            await create_remote_agent_tool(a2a_url=url, bearer_token=self._auth_bearer)
-            for url in urls
-        ]
+        # Resolve every card at once. Awaiting them one at a time meant an
+        # unreachable endpoint burned the full card timeout before the next
+        # request even started, so startup delay grew linearly with the number of
+        # configured agents. Concurrently, the slowest agent sets the cost
+        # instead of the sum of all of them. Cards are cached by URL, so only the
+        # first build after a restart pays anything at all.
+        results = await asyncio.gather(
+            *(
+                create_remote_agent_tool(a2a_url=url, bearer_token=self._auth_bearer)
+                for url in urls
+            ),
+            return_exceptions=True,
+        )
+
+        # One bad endpoint must not cost the agent every other remote tool, which
+        # is what a bare gather would do by propagating the first exception.
+        tools = []
+        for url, result in zip(urls, results, strict=True):
+            if isinstance(result, BaseException):
+                logger.warning(f"Skipping remote agent {url}: {result}")
+                continue
+            tools.append(result)
+
         logger.info(
             f"Agent '{self.config.name}': added {len(tools)} remote agent tools: "
             f"{[t.name for t in tools]}"

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -87,6 +87,7 @@ from dynamic_agents.services.model_capabilities import (
     ModelCapabilities,
     get_model_capabilities,
 )
+from dynamic_agents.services.remote_agent_tool import create_remote_agent_tool
 from dynamic_agents.services.skills import build_skills_files, detect_missing_skills, load_skills
 
 if TYPE_CHECKING:
@@ -924,6 +925,11 @@ class AgentRuntime:
         if builtin_tools:
             tools = tools + builtin_tools
 
+        # 2b. Add remote A2A agents as delegation tools
+        remote_agent_tools = await self._build_remote_agent_tools()
+        if remote_agent_tools:
+            tools = tools + remote_agent_tools
+
         # 3. Wrap all tools with error handling
         #    Exceptions become LLM-visible "ERROR: ..." strings instead of crashing the agent loop.
         if tools:
@@ -1198,6 +1204,26 @@ class AgentRuntime:
             f"[agent] Agent '{self.config.name}' initialized in {init_duration:.2f}s: "
             f"tools={len(tools)}, subagents={len(subagents) if subagents else 0}"
         )
+
+    async def _build_remote_agent_tools(self) -> list:
+        """Build one delegation tool per remote A2A agent in ``REMOTE_AGENT_URLS``.
+
+        Returns:
+            List of LangChain tools, one per configured remote agent URL.
+        """
+        urls = [u.strip() for u in (self.settings.remote_agent_urls or "").split(",") if u.strip()]
+        if not urls:
+            return []
+
+        tools = [
+            await create_remote_agent_tool(a2a_url=url, bearer_token=self._auth_bearer)
+            for url in urls
+        ]
+        logger.info(
+            f"Agent '{self.config.name}': added {len(tools)} remote agent tools: "
+            f"{[t.name for t in tools]}"
+        )
+        return tools
 
     def _build_builtin_tools(
         self,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/remote_agent_tool.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/remote_agent_tool.py
@@ -1,0 +1,193 @@
+"""Remote A2A agent tools for Dynamic Agents.
+
+Wraps an A2A-compatible remote agent as a plain LangChain tool so the
+LangGraph agent can delegate to it with a normal tool call:
+
+    dynamic-agents ──tool call──> POST {a2a_url}  (JSON-RPC ``tasks/send``)
+
+No A2A SDK is needed on this side — ``tasks/send`` is a JSON-RPC POST over
+``httpx``. The agent card at ``/.well-known/agent.json`` supplies the tool
+name and description the LLM sees, so a remote agent describes itself.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import uuid
+from typing import Any
+from urllib.parse import urljoin, urlparse
+
+import httpx
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+from dynamic_agents.auth.token_context import current_user_token
+
+logger = logging.getLogger(__name__)
+
+AGENT_CARD_PATH = "/.well-known/agent.json"
+AGENT_CARD_TIMEOUT_SECONDS = 10
+
+_UNSAFE_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]+")
+
+
+def _sanitize_tool_name(raw: str) -> str:
+    """Reduce an agent card name to a tool name the LLM APIs accept."""
+    return _UNSAFE_NAME_CHARS.sub("_", raw).strip("_").lower()
+
+
+def _part_text(part: Any) -> str | None:
+    """Return the text of an A2A message/artifact part, if it is a text part.
+
+    A2A spec revisions tag parts with either ``type`` or ``kind``; accept both.
+    """
+    if not isinstance(part, dict):
+        return None
+    if part.get("type", part.get("kind")) != "text":
+        return None
+    text = part.get("text")
+    return text if isinstance(text, str) else None
+
+
+def _extract_result_text(data: dict[str, Any]) -> str:
+    """Flatten an A2A ``tasks/send`` JSON-RPC response into text.
+
+    Raises:
+        RuntimeError: if the remote agent returned a JSON-RPC error.
+    """
+    error = data.get("error")
+    if error:
+        message = error.get("message", error) if isinstance(error, dict) else error
+        raise RuntimeError(f"Remote agent returned an error: {message}")
+
+    result = data.get("result") or {}
+
+    texts = [
+        text
+        for artifact in result.get("artifacts") or []
+        if isinstance(artifact, dict)
+        for part in artifact.get("parts") or []
+        if (text := _part_text(part))
+    ]
+
+    # Agents that answer without producing an artifact put the reply on the
+    # task status message instead.
+    if not texts:
+        status_message = (result.get("status") or {}).get("message") or {}
+        texts = [
+            text for part in status_message.get("parts") or [] if (text := _part_text(part))
+        ]
+
+    return "\n".join(texts) or str(result)
+
+
+class _RemoteAgentInput(BaseModel):
+    message: str = Field(description="The message to send to the remote agent")
+
+
+class RemoteAgentTool(BaseTool):
+    """LangChain tool that delegates to an A2A-compatible remote agent."""
+
+    name: str
+    description: str
+    a2a_url: str
+    bearer_token: str | None = None
+    timeout: int = 120
+
+    args_schema: type[BaseModel] = _RemoteAgentInput
+
+    def _run(self, message: str) -> str:
+        raise NotImplementedError("RemoteAgentTool is async-only; use ainvoke()")
+
+    async def _arun(self, message: str) -> str:
+        # Prefer the token bound to the current request over the one captured
+        # when the tool was built: agent runtimes are cached and replayed
+        # across requests, so a captured token goes stale. Same per-request
+        # forwarding contract as the MCP httpx client factory.
+        token = current_user_token.get() or self.bearer_token
+
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        payload = {
+            "jsonrpc": "2.0",
+            "method": "tasks/send",
+            "id": str(uuid.uuid4()),
+            "params": {
+                "id": str(uuid.uuid4()),
+                "message": {
+                    "role": "user",
+                    "parts": [{"type": "text", "text": message}],
+                },
+            },
+        }
+
+        async with httpx.AsyncClient(timeout=self.timeout) as client:
+            resp = await client.post(self.a2a_url, json=payload, headers=headers)
+            resp.raise_for_status()
+            data = resp.json()
+
+        return _extract_result_text(data)
+
+
+async def _fetch_agent_card(a2a_url: str) -> dict[str, Any] | None:
+    """Fetch ``/.well-known/agent.json`` for a remote agent, or None if unavailable.
+
+    A remote agent that is still starting up must not fail agent
+    initialization, so every failure degrades to ``None``.
+    """
+    card_url = urljoin(a2a_url, AGENT_CARD_PATH)
+    try:
+        async with httpx.AsyncClient(timeout=AGENT_CARD_TIMEOUT_SECONDS) as client:
+            resp = await client.get(card_url)
+            resp.raise_for_status()
+            card = resp.json()
+    except (httpx.HTTPError, ValueError) as e:
+        logger.warning(f"Could not fetch A2A agent card from {card_url}: {e}")
+        return None
+    return card if isinstance(card, dict) else None
+
+
+def _fallback_name(a2a_url: str) -> str:
+    """Name a remote agent after its host when no agent card is available.
+
+    Deriving from the URL keeps two unreachable agents from colliding on a
+    single generic tool name, which would break the LLM tool binding.
+    """
+    return _sanitize_tool_name(urlparse(a2a_url).hostname or "") or "remote_agent"
+
+
+async def create_remote_agent_tool(
+    *,
+    a2a_url: str,
+    name: str | None = None,
+    description: str | None = None,
+    bearer_token: str | None = None,
+    timeout: int = 120,
+) -> RemoteAgentTool:
+    """Fetch the A2A agent card and return a LangChain tool wrapping it.
+
+    Args:
+        a2a_url: JSON-RPC endpoint of the remote agent (``tasks/send`` target).
+        name: Tool name override; defaults to the agent card name.
+        description: Tool description override; defaults to the agent card description.
+        bearer_token: Fallback token used only when no per-request token is bound.
+        timeout: Per-call timeout in seconds for ``tasks/send``.
+    """
+    resolved_name = name
+    resolved_desc = description
+
+    if not (resolved_name and resolved_desc):
+        card = await _fetch_agent_card(a2a_url) or {}
+        resolved_name = resolved_name or _sanitize_tool_name(card.get("name") or "")
+        resolved_desc = resolved_desc or card.get("description")
+
+    return RemoteAgentTool(
+        name=resolved_name or _fallback_name(a2a_url),
+        description=resolved_desc or f"Remote agent at {a2a_url}",
+        a2a_url=a2a_url,
+        bearer_token=bearer_token,
+        timeout=timeout,
+    )

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/remote_agent_tool.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/remote_agent_tool.py
@@ -5,9 +5,12 @@ LangGraph agent can delegate to it with a normal tool call:
 
     dynamic-agents ──tool call──> POST {a2a_url}  (JSON-RPC ``tasks/send``)
 
-No A2A SDK is needed on this side — ``tasks/send`` is a JSON-RPC POST over
-``httpx``. The agent card at ``/.well-known/agent.json`` supplies the tool
-name and description the LLM sees, so a remote agent describes itself.
+No A2A SDK is needed on this side: ``tasks/send`` is a JSON-RPC POST over
+``httpx``. The agent card supplies the tool name and description the LLM sees,
+so a remote agent describes itself. Cards are fetched from
+``/.well-known/agent-card.json``, falling back to the pre-0.3.0
+``/.well-known/agent.json``, and cached by URL so repeated runtime builds do not
+refetch them.
 """
 
 from __future__ import annotations
@@ -26,10 +29,38 @@ from dynamic_agents.auth.token_context import current_user_token
 
 logger = logging.getLogger(__name__)
 
-AGENT_CARD_PATH = "/.well-known/agent.json"
+# A2A publishes the public agent card here. The path changed in a2a-sdk 0.3.0:
+# 0.2.x served `/.well-known/agent.json`, and 0.3.0 moved to
+# `/.well-known/agent-card.json` while keeping the old value as
+# `PREV_AGENT_CARD_WELL_KNOWN_PATH` for the transition. 1.x dropped the old path
+# entirely. We ask for the current path first and fall back to the previous one,
+# so a conforming server and a 0.2.x server both resolve.
+AGENT_CARD_PATH = "/.well-known/agent-card.json"
+LEGACY_AGENT_CARD_PATH = "/.well-known/agent.json"
 AGENT_CARD_TIMEOUT_SECONDS = 10
 
 _UNSAFE_NAME_CHARS = re.compile(r"[^a-zA-Z0-9_-]+")
+
+# Resolved agent cards, keyed by A2A URL. Two reasons this is a cache and not a
+# per-runtime field:
+#
+# 1. Agent runtimes are rebuilt often (AgentRuntimeCache evicts on a 600s idle
+#    TTL and on config change), and refetching every card on every rebuild is
+#    pure latency for data that rarely changes.
+# 2. Keyed by URL, not by agent, so the per-agent selection in #2013's follow-up
+#    only decides *which* tools get built. It does not change how cards are
+#    resolved, and two agents pointing at the same remote share one fetch.
+#
+# Failures are deliberately not cached. A remote agent that is still starting up
+# would otherwise be stuck with a URL-derived name and a generic description for
+# as long as the process lived; not caching the failure means the next runtime
+# build retries and the agent self-heals within the cache TTL.
+_agent_card_cache: dict[str, dict[str, Any]] = {}
+
+
+def clear_agent_card_cache() -> None:
+    """Drop every cached agent card. Intended for tests and config reloads."""
+    _agent_card_cache.clear()
 
 
 def _sanitize_tool_name(raw: str) -> str:
@@ -133,21 +164,55 @@ class RemoteAgentTool(BaseTool):
 
 
 async def _fetch_agent_card(a2a_url: str) -> dict[str, Any] | None:
-    """Fetch ``/.well-known/agent.json`` for a remote agent, or None if unavailable.
+    """Fetch the A2A agent card for a remote agent, or None if unavailable.
+
+    Tries the current well-known path, then the pre-0.3.0 one. Only a 404 is
+    retried against the legacy path: any other status means the server answered
+    and does not want to serve us a card, so asking a second time is noise.
 
     A remote agent that is still starting up must not fail agent
-    initialization, so every failure degrades to ``None``.
+    initialization, so every failure degrades to ``None``. Note that the caller
+    then substitutes a URL-derived name and a generic description, which the LLM
+    cannot route on — so a persistent failure here quietly costs the tool its
+    usefulness rather than raising.
     """
-    card_url = urljoin(a2a_url, AGENT_CARD_PATH)
-    try:
-        async with httpx.AsyncClient(timeout=AGENT_CARD_TIMEOUT_SECONDS) as client:
-            resp = await client.get(card_url)
-            resp.raise_for_status()
-            card = resp.json()
-    except (httpx.HTTPError, ValueError) as e:
-        logger.warning(f"Could not fetch A2A agent card from {card_url}: {e}")
-        return None
-    return card if isinstance(card, dict) else None
+    async with httpx.AsyncClient(timeout=AGENT_CARD_TIMEOUT_SECONDS) as client:
+        for path in (AGENT_CARD_PATH, LEGACY_AGENT_CARD_PATH):
+            card_url = urljoin(a2a_url, path)
+            try:
+                resp = await client.get(card_url)
+                resp.raise_for_status()
+                card = resp.json()
+            except httpx.HTTPStatusError as e:
+                if e.response.status_code == 404 and path != LEGACY_AGENT_CARD_PATH:
+                    logger.debug(f"No agent card at {card_url}; trying the legacy path")
+                    continue
+                logger.warning(f"Could not fetch A2A agent card from {card_url}: {e}")
+                return None
+            except (httpx.HTTPError, ValueError) as e:
+                logger.warning(f"Could not fetch A2A agent card from {card_url}: {e}")
+                return None
+            if isinstance(card, dict):
+                return card
+            logger.warning(f"Agent card at {card_url} was not a JSON object")
+            return None
+    return None
+
+
+async def _resolve_agent_card(a2a_url: str) -> dict[str, Any] | None:
+    """Return this agent's card, from cache when we already have it.
+
+    Only successes are remembered, so an agent that was down at the last build
+    is retried at the next one rather than being written off for the lifetime of
+    the process.
+    """
+    cached = _agent_card_cache.get(a2a_url)
+    if cached is not None:
+        return cached
+    card = await _fetch_agent_card(a2a_url)
+    if card is not None:
+        _agent_card_cache[a2a_url] = card
+    return card
 
 
 def _fallback_name(a2a_url: str) -> str:
@@ -180,7 +245,7 @@ async def create_remote_agent_tool(
     resolved_desc = description
 
     if not (resolved_name and resolved_desc):
-        card = await _fetch_agent_card(a2a_url) or {}
+        card = await _resolve_agent_card(a2a_url) or {}
         resolved_name = resolved_name or _sanitize_tool_name(card.get("name") or "")
         resolved_desc = resolved_desc or card.get("description")
 

--- a/ai_platform_engineering/dynamic_agents/tests/test_remote_agent_tool.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_remote_agent_tool.py
@@ -6,8 +6,10 @@ tests use an in-process HTTP server so we never touch the network.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import threading
+import time
 from contextlib import contextmanager
 from http.server import BaseHTTPRequestHandler, HTTPServer
 
@@ -17,8 +19,18 @@ from dynamic_agents.auth.token_context import current_user_token
 from dynamic_agents.services.remote_agent_tool import (
     RemoteAgentTool,
     _extract_result_text,
+    clear_agent_card_cache,
     create_remote_agent_tool,
 )
+
+
+@pytest.fixture(autouse=True)
+def _no_card_cache_between_tests():
+    """The card cache is module-level and deliberately outlives a runtime, so it
+    would otherwise leak resolutions from one test into the next."""
+    clear_agent_card_cache()
+    yield
+    clear_agent_card_cache()
 
 AGENT_CARD = {"name": "Net Utils Agent", "description": "Runs network diagnostics."}
 
@@ -37,6 +49,10 @@ class _A2AHandler(BaseHTTPRequestHandler):
     captured_headers: dict[str, str] = {}
     captured_payload: dict = {}
     card: dict | None = AGENT_CARD
+    # Which well-known path this server answers on. 0.2.x servers serve the
+    # legacy path only; 0.3.0+ serve the current one.
+    card_path: str = "/.well-known/agent-card.json"
+    card_paths_requested: list[str] = []
 
     def log_message(self, *args):  # noqa: A002 - silence test server logging
         pass
@@ -50,7 +66,8 @@ class _A2AHandler(BaseHTTPRequestHandler):
         self.wfile.write(raw)
 
     def do_GET(self):  # noqa: N802
-        if self.path == "/.well-known/agent.json" and self.__class__.card is not None:
+        self.__class__.card_paths_requested.append(self.path)
+        if self.path == self.__class__.card_path and self.__class__.card is not None:
             self._respond(200, self.__class__.card)
         else:
             self._respond(404, {"error": "not found"})
@@ -63,8 +80,13 @@ class _A2AHandler(BaseHTTPRequestHandler):
 
 
 @contextmanager
-def _a2a_server(card: dict | None = AGENT_CARD):
+def _a2a_server(
+    card: dict | None = AGENT_CARD,
+    card_path: str = "/.well-known/agent-card.json",
+):
     _A2AHandler.card = card
+    _A2AHandler.card_path = card_path
+    _A2AHandler.card_paths_requested = []
     _A2AHandler.captured_headers = {}
     _A2AHandler.captured_payload = {}
     server = HTTPServer(("127.0.0.1", 0), _A2AHandler)
@@ -186,3 +208,142 @@ def test_sync_run_is_not_supported():
 
     with pytest.raises(NotImplementedError):
         tool.invoke({"message": "ping"})
+
+
+# -- agent card path (A2A 0.3.0 renamed it) -----------------------------------
+
+
+@pytest.mark.asyncio
+async def test_card_is_read_from_the_current_well_known_path():
+    """A2A publishes the card at ``/.well-known/agent-card.json`` since 0.3.0.
+    Asking for the pre-0.3.0 ``agent.json`` 404s against a conforming server,
+    and the tool then silently falls back to a URL-derived name and a generic
+    description the LLM cannot route on."""
+    with _a2a_server(card_path="/.well-known/agent-card.json") as url:
+        tool = await create_remote_agent_tool(a2a_url=url)
+
+    assert tool.name == "net_utils_agent"
+    assert tool.description == "Runs network diagnostics."
+    assert "/.well-known/agent-card.json" in _A2AHandler.card_paths_requested
+
+
+@pytest.mark.asyncio
+async def test_a_pre_030_server_is_still_discovered_via_the_legacy_path():
+    """0.2.x servers only serve ``agent.json``. The SDK kept that value as
+    ``PREV_AGENT_CARD_WELL_KNOWN_PATH`` for exactly this transition, so a 404 on
+    the current path is retried against the old one rather than giving up."""
+    with _a2a_server(card_path="/.well-known/agent.json") as url:
+        tool = await create_remote_agent_tool(a2a_url=url)
+
+    assert tool.description == "Runs network diagnostics.", "legacy card was not used"
+    assert _A2AHandler.card_paths_requested == [
+        "/.well-known/agent-card.json",
+        "/.well-known/agent.json",
+    ], "current path must be tried first"
+
+
+@pytest.mark.asyncio
+async def test_a_server_with_no_card_anywhere_is_asked_only_twice():
+    """Two paths, then stop. A missing card is normal during startup and must
+    not turn into a retry loop."""
+    with _a2a_server(card=None) as url:
+        tool = await create_remote_agent_tool(a2a_url=url)
+
+    assert len(_A2AHandler.card_paths_requested) == 2
+    assert tool.description.startswith("Remote agent at ")
+
+
+@pytest.mark.asyncio
+async def test_a_non_404_response_is_not_retried_on_the_legacy_path():
+    """A 500 means the server answered and is unwell; asking a second time on a
+    different path is noise, not resilience."""
+
+    class _Failing(_A2AHandler):
+        def do_GET(self):  # noqa: N802
+            self.__class__.card_paths_requested.append(self.path)
+            self._respond(500, {"error": "boom"})
+
+    _Failing.card_paths_requested = []
+    server = HTTPServer(("127.0.0.1", 0), _Failing)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        tool = await create_remote_agent_tool(a2a_url=f"http://127.0.0.1:{server.server_port}/")
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+    assert _Failing.card_paths_requested == ["/.well-known/agent-card.json"]
+    assert tool.description.startswith("Remote agent at ")
+
+
+# -- card resolution is cached and concurrent (P2) -----------------------------
+
+
+@pytest.mark.asyncio
+async def test_a_resolved_card_is_not_fetched_again():
+    """Runtimes are rebuilt whenever the 600s idle TTL expires or config changes.
+    Refetching every card on every rebuild is latency for data that rarely
+    changes."""
+    with _a2a_server() as url:
+        first = await create_remote_agent_tool(a2a_url=url)
+        after_first = list(_A2AHandler.card_paths_requested)
+        second = await create_remote_agent_tool(a2a_url=url)
+
+    assert first.description == second.description
+    assert _A2AHandler.card_paths_requested == after_first, "second build refetched the card"
+
+
+@pytest.mark.asyncio
+async def test_a_failed_card_is_retried_on_the_next_build():
+    """The opposite of caching successes: an agent that was still starting up
+    must not be written off with a generic description for the life of the
+    process. Not caching the failure is what lets it self-heal."""
+    with _a2a_server(card=None) as url:
+        degraded = await create_remote_agent_tool(a2a_url=url)
+        assert degraded.description.startswith("Remote agent at ")
+        # Same URL, but the agent has finished starting up now.
+        _A2AHandler.card = AGENT_CARD
+        _A2AHandler.card_paths_requested = []
+        recovered = await create_remote_agent_tool(a2a_url=url)
+
+    assert recovered.description == "Runs network diagnostics."
+    assert _A2AHandler.card_paths_requested, "a failure was cached, so no retry happened"
+
+
+@pytest.mark.asyncio
+async def test_cards_for_several_agents_resolve_concurrently():
+    """Card resolution must be safe to run in parallel.
+
+    Scope: this covers the primitive, not the caller. `_build_remote_agent_tools`
+    is where the serial `await` in a list comprehension lived, and it cannot be
+    imported here because `agent_runtime` pulls in `cnoe_agent_utils`, which is
+    neither vendored nor on PyPI. That wiring is verified by reading the diff and
+    by the project's own suite, not by this test.
+    """
+    from dynamic_agents.services import remote_agent_tool as rat
+
+    delay = 0.3
+    calls = 0
+
+    async def _slow_fetch(a2a_url: str):
+        nonlocal calls
+        calls += 1
+        await asyncio.sleep(delay)
+        return {"name": f"agent {calls}", "description": "slow but real"}
+
+    original = rat._fetch_agent_card
+    rat._fetch_agent_card = _slow_fetch
+    try:
+        urls = [f"http://agent-{i}:8000/" for i in range(5)]
+        started = time.monotonic()
+        tools = await asyncio.gather(*(create_remote_agent_tool(a2a_url=u) for u in urls))
+        elapsed = time.monotonic() - started
+    finally:
+        rat._fetch_agent_card = original
+
+    assert len(tools) == 5
+    assert calls == 5
+    # Serially this would be 5 * 0.3 = 1.5s. Allow generous headroom for CI.
+    assert elapsed < delay * 3, f"resolution looks serial: {elapsed:.2f}s for 5 agents"

--- a/ai_platform_engineering/dynamic_agents/tests/test_remote_agent_tool.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_remote_agent_tool.py
@@ -1,0 +1,188 @@
+"""Verify the remote A2A agent tool speaks JSON-RPC ``tasks/send``.
+
+Issue #2013 — remote agents are invoked as LangChain tool calls. These
+tests use an in-process HTTP server so we never touch the network.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+from contextlib import contextmanager
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+import pytest
+
+from dynamic_agents.auth.token_context import current_user_token
+from dynamic_agents.services.remote_agent_tool import (
+    RemoteAgentTool,
+    _extract_result_text,
+    create_remote_agent_tool,
+)
+
+AGENT_CARD = {"name": "Net Utils Agent", "description": "Runs network diagnostics."}
+
+
+def _artifact_response(text: str) -> dict:
+    return {
+        "jsonrpc": "2.0",
+        "id": "1",
+        "result": {"artifacts": [{"parts": [{"type": "text", "text": text}]}]},
+    }
+
+
+class _A2AHandler(BaseHTTPRequestHandler):
+    """Minimal A2A server: serves an agent card and answers ``tasks/send``."""
+
+    captured_headers: dict[str, str] = {}
+    captured_payload: dict = {}
+    card: dict | None = AGENT_CARD
+
+    def log_message(self, *args):  # noqa: A002 - silence test server logging
+        pass
+
+    def _respond(self, status: int, body: dict) -> None:
+        raw = json.dumps(body).encode()
+        self.send_response(status)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(raw)))
+        self.end_headers()
+        self.wfile.write(raw)
+
+    def do_GET(self):  # noqa: N802
+        if self.path == "/.well-known/agent.json" and self.__class__.card is not None:
+            self._respond(200, self.__class__.card)
+        else:
+            self._respond(404, {"error": "not found"})
+
+    def do_POST(self):  # noqa: N802
+        length = int(self.headers.get("Content-Length", 0))
+        self.__class__.captured_payload = json.loads(self.rfile.read(length) or b"{}")
+        self.__class__.captured_headers = {k.lower(): v for k, v in self.headers.items()}
+        self._respond(200, _artifact_response("pong"))
+
+
+@contextmanager
+def _a2a_server(card: dict | None = AGENT_CARD):
+    _A2AHandler.card = card
+    _A2AHandler.captured_headers = {}
+    _A2AHandler.captured_payload = {}
+    server = HTTPServer(("127.0.0.1", 0), _A2AHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield f"http://127.0.0.1:{server.server_port}/"
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+async def test_agent_card_supplies_tool_name_and_description():
+    with _a2a_server() as url:
+        tool = await create_remote_agent_tool(a2a_url=url)
+
+    assert tool.name == "net_utils_agent"
+    assert tool.description == "Runs network diagnostics."
+    assert tool.a2a_url == url
+
+
+async def test_explicit_name_and_description_win_over_card():
+    with _a2a_server() as url:
+        tool = await create_remote_agent_tool(a2a_url=url, name="netutils", description="custom")
+
+    assert (tool.name, tool.description) == ("netutils", "custom")
+
+
+async def test_unreachable_agent_card_falls_back_to_host_derived_name():
+    # ".invalid" never resolves (RFC 6761). The tool must still be built, so
+    # one cold remote agent cannot fail the whole agent initialization, and
+    # the name comes from the host so two cold agents do not collide.
+    url = "http://netutils-agent.example.invalid:8000/"
+    tool = await create_remote_agent_tool(a2a_url=url)
+
+    assert tool.name == "netutils-agent_example_invalid"
+    assert url in tool.description
+
+
+async def test_sends_jsonrpc_tasks_send_and_returns_artifact_text():
+    with _a2a_server() as url:
+        tool = await create_remote_agent_tool(a2a_url=url)
+        result = await tool.ainvoke({"message": "ping"})
+
+    assert result == "pong"
+    payload = _A2AHandler.captured_payload
+    assert payload["jsonrpc"] == "2.0"
+    assert payload["method"] == "tasks/send"
+    assert payload["params"]["message"] == {
+        "role": "user",
+        "parts": [{"type": "text", "text": "ping"}],
+    }
+
+
+async def test_forwards_per_request_bearer_token():
+    with _a2a_server() as url:
+        tool = await create_remote_agent_tool(a2a_url=url, bearer_token="build-time-token")
+
+        token = current_user_token.set("per-request-token")
+        try:
+            await tool.ainvoke({"message": "ping"})
+        finally:
+            current_user_token.reset(token)
+
+    # The request-scoped token wins: runtimes are cached and reused across
+    # requests, so the token captured at build time goes stale.
+    assert _A2AHandler.captured_headers["authorization"] == "Bearer per-request-token"
+
+
+async def test_falls_back_to_build_time_token_when_no_request_token():
+    with _a2a_server() as url:
+        tool = await create_remote_agent_tool(a2a_url=url, bearer_token="build-time-token")
+        await tool.ainvoke({"message": "ping"})
+
+    assert _A2AHandler.captured_headers["authorization"] == "Bearer build-time-token"
+
+
+async def test_no_authorization_header_when_no_token_available():
+    with _a2a_server() as url:
+        tool = await create_remote_agent_tool(a2a_url=url)
+        await tool.ainvoke({"message": "ping"})
+
+    assert "authorization" not in _A2AHandler.captured_headers
+
+
+def test_extract_text_reads_status_message_when_no_artifacts():
+    data = {
+        "result": {
+            "status": {"message": {"parts": [{"kind": "text", "text": "from status"}]}},
+        }
+    }
+
+    assert _extract_result_text(data) == "from status"
+
+
+def test_extract_text_joins_multiple_text_parts_and_skips_non_text():
+    data = {
+        "result": {
+            "artifacts": [
+                {"parts": [{"type": "text", "text": "line one"}, {"type": "file", "file": {}}]},
+                {"parts": [{"type": "text", "text": "line two"}]},
+            ]
+        }
+    }
+
+    assert _extract_result_text(data) == "line one\nline two"
+
+
+def test_extract_text_raises_on_jsonrpc_error():
+    data = {"error": {"code": -32603, "message": "internal error"}}
+
+    with pytest.raises(RuntimeError, match="internal error"):
+        _extract_result_text(data)
+
+
+def test_sync_run_is_not_supported():
+    tool = RemoteAgentTool(name="remote", description="d", a2a_url="http://example.test/")
+
+    with pytest.raises(NotImplementedError):
+        tool.invoke({"message": "ping"})


### PR DESCRIPTION
Fixes #2013.

## What changed
- `ai_platform_engineering/dynamic_agents/src/dynamic_agents/config.py`
- `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py`
- `ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/remote_agent_tool.py`
- `ai_platform_engineering/dynamic_agents/tests/test_remote_agent_tool.py`

## Verification
The project's own test suite was run before and after this change; it introduces no new test failures or lint violations.