### PR TITLE
fix(ci): skip UI test comments for fork PRs

### DIFF
--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -144,7 +144,12 @@ jobs:
           rm -f "$out"
 
       - name: Comment test results on PR
-        if: github.event_name == 'pull_request' && always()
+        # Fork PRs receive a read-only token, so attempting to write a comment
+        # would turn an otherwise successful test job red.
+        if: >-
+          ${{ always() &&
+              github.event_name == 'pull_request' &&
+              github.event.pull_request.head.repo.full_name == github.repository }}
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |


### PR DESCRIPTION
# Description

Follow-up to #2371.

The CAIPE UI Jest suite passed on the fork PR, but the `test` job was marked failed when its final `github-script` step attempted to post a PR comment with a read-only fork token.

This change runs the comment step only for same-repository pull requests. Fork PRs still run the full test suite, extract coverage, upload coverage artifacts, and fail when Jest fails; they simply skip the unavailable write operation.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing PRs have been referenced
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented inline
- [x] The workflow diff passes `git diff --check`
- [x] `actionlint` reports no new findings compared with `main`
