### PR TITLE
fix(ui): add workflows breadcrumbs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.68-dev.4"
+version = "0.5.68-dev.5"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/workflows-rbac-regression.spec.ts
+++ b/ui/e2e/rbac/workflows-rbac-regression.spec.ts
@@ -35,6 +35,12 @@ test.describe("mocked workflows RBAC and MCP regression", () => {
     });
 
     await page.goto("/workflows", { waitUntil: "domcontentloaded" });
+    const breadcrumb = page.getByRole("navigation",{ name: "Breadcrumb" });
+    await expect(breadcrumb.getByRole("link",{ name: "Home" })).toHaveAttribute("href","/");
+    await expect(breadcrumb.getByRole("link",{ name: "Workflows" })).toHaveAttribute(
+      "href",
+      "/workflows",
+    );
     await expect(page.getByText("Platform team workflow")).toBeVisible();
     await expect(page.getByText("Global SRE workflow")).toBeVisible();
     await expect(page.getByText("Member private workflow")).toBeVisible();

--- a/ui/src/app/(app)/workflows/__tests__/layout-client.test.tsx
+++ b/ui/src/app/(app)/workflows/__tests__/layout-client.test.tsx
@@ -1,0 +1,31 @@
+import { render,screen } from "@testing-library/react";
+
+import { WorkflowsLayoutClient } from "../layout-client";
+
+jest.mock("@/components/auth-guard", () => ({
+  AuthGuard: ({ children }: { children: React.ReactNode }) => children,
+}));
+
+jest.mock("@/components/workflows/WorkflowSidebar", () => ({
+  WorkflowSidebar: () => <aside>Workflow sidebar</aside>,
+}));
+
+describe("WorkflowsLayoutClient", () => {
+  it("renders the workspace hierarchy above the sidebar and content", () => {
+    render(
+      <WorkflowsLayoutClient>
+        <div>Workflow content</div>
+      </WorkflowsLayoutClient>,
+    );
+
+    const breadcrumb = screen.getByRole("navigation",{ name: "Breadcrumb" });
+    expect(breadcrumb).toBeVisible();
+    expect(screen.getByRole("link",{ name: "Home" })).toHaveAttribute("href","/");
+    expect(screen.getByRole("link",{ name: "Workflows" })).toHaveAttribute(
+      "href",
+      "/workflows",
+    );
+    expect(screen.getByText("Workflow sidebar")).toBeVisible();
+    expect(screen.getByText("Workflow content")).toBeVisible();
+  });
+});

--- a/ui/src/app/(app)/workflows/layout-client.tsx
+++ b/ui/src/app/(app)/workflows/layout-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { AuthGuard } from "@/components/auth-guard";
+import { WorkspaceBreadcrumbs } from "@/components/layout/WorkspacePageHeader";
 import { WorkflowSidebar } from "@/components/workflows/WorkflowSidebar";
 import React,{ useState } from "react";
 
@@ -16,13 +17,24 @@ export function WorkflowsLayoutClient({
 
   return (
     <AuthGuard>
-      <div className="flex-1 flex overflow-hidden">
-        <WorkflowSidebar
-          collapsed={sidebarCollapsed}
-          onCollapse={setSidebarCollapsed}
-        />
-        <div className="flex-1 min-w-0 flex flex-col overflow-hidden">
-          {children}
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        <div className="shrink-0 px-4 pt-3 sm:px-6">
+          <WorkspaceBreadcrumbs
+            breadcrumbs={[
+              { label: "Home",href: "/" },
+              { label: "Workflows",href: "/workflows" },
+            ]}
+          />
+        </div>
+
+        <div className="flex min-h-0 flex-1">
+          <WorkflowSidebar
+            collapsed={sidebarCollapsed}
+            onCollapse={setSidebarCollapsed}
+          />
+          <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+            {children}
+          </div>
         </div>
       </div>
     </AuthGuard>

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.68.dev4"
+version = "0.5.68.dev5"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Add the shared workspace breadcrumb row to Workflows so its hierarchy is consistent with Chat, Skills, Knowledge Bases, Agents, Credentials, Settings, and Admin.

The breadcrumb sits above both the workflow sidebar and content, with clickable `Home` and `Workflows` destinations. Workflow editor and run behavior are unchanged.

The existing mocked workflow browser scenario now verifies the breadcrumb, avoiding another Playwright test, and a focused component test covers layout composition.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] Relevant unit tests and TypeScript checks pass

## Validation

- Focused Jest component test passed
- `tsc --noEmit --pretty false`
- `npm run lint -- ...`
- Playwright is left to CI per the repository workflow.