### PR TITLE
fix(helm): pin third-party MCP image versions

### DIFF
--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -432,7 +432,7 @@ mcp-confluence:
   mcp:
     image:
       repository: "ghcr.io/sooperset/mcp-atlassian"
-      tag: "latest"
+      tag: "0.23.0"
       pullPolicy: "IfNotPresent"
     mode: "http" # Options: stdio, http
     port: 8000
@@ -469,7 +469,7 @@ mcp-gitlab:
   mcp:
     image:
       repository: "zereight050/gitlab-mcp"
-      tag: "latest"
+      tag: "2.1.46"
       pullPolicy: "IfNotPresent"
     mode: "http" # Options: stdio, http
     port: 8000

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.68-dev.5"
+version = "0.5.68-dev.6"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.68.dev5"
+version = "0.5.68.dev6"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Pin the two third-party MCP images that still followed mutable `latest` tags:

- `ghcr.io/sooperset/mcp-atlassian:0.23.0`
- `zereight050/gitlab-mcp:2.1.46`

The chart sets `imagePullPolicy: IfNotPresent`, so a mutable `latest` default can resolve differently across nodes and can also reuse a stale cached image. Version pins make upgrades explicit and keep chart deployments on reviewable upstream releases.

`mcp-atlassian` 0.23.0 is also above the 0.22.0 security-fix boundary for [GHSA-3r68-hf9h-887v](https://github.com/sooperset/mcp-atlassian/security/advisories/GHSA-3r68-hf9h-887v).

The other external MCP defaults were audited as part of this change: the official GitHub MCP server is already digest-pinned, and the Slack MCP server is already pinned to `v1.2.3`. CNOE-owned MCP images continue to follow the chart app version.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- `helm lint charts/ai-platform-engineering`
- `python3 scripts/validate-helm-image-channel.py`
- Full `tags.complete=true` Helm render, confirming the expected Confluence, GitLab, and Slack images
- `git diff --check`
- `make helm-docs` was run; its repository-wide pre-existing README regeneration drift was intentionally excluded from this scoped values-only change

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality and rationale are documented above
- [x] Relevant code style and Helm checks pass
- [x] Automated test coverage is not applicable to these two values-only substitutions
- [x] Relevant existing Helm validations pass