### PR TITLE
fix(ui): prevent sidebar collapse flash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.68-dev.4"
+version = "0.5.68-dev.5"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/admin-settings-regression.spec.ts
+++ b/ui/e2e/rbac/admin-settings-regression.spec.ts
@@ -106,6 +106,16 @@ test.describe("mocked Admin workspace browser regression",() => {
 
     await page.getByRole("button",{ name: "Collapse sidebar",exact: true }).click();
     await expect(page.getByRole("button",{ name: "Expand sidebar",exact: true })).toBeVisible();
+    await expect.poll(async () => page.context().cookies()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: "caipe-application-navigation-collapsed",
+          value: "true",
+        }),
+      ]),
+    );
+    await page.reload({ waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("button",{ name: "Expand sidebar",exact: true })).toBeVisible();
     await page.getByRole("button",{ name: "Admin",exact: true }).hover();
     const flyoutNavigation = page.getByRole("navigation",{ name: "Admin sections" });
     const flyoutResources = flyoutNavigation.getByRole("button",{

--- a/ui/src/app/(app)/__tests__/layout.test.tsx
+++ b/ui/src/app/(app)/__tests__/layout.test.tsx
@@ -1,0 +1,54 @@
+import { render,screen } from "@testing-library/react";
+
+import AppLayout from "../layout";
+
+const mockGetCookie = jest.fn();
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(async () => ({ get: mockGetCookie })),
+}));
+
+jest.mock("../layout-client", () => ({
+  AppLayoutClient: ({
+    children,
+    initialNavigationCollapsed,
+  }: {
+    children: React.ReactNode;
+    initialNavigationCollapsed: boolean;
+  }) => (
+    <div data-collapsed={String(initialNavigationCollapsed)}>
+      {children}
+    </div>
+  ),
+}));
+
+describe("AppLayout", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("passes the persisted collapsed state into the first application render", async () => {
+    mockGetCookie.mockReturnValue({ value: "true" });
+
+    render(await AppLayout({ children: <span>Page content</span> }));
+
+    expect(screen.getByText("Page content").parentElement).toHaveAttribute(
+      "data-collapsed",
+      "true",
+    );
+    expect(mockGetCookie).toHaveBeenCalledWith(
+      "caipe-application-navigation-collapsed",
+    );
+  });
+
+  it("defaults to an expanded rail when no preference exists", async () => {
+    mockGetCookie.mockReturnValue(undefined);
+
+    render(await AppLayout({ children: <span>Page content</span> }));
+
+    expect(screen.getByText("Page content").parentElement).toHaveAttribute(
+      "data-collapsed",
+      "false",
+    );
+  });
+});

--- a/ui/src/app/(app)/layout-client.tsx
+++ b/ui/src/app/(app)/layout-client.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { AppHeader } from "@/components/layout/AppHeader";
+import {
+  ApplicationNavigationDrawer,
+  ApplicationNavigationRail,
+} from "@/components/layout/ApplicationNavigation";
+import { ApplicationNavigationProvider } from "@/components/layout/ApplicationNavigationContext";
+import { LiveStreamBanner } from "@/components/layout/LiveStreamBanner";
+import { useUserInit } from "@/hooks/use-user-init";
+import { finishNavigationProgress } from "@/lib/navigation-progress";
+import { usePathname } from "next/navigation";
+import React from "react";
+
+export function AppLayoutClient({
+  children,
+  initialNavigationCollapsed,
+}: {
+  children: React.ReactNode;
+  initialNavigationCollapsed: boolean;
+}): React.ReactElement {
+  const pathname = usePathname();
+
+  // Initialize user in MongoDB on first login
+  useUserInit();
+
+  React.useEffect(() => {
+    finishNavigationProgress();
+  }, [pathname]);
+
+  return (
+    <ApplicationNavigationProvider
+      initialCollapsed={initialNavigationCollapsed}
+    >
+      <div className="flex h-screen bg-background noise-overlay">
+        <ApplicationNavigationRail />
+        <div className="flex min-w-0 flex-1 flex-col">
+          <AppHeader />
+          <LiveStreamBanner />
+          <div className="flex min-h-0 flex-1 flex-col">
+            {children}
+          </div>
+        </div>
+        <ApplicationNavigationDrawer />
+      </div>
+    </ApplicationNavigationProvider>
+  );
+}

--- a/ui/src/app/(app)/layout.tsx
+++ b/ui/src/app/(app)/layout.tsx
@@ -1,44 +1,26 @@
-"use client";
-
-import { AppHeader } from "@/components/layout/AppHeader";
 import {
-  ApplicationNavigationDrawer,
-  ApplicationNavigationRail,
-} from "@/components/layout/ApplicationNavigation";
-import { ApplicationNavigationProvider } from "@/components/layout/ApplicationNavigationContext";
-import { LiveStreamBanner } from "@/components/layout/LiveStreamBanner";
-import { useUserInit } from "@/hooks/use-user-init";
-import { finishNavigationProgress } from "@/lib/navigation-progress";
-import { usePathname } from "next/navigation";
+  APPLICATION_NAVIGATION_COLLAPSED_COOKIE,
+  isWorkspaceRailCollapsed,
+} from "@/lib/workspace-rail";
+import { cookies } from "next/headers";
 import React from "react";
+import { AppLayoutClient } from "./layout-client";
 
-export default function AppLayout({
+export default async function AppLayout({
   children,
 }: {
   children: React.ReactNode;
-}) {
-  const pathname = usePathname();
+}): Promise<React.ReactElement> {
+  const cookieStore = await cookies();
+  const initialNavigationCollapsed = isWorkspaceRailCollapsed(
+    cookieStore.get(APPLICATION_NAVIGATION_COLLAPSED_COOKIE)?.value,
+  );
 
-  // Initialize user in MongoDB on first login
-  useUserInit();
-
-  React.useEffect(() => {
-    finishNavigationProgress();
-  }, [pathname]);
-  
   return (
-    <ApplicationNavigationProvider>
-      <div className="flex h-screen bg-background noise-overlay">
-        <ApplicationNavigationRail />
-        <div className="flex min-w-0 flex-1 flex-col">
-          <AppHeader />
-          <LiveStreamBanner />
-          <div className="flex min-h-0 flex-1 flex-col">
-            {children}
-          </div>
-        </div>
-        <ApplicationNavigationDrawer />
-      </div>
-    </ApplicationNavigationProvider>
+    <AppLayoutClient
+      initialNavigationCollapsed={initialNavigationCollapsed}
+    >
+      {children}
+    </AppLayoutClient>
   );
 }

--- a/ui/src/components/layout/ApplicationNavigationContext.tsx
+++ b/ui/src/components/layout/ApplicationNavigationContext.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { WorkspaceRailProvider } from "@/components/layout/WorkspaceRailContext";
+import { APPLICATION_NAVIGATION_COLLAPSED_COOKIE } from "@/lib/workspace-rail";
 import React from "react";
 
 interface ApplicationNavigationRegistration {
@@ -24,8 +25,10 @@ const ApplicationNavigationContext =
 
 export function ApplicationNavigationProvider({
   children,
+  initialCollapsed = false,
 }: {
   children: React.ReactNode;
+  initialCollapsed?: boolean;
 }): React.ReactElement {
   const [registration,setRegistration] =
     React.useState<ApplicationNavigationRegistration | null>(null);
@@ -73,7 +76,8 @@ export function ApplicationNavigationProvider({
     <ApplicationNavigationContext.Provider value={value}>
       <WorkspaceRailProvider
         collapsible
-        storageKey="application-navigation-collapsed"
+        cookieName={APPLICATION_NAVIGATION_COLLAPSED_COOKIE}
+        initialCollapsed={initialCollapsed}
       >
         {children}
       </WorkspaceRailProvider>

--- a/ui/src/components/layout/WorkspaceRailContext.tsx
+++ b/ui/src/components/layout/WorkspaceRailContext.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import {
-  createContext,
   useCallback,
+  createContext,
   useContext,
   useMemo,
-  useSyncExternalStore,
+  useState,
 } from "react";
+import { WORKSPACE_RAIL_COOKIE_MAX_AGE_SECONDS } from "@/lib/workspace-rail";
 
 interface WorkspaceRailState {
   collapsed: boolean;
@@ -20,62 +21,33 @@ const WorkspaceRailContext = createContext<WorkspaceRailState>({
   toggle: () => undefined,
 });
 
-const WORKSPACE_RAIL_STORAGE_EVENT = "caipe:workspace-rail-storage";
-const workspaceRailFallback = new Map<string,boolean>();
-
 export function WorkspaceRailProvider({
   children,
   collapsible,
-  storageKey = "workspace-navigation-collapsed",
+  cookieName = "workspace-navigation-collapsed",
+  initialCollapsed = false,
 }: {
   children: React.ReactNode;
   collapsible: boolean;
-  storageKey?: string;
+  cookieName?: string;
+  initialCollapsed?: boolean;
 }): React.ReactElement {
-  const readCollapsed = useCallback((): boolean => {
-    if (!collapsible || typeof window === "undefined") return false;
-    try {
-      return window.localStorage.getItem(storageKey) === "true";
-    } catch {
-      // Storage can be unavailable in privacy-restricted browser contexts.
-      return workspaceRailFallback.get(storageKey) ?? false;
-    }
-  },[collapsible,storageKey]);
-  const subscribe = useCallback((onStoreChange: () => void) => {
-    if (!collapsible || typeof window === "undefined") return () => undefined;
-    const handleStorage = (event: StorageEvent) => {
-      if (event.key === storageKey) onStoreChange();
-    };
-    const handleLocalStorage = (event: Event) => {
-      if (
-        event instanceof CustomEvent
-        && event.detail === storageKey
-      ) onStoreChange();
-    };
-    window.addEventListener("storage",handleStorage);
-    window.addEventListener(WORKSPACE_RAIL_STORAGE_EVENT,handleLocalStorage);
-    return () => {
-      window.removeEventListener("storage",handleStorage);
-      window.removeEventListener(WORKSPACE_RAIL_STORAGE_EVENT,handleLocalStorage);
-    };
-  },[collapsible,storageKey]);
-  const collapsed = useSyncExternalStore(subscribe,readCollapsed,() => false);
+  const [collapsed,setCollapsed] = useState(
+    collapsible && initialCollapsed,
+  );
+  const toggle = useCallback(() => {
+    if (!collapsible) return;
+    const next = !collapsed;
+    const secure = window.location.protocol === "https:" ? "; Secure" : "";
+    document.cookie = `${encodeURIComponent(cookieName)}=${String(next)}; Path=/; Max-Age=${WORKSPACE_RAIL_COOKIE_MAX_AGE_SECONDS}; SameSite=Lax${secure}`;
+    setCollapsed(next);
+  },[collapsed,collapsible,cookieName]);
 
   const value = useMemo<WorkspaceRailState>(() => ({
     collapsed,
     collapsible,
-    toggle: () => {
-      if (!collapsible) return;
-      try {
-        window.localStorage.setItem(storageKey,String(!collapsed));
-      } catch {
-        workspaceRailFallback.set(storageKey,!collapsed);
-      }
-      window.dispatchEvent(new CustomEvent(WORKSPACE_RAIL_STORAGE_EVENT,{
-        detail: storageKey,
-      }));
-    },
-  }),[collapsed,collapsible,storageKey]);
+    toggle,
+  }),[collapsed,collapsible,toggle]);
 
   return (
     <WorkspaceRailContext.Provider value={value}>

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -451,7 +451,6 @@ beforeEach(() => {
 describe('AppHeader — application chrome', () => {
   beforeEach(() => {
     jest.clearAllMocks()
-    window.localStorage.removeItem('application-navigation-collapsed')
     mockStorageMode = 'mongodb'
     mockPathname = '/chat'
     mockIsAdmin = false

--- a/ui/src/components/layout/__tests__/WorkspaceRailContext.test.tsx
+++ b/ui/src/components/layout/__tests__/WorkspaceRailContext.test.tsx
@@ -1,0 +1,50 @@
+import { fireEvent,render,screen } from "@testing-library/react";
+
+import {
+  useWorkspaceRail,
+  WorkspaceRailProvider,
+} from "../WorkspaceRailContext";
+
+const TEST_COOKIE = "test-workspace-navigation-collapsed";
+
+function RailState(): React.ReactElement {
+  const { collapsed,toggle } = useWorkspaceRail();
+  return (
+    <button onClick={toggle} type="button">
+      {collapsed ? "Collapsed" : "Expanded"}
+    </button>
+  );
+}
+
+describe("WorkspaceRailProvider", () => {
+  afterEach(() => {
+    document.cookie = `${TEST_COOKIE}=; Path=/; Max-Age=0`;
+  });
+
+  it("uses the server-provided state on its first render", () => {
+    render(
+      <WorkspaceRailProvider
+        collapsible
+        cookieName={TEST_COOKIE}
+        initialCollapsed
+      >
+        <RailState />
+      </WorkspaceRailProvider>,
+    );
+
+    expect(screen.getByRole("button",{ name: "Collapsed" })).toBeVisible();
+  });
+
+  it("updates the rail and its persistent cookie together", () => {
+    render(
+      <WorkspaceRailProvider collapsible cookieName={TEST_COOKIE}>
+        <RailState />
+      </WorkspaceRailProvider>,
+    );
+
+    fireEvent.click(screen.getByRole("button",{ name: "Expanded" }));
+
+    expect(screen.getByRole("button",{ name: "Collapsed" })).toBeVisible();
+    expect(document.cookie).toContain(`${TEST_COOKIE}=true`);
+  });
+});

--- a/ui/src/lib/workspace-rail.ts
+++ b/ui/src/lib/workspace-rail.ts
@@ -1,0 +1,10 @@
+export const APPLICATION_NAVIGATION_COLLAPSED_COOKIE =
+  "caipe-application-navigation-collapsed";
+
+export const WORKSPACE_RAIL_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 24 * 365;
+
+export function isWorkspaceRailCollapsed(
+  value: string | undefined,
+): boolean {
+  return value === "true";
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.68.dev4"
+version = "0.5.68.dev5"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Persist the application sidebar collapse preference in an SSR-readable cookie. The server app layout now reads that preference and passes it into the client shell, so the first rendered frame matches the saved rail width instead of rendering expanded and snapping closed after hydration.

The toggle updates React state immediately and writes the same non-sensitive UI preference cookie with `Path=/`, `SameSite=Lax`, and a one-year lifetime.

Tests cover the server-provided initial state, cookie persistence on toggle, and persistence after a browser reload.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] Relevant unit tests and TypeScript checks pass

## Validation

- `npm test -- --runInBand --runTestsByPath ...` — 75 tests passed
- `tsc --noEmit --pretty false`
- `npm run lint -- ...`
- Playwright is left to CI per the repository workflow.