### PR TITLE
feat(mcp): add server visibility sharing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.68-dev.6"
+version = "0.5.68-dev.7"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/src/app/api/__tests__/mcp-servers-rbac.test.ts
+++ b/ui/src/app/api/__tests__/mcp-servers-rbac.test.ts
@@ -269,6 +269,8 @@ describe("MCP server per-resource RBAC", () => {
         ownerSubject: "bot-client-id",
         ownerSubjectKind: "service_account",
         ownerTeamSlug: null,
+        nextSharedTeamSlugs: [],
+        sharedWithOrg: false,
       },
       {
         caller: { type: "service_account", id: "bot-client-id" },
@@ -364,6 +366,8 @@ describe("MCP server per-resource RBAC", () => {
         ownerSubject: "alice-sub",
         ownerSubjectKind: "user",
         ownerTeamSlug: null,
+        nextSharedTeamSlugs: [],
+        sharedWithOrg: false,
       },
       {
         caller: { type: "user", id: "alice-sub" },
@@ -376,6 +380,8 @@ describe("MCP server per-resource RBAC", () => {
         owner_id: "alice@example.com",
         owner_subject: "alice-sub",
         owner_team_slug: undefined,
+        visibility: "private",
+        shared_with_teams: [],
       }),
     );
   });
@@ -440,6 +446,8 @@ describe("MCP server per-resource RBAC", () => {
         ownerSubject: "alice-sub",
         ownerSubjectKind: "user",
         ownerTeamSlug: "platform",
+        nextSharedTeamSlugs: [],
+        sharedWithOrg: false,
       },
       {
         caller: { type: "user", id: "alice-sub" },
@@ -472,6 +480,102 @@ describe("MCP server per-resource RBAC", () => {
     expect(mockRequireResourcePermission).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub", role: "user" }),
       { type: "mcp_server", id: "mcp-visible", action: "manage" },
+    );
+  });
+
+  it("makes an AgentGateway MCP server global and replaces its legacy org policy", async () => {
+    const server = {
+      _id: "mcp-tome",
+      name: "Tome",
+      transport: "http",
+      config_driven: false,
+      source: "agentgateway",
+      owner_subject: "alice-sub",
+    };
+    const findOneAndUpdate = jest.fn().mockResolvedValue({
+      ...server,
+      visibility: "global",
+      shared_with_teams: [],
+    });
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue(server),
+      findOneAndUpdate,
+    });
+    const { PUT } = await import("../mcp-servers/route");
+
+    const response = await PUT(
+      request("/api/mcp-servers?id=mcp-tome", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ visibility: "global", shared_with_teams: [] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockReconcileMcpServerRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: "mcp-tome",
+        sharedWithOrg: true,
+        previousSharedWithOrg: true,
+        nextSharedTeamSlugs: [],
+      }),
+      expect.objectContaining({ source: "mcp_server_update_sharing" }),
+    );
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: "mcp-tome" },
+      { $set: expect.objectContaining({ visibility: "global", shared_with_teams: [] }) },
+      { returnDocument: "after" },
+    );
+  });
+
+  it("resolves selected team slugs before creating a team-visible MCP server", async () => {
+    const insertOne = jest.fn();
+    mockGetCollection.mockImplementation(async (name: string) => {
+      if (name === "teams") {
+        return {
+          find: jest.fn().mockReturnValue({
+            project: jest.fn().mockReturnValue({
+              toArray: jest.fn().mockResolvedValue([{ slug: "platform" }]),
+            }),
+          }),
+        };
+      }
+      return {
+        findOne: jest.fn().mockResolvedValue(null),
+        insertOne,
+      };
+    });
+    const { POST } = await import("../mcp-servers/route");
+
+    const response = await POST(
+      request("/api/mcp-servers", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          id: "team-search",
+          name: "Team Search",
+          transport: "http",
+          endpoint: "https://mcp.example.test/mcp",
+          visibility: "team",
+          shared_with_teams: ["platform"],
+        }),
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(mockReconcileMcpServerRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: "mcp-team-search",
+        nextSharedTeamSlugs: ["platform"],
+        sharedWithOrg: false,
+      }),
+      expect.anything(),
+    );
+    expect(insertOne).toHaveBeenCalledWith(
+      expect.objectContaining({
+        visibility: "team",
+        shared_with_teams: ["platform"],
+      }),
     );
   });
 

--- a/ui/src/app/api/mcp-servers/agentgateway/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/__tests__/route.test.ts
@@ -8,6 +8,7 @@ const mockGetAuthFromBearerOrSession = jest.fn();
 const mockRequireResourcePermission = jest.fn();
 const mockGetCollection = jest.fn();
 const mockReconcileConfigDrivenMcpServerRelationships = jest.fn();
+const mockReconcileMcpServerRelationships = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => {
   class ApiError extends Error {
@@ -39,6 +40,8 @@ jest.mock("@/lib/rbac/resource-authz", () => ({
 jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
   reconcileConfigDrivenMcpServerRelationships: (...args: unknown[]) =>
     mockReconcileConfigDrivenMcpServerRelationships(...args),
+  reconcileMcpServerRelationships: (...args: unknown[]) =>
+    mockReconcileMcpServerRelationships(...args),
 }));
 
 const agentGatewayConfig = {
@@ -75,6 +78,7 @@ beforeEach(() => {
   mockGetAuthFromBearerOrSession.mockResolvedValue({ session: { sub: "admin-sub", role: "admin" } });
   mockRequireResourcePermission.mockResolvedValue(undefined);
   mockReconcileConfigDrivenMcpServerRelationships.mockResolvedValue({ enabled: true, writes: 4, deletes: 0 });
+  mockReconcileMcpServerRelationships.mockResolvedValue({ enabled: true, writes: 4, deletes: 0 });
   global.fetch = jest.fn().mockResolvedValue({
     ok: true,
     json: async () => agentGatewayConfig,
@@ -295,6 +299,10 @@ describe("AgentGateway MCP server discovery API", () => {
       }),
       insertOne,
       updateOne,
+      findOne: jest.fn().mockImplementation(async ({ _id }: { _id: string }) => ({
+        _id,
+        source: "agentgateway",
+      })),
     });
     const { POST } = await import("../sync/route");
 
@@ -333,6 +341,46 @@ describe("AgentGateway MCP server discovery API", () => {
     });
   });
 
+  it("preserves an explicit global sharing policy during AgentGateway sync", async () => {
+    const existing = {
+      _id: "rag",
+      name: "RAG",
+      transport: "http",
+      endpoint: "http://agentgateway:4000/mcp",
+      enabled: true,
+      source: "agentgateway",
+      visibility: "global",
+      shared_with_teams: [],
+    };
+    mockGetCollection.mockResolvedValue({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([existing]),
+      }),
+      findOne: jest.fn().mockResolvedValue(existing),
+      insertOne: jest.fn(),
+      updateOne: jest.fn(),
+    });
+    const { POST } = await import("../sync/route");
+
+    const response = await POST(
+      request("/api/mcp-servers/agentgateway/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: ["rag"] }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockReconcileMcpServerRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: "rag",
+        sharedWithOrg: true,
+        nextSharedTeamSlugs: [],
+      }),
+    );
+    expect(mockReconcileConfigDrivenMcpServerRelationships).not.toHaveBeenCalled();
+  });
+
   it("denies admin discovery when OpenFGA denies the AgentGateway object grant", async () => {
     mockRequireResourcePermission.mockRejectedValue(new Error("no discovery"));
     mockGetCollection.mockResolvedValue({
@@ -366,6 +414,11 @@ describe("AgentGateway MCP server discovery API", () => {
       }),
       insertOne,
       updateOne,
+      findOne: jest.fn().mockResolvedValue({
+        _id: "jira",
+        transport: "http",
+        endpoint: "http://mcp-jira:8000/mcp",
+      }),
     });
     mockReconcileConfigDrivenMcpServerRelationships.mockRejectedValueOnce(
       new Error("OpenFGA reconcile failed"),

--- a/ui/src/app/api/mcp-servers/agentgateway/_lib.ts
+++ b/ui/src/app/api/mcp-servers/agentgateway/_lib.ts
@@ -6,7 +6,10 @@ buildAgentGatewayMcpDiscovery,
 toAgentGatewayMcpServerDocument,
 type AgentGatewayMcpDiscovery,
 } from "@/lib/rbac/agentgateway-mcp-discovery";
-import { reconcileConfigDrivenMcpServerRelationships } from "@/lib/rbac/openfga-owned-resources-reconcile";
+import {
+  reconcileConfigDrivenMcpServerRelationships,
+  reconcileMcpServerRelationships,
+} from "@/lib/rbac/openfga-owned-resources-reconcile";
 import { caipeOrgKey } from "@/lib/rbac/organization";
 import type { MCPServerConfig } from "@/types/dynamic-agent";
 
@@ -19,6 +22,32 @@ type AgentGatewayMigrationWarning = {
   existing_endpoint?: string;
   message: string;
 };
+
+async function reconcileAgentGatewayMcpServer(
+  serverId: string,
+  existing: MCPServerConfig | null,
+): Promise<void> {
+  if (existing?.visibility) {
+    await reconcileMcpServerRelationships({
+      serverId,
+      ownerSubject: existing.owner_subject,
+      ownerTeamSlug:
+        existing.visibility === "team" ? existing.owner_team_slug : null,
+      nextSharedTeamSlugs:
+        existing.visibility === "team" ? existing.shared_with_teams ?? [] : [],
+      sharedWithOrg: existing.visibility === "global",
+    });
+    return;
+  }
+
+  // Unclassified discovery records retain the legacy discover-only policy.
+  // Once an owner selects Private, Teams, or Global in the editor, that
+  // explicit policy becomes authoritative on every future AgentGateway sync.
+  await reconcileConfigDrivenMcpServerRelationships({
+    serverId,
+    organizationId: caipeOrgKey(),
+  });
+}
 
 export async function fetchAgentGatewayMcpDiscovery(): Promise<AgentGatewayMcpDiscovery> {
   const response = await fetch(agentGatewayAdminConfigUrl(), { method: "GET" });
@@ -56,10 +85,8 @@ export async function syncSelectedAgentGatewayMcpServers(ids?: string[]) {
   for (const target of discovery.targets) {
     if (!selectedIds.has(target.id)) continue;
     if (target.status === "existing") {
-      await reconcileConfigDrivenMcpServerRelationships({
-        serverId: target.id,
-        organizationId: caipeOrgKey(),
-      });
+      const existing = await collection.findOne({ _id: target.id } as never);
+      await reconcileAgentGatewayMcpServer(target.id, existing);
       refreshed.push(target.id);
       continue;
     }
@@ -67,13 +94,10 @@ export async function syncSelectedAgentGatewayMcpServers(ids?: string[]) {
       skipped.push({ id: target.id, reason: target.status });
       continue;
     }
-    await reconcileConfigDrivenMcpServerRelationships({
-      serverId: target.id,
-      organizationId: caipeOrgKey(),
-    });
+    const existing = await collection.findOne({ _id: target.id } as never);
+    await reconcileAgentGatewayMcpServer(target.id, existing);
     const doc = toAgentGatewayMcpServerDocument(target);
     if (target.status === "legacy") {
-      const existing = await collection.findOne({ _id: target.id } as never);
       const existingCredentialSources = existing?.credential_sources;
       if (Array.isArray(existingCredentialSources) && existingCredentialSources.length > 0) {
         doc.credential_sources = existingCredentialSources;

--- a/ui/src/app/api/mcp-servers/route.ts
+++ b/ui/src/app/api/mcp-servers/route.ts
@@ -34,6 +34,7 @@ import type {
 MCPCredentialSource,
 MCPServerConfig,
 MCPServerConfigWithPermissions,
+MCPServerVisibilityType,
 TransportType,
 } from "@/types/dynamic-agent";
 import { NextRequest, NextResponse } from "next/server";
@@ -79,6 +80,60 @@ function requireStableSubject(session: { sub?: unknown }): string {
     throw new ApiError("A stable user subject is required for MCP server ownership.", 401, "NO_SUBJECT");
   }
   return subject;
+}
+
+function normalizeVisibility(
+  value: unknown,
+  fallback: MCPServerVisibilityType,
+): MCPServerVisibilityType {
+  if (value === undefined || value === null || value === "") return fallback;
+  if (value === "private" || value === "team" || value === "global") return value;
+  throw new ApiError(
+    "MCP server visibility must be 'private', 'team', or 'global'.",
+    400,
+    "INVALID_MCP_VISIBILITY",
+  );
+}
+
+interface McpSharingTeamDoc {
+  slug?: string;
+}
+
+async function resolveSharedTeamSlugs(rawInput: unknown): Promise<string[]> {
+  if (!Array.isArray(rawInput)) return [];
+  const requested = [...new Set(
+    rawInput
+      .map((value) => normalizeString(value))
+      .filter((value): value is string => value !== null),
+  )];
+  if (requested.length === 0) return [];
+
+  const teams = await getCollection<McpSharingTeamDoc>("teams");
+  const matches = await teams
+    .find({ slug: { $in: requested } })
+    .project({ slug: 1 })
+    .toArray();
+  const existing = new Set(
+    matches
+      .map((team) => normalizeString(team.slug))
+      .filter((slug): slug is string => slug !== null),
+  );
+  const missing = requested.filter((slug) => !existing.has(slug));
+  if (missing.length > 0) {
+    throw new ApiError(
+      `Unknown MCP sharing team(s): ${missing.join(", ")}`,
+      400,
+      "INVALID_MCP_SHARED_TEAM",
+    );
+  }
+  return requested;
+}
+
+function hasLegacyOrganizationAccess(server: MCPServerConfig): boolean {
+  return (
+    server.visibility === undefined &&
+    (server.config_driven !== false || server.source === "agentgateway")
+  );
 }
 
 /**
@@ -346,6 +401,19 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     if (ownerTeamSlug) {
       await requireOwnerTeamMembership(session, ownerTeamSlug);
     }
+    const visibility = normalizeVisibility(
+      body.visibility,
+      ownerTeamSlug ? "team" : "private",
+    );
+    const sharedTeamSlugs =
+      visibility === "team" ? await resolveSharedTeamSlugs(body.shared_with_teams) : [];
+    if (visibility === "team" && !ownerTeamSlug && sharedTeamSlugs.length === 0) {
+      throw new ApiError(
+        "Select at least one team for team-visible MCP servers.",
+        400,
+        "MCP_SHARED_TEAM_REQUIRED",
+      );
+    }
 
     // Uniqueness check
     const existing = await collection.findOne({ _id: serverId });
@@ -393,6 +461,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       owner_id: user.email,
       owner_subject: ownerSubject,
       owner_team_slug: ownerTeamSlug ?? undefined,
+      visibility,
+      shared_with_teams: sharedTeamSlugs,
       // Server-controlled — never from request body
       config_driven: false,
       created_at: now.toISOString(),
@@ -407,7 +477,9 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
         serverId,
         ownerSubject,
         ownerSubjectKind,
-        ownerTeamSlug,
+        ownerTeamSlug: visibility === "team" ? ownerTeamSlug : null,
+        nextSharedTeamSlugs: visibility === "team" ? sharedTeamSlugs : [],
+        sharedWithOrg: visibility === "global",
       },
       {
         caller: { type: ownerSubjectKind, id: ownerSubject },
@@ -462,8 +534,57 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       );
     }
 
+    const sharingUpdateRequested =
+      body.visibility !== undefined || body.shared_with_teams !== undefined;
+
     // Build update with explicit field allowlist
     const updateData = pickMutableFields(body);
+    if (sharingUpdateRequested) {
+      const visibility = normalizeVisibility(
+        body.visibility,
+        server.visibility ?? "private",
+      );
+      const sharedTeamSlugs =
+        visibility === "team" ? await resolveSharedTeamSlugs(body.shared_with_teams) : [];
+      const ownerTeamSlug = normalizeString(server.owner_team_slug);
+      if (visibility === "team" && !ownerTeamSlug && sharedTeamSlugs.length === 0) {
+        throw new ApiError(
+          "Select at least one team for team-visible MCP servers.",
+          400,
+          "MCP_SHARED_TEAM_REQUIRED",
+        );
+      }
+      updateData.visibility = visibility;
+      updateData.shared_with_teams = sharedTeamSlugs;
+
+      const previousVisibility = server.visibility;
+      const previousTeamVisibility =
+        previousVisibility === "team" ||
+        (previousVisibility === undefined && Boolean(server.owner_team_slug));
+      await reconcileMcpServerRelationships(
+        {
+          serverId: id,
+          ownerTeamSlug: visibility === "team" ? ownerTeamSlug : null,
+          previousOwnerTeamSlug: previousTeamVisibility ? ownerTeamSlug : null,
+          nextSharedTeamSlugs: visibility === "team" ? sharedTeamSlugs : [],
+          previousSharedTeamSlugs: previousTeamVisibility
+            ? server.shared_with_teams ?? []
+            : [],
+          sharedWithOrg: visibility === "global",
+          previousSharedWithOrg:
+            previousVisibility === "global" || hasLegacyOrganizationAccess(server),
+        },
+        {
+          caller: session.sub
+            ? {
+                type: session.isServiceAccount === true ? "service_account" : "user",
+                id: String(session.sub).trim(),
+              }
+            : undefined,
+          source: "mcp_server_update_sharing",
+        },
+      );
+    }
     if (Object.keys(updateData).length === 0) {
       // No fields to update — return current state
       return successResponse(server);

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -7,7 +7,7 @@ import { Button } from "@/components/ui/button";
 import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { TeamPicker,type TeamPickerOption } from "@/components/ui/team-picker";
+import { TeamMultiPicker,TeamPicker,type TeamPickerOption } from "@/components/ui/team-picker";
 import { Textarea } from "@/components/ui/textarea";
 import {
   Tooltip,
@@ -26,9 +26,10 @@ MCPCredentialSource,
 MCPServerConfig,
 MCPServerConfigCreate,
 MCPServerConfigUpdate,
+MCPServerVisibilityType,
 TransportType,
 } from "@/types/dynamic-agent";
-import { ArrowLeft,Info,Loader2,Plus,X } from "lucide-react";
+import { ArrowLeft,Globe2,Info,Loader2,LockKeyhole,Plus,Users,X } from "lucide-react";
 import React from "react";
 
 export interface MCPServerInitialValues {
@@ -36,6 +37,12 @@ export interface MCPServerInitialValues {
   description?: string;
   endpoint?: string;
   credential_sources?: MCPCredentialSource[];
+}
+
+interface SharingTeam {
+  _id?: string;
+  slug?: string;
+  name?: string;
 }
 
 interface MCPServerEditorProps {
@@ -208,6 +215,16 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
   const [credentialSources, setCredentialSources] = React.useState<MCPCredentialSource[]>(
     normalizeCredentialSourcesForEditor(server?.credential_sources ?? initialValues?.credential_sources),
   );
+  const [visibility, setVisibility] = React.useState<MCPServerVisibilityType | null>(() => {
+    if (!server) return "private";
+    if (server.visibility) return server.visibility;
+    return server.owner_team_slug ? "team" : null;
+  });
+  const [sharedWithTeams, setSharedWithTeams] = React.useState<string[]>(() => {
+    if (server?.shared_with_teams?.length) return server.shared_with_teams;
+    return server?.owner_team_slug ? [server.owner_team_slug] : [];
+  });
+  const [availableTeams, setAvailableTeams] = React.useState<SharingTeam[]>([]);
 
   const [loading, setLoading] = React.useState(false);
   const [error, setError] = React.useState<string | null>(null);
@@ -286,6 +303,25 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
       }
     }
     void loadDiscovery();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    let cancelled = false;
+    async function loadTeams() {
+      try {
+        const response = await fetch("/api/dynamic-agents/teams");
+        const payload = (await response.json()) as { success?: boolean; data?: SharingTeam[] };
+        if (!cancelled && payload.success && Array.isArray(payload.data)) {
+          setAvailableTeams(payload.data);
+        }
+      } catch {
+        // Best effort. The team picker remains empty and team saves stay disabled.
+      }
+    }
+    void loadTeams();
     return () => {
       cancelled = true;
     };
@@ -542,6 +578,12 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
           // Always send credential_sources on update (including []) so the BFF can
           // clear previously saved bindings; omitting the field is a no-op.
           credential_sources: normalizedCredentialSources,
+          ...(visibility
+            ? {
+                visibility,
+                shared_with_teams: visibility === "team" ? sharedWithTeams : [],
+              }
+            : {}),
         };
 
         const response = await fetch(`/api/mcp-servers?id=${server._id}`, {
@@ -572,6 +614,8 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
           args: transport === "stdio" ? args : undefined,
           env: transport === "stdio" && Object.keys(env).length > 0 ? env : undefined,
           credential_sources: normalizedCredentialSources.length > 0 ? normalizedCredentialSources : undefined,
+          visibility: visibility ?? "private",
+          shared_with_teams: visibility === "team" ? sharedWithTeams : [],
         };
 
         const response = await fetch("/api/mcp-servers", {
@@ -598,6 +642,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
     name.trim() &&
     (isEditing || id.trim() || deriveServerIdFromDisplayName(name)) &&
     (transport === "stdio" ? command.trim() : endpoint.trim()) &&
+    (visibility !== "team" || sharedWithTeams.length > 0) &&
     credentialSources.every((source) =>
       normalizedCredentialSource(source, providerConnectionOptions) !== null
     );
@@ -942,6 +987,97 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
                 </div>
               </div>
             )}
+          </div>
+
+          {/* Sharing */}
+          <div className="space-y-4 border-t border-border/60 pt-6">
+            <div className="space-y-1">
+              <h3 className="text-sm font-medium">Access</h3>
+              <p className="text-xs text-muted-foreground">
+                Choose who can discover and invoke this MCP server.
+              </p>
+            </div>
+            {visibility === null ? (
+              <div className="rounded-lg border border-amber-500/40 bg-amber-500/5 p-3 text-xs text-muted-foreground">
+                This existing server uses a legacy access policy. It will remain unchanged until
+                you select Private, Teams, or Global.
+              </div>
+            ) : null}
+            <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+              {([
+                {
+                  value: "private" as const,
+                  label: "Private",
+                  description: "Only you and organization admins",
+                  Icon: LockKeyhole,
+                },
+                {
+                  value: "team" as const,
+                  label: "Teams",
+                  description: "Members of selected teams",
+                  Icon: Users,
+                },
+                {
+                  value: "global" as const,
+                  label: "Global",
+                  description: "Every signed-in organization member",
+                  Icon: Globe2,
+                },
+              ]).map((option) => (
+                <button
+                  key={option.value}
+                  type="button"
+                  aria-pressed={visibility === option.value}
+                  onClick={() => setVisibility(option.value)}
+                  disabled={loading || readOnly}
+                  className={`rounded-lg border p-3 text-left transition-colors ${
+                    visibility === option.value
+                      ? "border-primary bg-primary/5"
+                      : "border-muted hover:border-primary/50"
+                  }`}
+                >
+                  <div className="mb-1 flex items-center gap-2">
+                    <option.Icon className="h-4 w-4" aria-hidden="true" />
+                    <span className="text-sm font-medium">{option.label}</span>
+                  </div>
+                  <div className="text-xs text-muted-foreground">{option.description}</div>
+                </button>
+              ))}
+            </div>
+            {visibility === "team" ? (
+              <div className="space-y-2">
+                <Label htmlFor="mcp-shared-teams">
+                  Share with teams <span className="text-destructive">*</span>
+                </Label>
+                <TeamMultiPicker
+                  id="mcp-shared-teams"
+                  selected={sharedWithTeams}
+                  onChange={setSharedWithTeams}
+                  options={availableTeams
+                    .filter((team): team is SharingTeam & { slug: string } => Boolean(team.slug))
+                    .map((team) => ({
+                      slug: team.slug,
+                      name: team.name,
+                      _id: team._id,
+                    }))}
+                  placeholder="Select teams..."
+                  searchPlaceholder="Search teams..."
+                  disabled={loading || readOnly}
+                  portalled={false}
+                  helperText={`${availableTeams.length} teams available`}
+                />
+                {sharedWithTeams.length === 0 ? (
+                  <p className="text-xs text-destructive">
+                    Select at least one team before saving team access.
+                  </p>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    Selected team members can discover, probe, and invoke this server. Team admins
+                    can manage its configuration.
+                  </p>
+                )}
+              </div>
+            ) : null}
           </div>
 
           <div className="space-y-4 border-t border-border/60 pt-6">

--- a/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
@@ -36,6 +36,12 @@ describe("MCPServerEditor credential sources", () => {
       if (url === "/api/mcp-servers/agentgateway/discover") {
         return response({ targets: [] });
       }
+      if (url === "/api/dynamic-agents/teams") {
+        return response([
+          { _id: "team-platform", slug: "platform", name: "Platform" },
+          { _id: "team-data", slug: "data", name: "Data" },
+        ]);
+      }
       if (url === "/api/mcp-servers/endpoint-probe") {
         return response({
           attempts: [
@@ -368,6 +374,25 @@ describe("MCPServerEditor credential sources", () => {
     expect(screen.queryByLabelText(/provider connection/i)).not.toBeInTheDocument();
     expect(screen.getByLabelText(/^provider$/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/credential header/i)).toHaveValue("X-CAIPE-Provider-Token");
+  });
+
+  it("saves explicit global MCP access from the editor", async () => {
+    const user = userEvent.setup();
+    render(<MCPServerEditor server={null} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    await user.type(screen.getByLabelText(/display name/i), "Shared Search");
+    await user.type(screen.getByLabelText(/upstream url|endpoint url/i), "https://mcp.example.com/mcp");
+    await user.click(screen.getByRole("button", { name: /Global Every signed-in organization member/i }));
+    await user.click(screen.getByRole("button", { name: /create server/i }));
+
+    await waitFor(() =>
+      expect(createBody()).toEqual(
+        expect.objectContaining({
+          visibility: "global",
+          shared_with_teams: [],
+        }),
+      ),
+    );
   });
 
   it("sends an empty credential_sources array when all credentials are removed on edit", async () => {

--- a/ui/src/lib/rbac/__tests__/mcp-openfga-tuples.test.ts
+++ b/ui/src/lib/rbac/__tests__/mcp-openfga-tuples.test.ts
@@ -336,6 +336,59 @@ describe("MCP OpenFGA tuple contract", () => {
         ]),
       );
     });
+
+    it("grants selected teams invoke access and revokes teams removed from sharing", () => {
+      const diff = buildMcpServerRelationshipTupleDiff({
+        serverId: "mcp-shared-search",
+        ownerSubject: "alice-sub",
+        nextSharedTeamSlugs: ["platform"],
+        previousSharedTeamSlugs: ["data"],
+      });
+
+      expect(diff.writes).toEqual(
+        expect.arrayContaining([
+          { user: "team:platform#member", relation: "reader", object: "mcp_server:mcp-shared-search" },
+          { user: "team:platform#member", relation: "user", object: "mcp_server:mcp-shared-search" },
+          { user: "team:platform#member", relation: "invoker", object: "mcp_server:mcp-shared-search" },
+          { user: "team:platform#admin", relation: "manager", object: "mcp_server:mcp-shared-search" },
+        ]),
+      );
+      expect(diff.deletes).toEqual(
+        expect.arrayContaining([
+          { user: "team:data#member", relation: "reader", object: "mcp_server:mcp-shared-search" },
+          { user: "team:data#member", relation: "user", object: "mcp_server:mcp-shared-search" },
+          { user: "team:data#member", relation: "invoker", object: "mcp_server:mcp-shared-search" },
+          { user: "team:data#admin", relation: "manager", object: "mcp_server:mcp-shared-search" },
+        ]),
+      );
+    });
+
+    it("writes and revokes organization-member grants for global visibility", () => {
+      const global = buildMcpServerRelationshipTupleDiff({
+        serverId: "mcp-global-search",
+        ownerSubject: "alice-sub",
+        sharedWithOrg: true,
+      });
+      expect(global.writes).toEqual(
+        expect.arrayContaining([
+          { user: "organization:caipe#member", relation: "reader", object: "mcp_server:mcp-global-search" },
+          { user: "organization:caipe#member", relation: "user", object: "mcp_server:mcp-global-search" },
+          { user: "organization:caipe#member", relation: "invoker", object: "mcp_server:mcp-global-search" },
+        ]),
+      );
+
+      const privateDiff = buildMcpServerRelationshipTupleDiff({
+        serverId: "mcp-global-search",
+        ownerSubject: "alice-sub",
+        sharedWithOrg: false,
+        previousSharedWithOrg: true,
+      });
+      expect(privateDiff.deletes).toEqual([
+        { user: "organization:caipe#member", relation: "reader", object: "mcp_server:mcp-global-search" },
+        { user: "organization:caipe#member", relation: "user", object: "mcp_server:mcp-global-search" },
+        { user: "organization:caipe#member", relation: "invoker", object: "mcp_server:mcp-global-search" },
+      ]);
+    });
   });
 
   describe("delete cleanup object inventory", () => {

--- a/ui/src/lib/rbac/openfga-owned-resources.ts
+++ b/ui/src/lib/rbac/openfga-owned-resources.ts
@@ -50,6 +50,13 @@ interface OwnedResourceInput {
 
 export interface McpServerRelationshipInput extends OwnedResourceInput {
   serverId: string;
+  nextSharedTeamSlugs?: readonly string[] | null;
+  previousSharedTeamSlugs?: readonly string[] | null;
+  previousOwnerTeamSlug?: string | null;
+  /** Organization-wide reader/user/invoker grant for global MCP servers. */
+  sharedWithOrg?: boolean;
+  /** Prior global or legacy organization grant, used to revoke all member access. */
+  previousSharedWithOrg?: boolean;
 }
 
 export interface ConfigDrivenMcpServerRelationshipInput {
@@ -383,18 +390,36 @@ export function buildMcpServerRelationshipTupleDiff(
   if (ownerUser) {
     writes.push({ user: ownerUser, relation: "owner", object });
   }
-  if (input.ownerTeamSlug && isValidOpenFgaId(input.ownerTeamSlug)) {
+  const teamGrants = buildTeamGrantTuples({
+    object,
+    memberRelations: ["reader", "user", "invoker"],
+    ownerTeamSlug: input.ownerTeamSlug,
+    previousOwnerTeamSlug: input.previousOwnerTeamSlug,
+    nextSharedTeamSlugs: input.nextSharedTeamSlugs,
+    previousSharedTeamSlugs: input.previousSharedTeamSlugs,
+  });
+  writes.push(...teamGrants.writes);
+  const deletes = [...teamGrants.deletes];
+
+  if (input.sharedWithOrg === true) {
+    const orgMember = `${organizationObjectId()}#member`;
     writes.push(
-      { user: `team:${input.ownerTeamSlug}#member`, relation: "reader", object },
-      { user: `team:${input.ownerTeamSlug}#member`, relation: "user", object },
-      { user: `team:${input.ownerTeamSlug}#member`, relation: "invoker", object },
-      { user: `team:${input.ownerTeamSlug}#admin`, relation: "manager", object },
+      { user: orgMember, relation: "reader", object },
+      { user: orgMember, relation: "user", object },
+      { user: orgMember, relation: "invoker", object },
+    );
+  } else if (input.previousSharedWithOrg === true) {
+    const orgMember = `${organizationObjectId()}#member`;
+    deletes.push(
+      { user: orgMember, relation: "reader", object },
+      { user: orgMember, relation: "user", object },
+      { user: orgMember, relation: "invoker", object },
     );
   }
   // assisted-by Codex Codex-sonnet-4-6
   // User-created servers should be visible/manageable to organization admins immediately.
   writes.push({ user: `${organizationObjectId()}#admin`, relation: "manager", object });
-  return { writes: uniqueTuples(writes), deletes: [] };
+  return { writes: uniqueTuples(writes), deletes: uniqueTuples(deletes) };
 }
 
 export function buildConfigDrivenMcpServerRelationshipTupleDiff(

--- a/ui/src/lib/rbac/self-check-catalog.ts
+++ b/ui/src/lib/rbac/self-check-catalog.ts
@@ -58,6 +58,7 @@ export const RBAC_SELF_CHECKS: RbacSelfCheckDefinition[] = [
       "mcp_servers.config_driven",
       "mcp_servers.owner_subject",
       "mcp_servers.owner_team_slug",
+      "mcp_servers.sharing",
       "mcp_servers.org_admin_manager",
       "baseline_access",
     ],

--- a/ui/src/lib/rbac/self-check-tests.ts
+++ b/ui/src/lib/rbac/self-check-tests.ts
@@ -86,7 +86,10 @@ interface McpServerDoc extends Document {
   name?: string;
   owner_subject?: string;
   owner_team_slug?: string | null;
+  shared_with_teams?: string[];
+  visibility?: string;
   config_driven?: boolean;
+  source?: string;
 }
 
 interface LlmModelDoc extends Document {
@@ -821,7 +824,12 @@ function firstMcpForMember(
   for (const server of inventory.mcpServers) {
     const serverId = normalizeObjectId(server);
     if (!isValidOpenFgaId(serverId)) continue;
-    if (server.config_driven !== false || (server.owner_team_slug && teamSet.has(server.owner_team_slug))) {
+    const teamAccess = [server.owner_team_slug, ...(server.shared_with_teams ?? [])]
+      .some((teamSlug) => Boolean(teamSlug && teamSet.has(teamSlug)));
+    const legacyDiscovery =
+      server.visibility === undefined &&
+      (server.config_driven !== false || server.source === "agentgateway");
+    if (server.visibility === "global" || legacyDiscovery || teamAccess) {
       return resource("mcp_server", serverId, server.name, "mcp_servers");
     }
   }

--- a/ui/src/lib/rbac/self-check.ts
+++ b/ui/src/lib/rbac/self-check.ts
@@ -51,6 +51,7 @@ type TupleSource =
   | "mcp_servers.config_driven"
   | "mcp_servers.owner_subject"
   | "mcp_servers.owner_team_slug"
+  | "mcp_servers.sharing"
   | "mcp_servers.org_admin_manager"
   | "llm_models.config_driven"
   | "llm_models.owner_subject"
@@ -112,6 +113,8 @@ interface McpServerDoc extends Document {
   name?: string;
   owner_subject?: string;
   owner_team_slug?: string | null;
+  shared_with_teams?: string[];
+  visibility?: string;
   config_driven?: boolean;
   source?: string;
 }
@@ -733,7 +736,14 @@ function buildExpectedTuplesAndStaleReferences(
     if (!isValidOpenFgaId(serverId)) continue;
     const object = `mcp_server:${serverId}`;
     const resource = { type: "mcp_server", id: serverId };
-    if (server.config_driven !== false) {
+    const hasExplicitVisibility =
+      server.visibility === "private" ||
+      server.visibility === "team" ||
+      server.visibility === "global";
+    const usesLegacyDiscoveryPolicy =
+      !hasExplicitVisibility &&
+      (server.config_driven !== false || server.source === "agentgateway");
+    if (usesLegacyDiscoveryPolicy) {
       tuples.push(expected("mcp_servers.config_driven", `${orgObject}#member`, "reader", object, resource));
       tuples.push(expected("mcp_servers.config_driven", `${orgObject}#member`, "user", object, resource));
       tuples.push(expected("mcp_servers.config_driven", `${orgObject}#admin`, "manager", object, resource));
@@ -741,21 +751,31 @@ function buildExpectedTuplesAndStaleReferences(
       if (isValidOpenFgaId(server.owner_subject)) {
         tuples.push(expected("mcp_servers.owner_subject", `user:${server.owner_subject}`, "owner", object, resource));
       }
-      if (isValidOpenFgaId(server.owner_team_slug)) {
-        if (resourceIndex.teamSlugs.has(server.owner_team_slug)) {
-          tuples.push(expected("mcp_servers.owner_team_slug", `team:${server.owner_team_slug}#member`, "reader", object, resource));
-          tuples.push(expected("mcp_servers.owner_team_slug", `team:${server.owner_team_slug}#member`, "user", object, resource));
-          tuples.push(expected("mcp_servers.owner_team_slug", `team:${server.owner_team_slug}#member`, "invoker", object, resource));
-          tuples.push(expected("mcp_servers.owner_team_slug", `team:${server.owner_team_slug}#admin`, "manager", object, resource));
+      const sharingTeamSlugs =
+        server.visibility === "team" || (!hasExplicitVisibility && server.owner_team_slug)
+        ? [server.owner_team_slug, ...(server.shared_with_teams ?? [])]
+        : [];
+      for (const rawTeamSlug of new Set(sharingTeamSlugs)) {
+        if (!isValidOpenFgaId(rawTeamSlug)) continue;
+        if (resourceIndex.teamSlugs.has(rawTeamSlug)) {
+          tuples.push(expected("mcp_servers.sharing", `team:${rawTeamSlug}#member`, "reader", object, resource));
+          tuples.push(expected("mcp_servers.sharing", `team:${rawTeamSlug}#member`, "user", object, resource));
+          tuples.push(expected("mcp_servers.sharing", `team:${rawTeamSlug}#member`, "invoker", object, resource));
+          tuples.push(expected("mcp_servers.sharing", `team:${rawTeamSlug}#admin`, "manager", object, resource));
         } else {
           staleReferences.push(stale(
-            "mcp_servers.owner_team_slug",
-            `MCP server references missing team ${server.owner_team_slug}`,
-            `${serverId} has owner_team_slug=${server.owner_team_slug}, but that team is not active.`,
-            "Move the MCP server to an active owner team or restore the missing team.",
-            { type: "team", id: server.owner_team_slug },
+            "mcp_servers.sharing",
+            `MCP server references missing team ${rawTeamSlug}`,
+            `${serverId} is shared with ${rawTeamSlug}, but that team is not active.`,
+            "Remove the stale MCP server share or restore the missing team.",
+            { type: "team", id: rawTeamSlug },
           ));
         }
+      }
+      if (server.visibility === "global") {
+        tuples.push(expected("mcp_servers.sharing", `${orgObject}#member`, "reader", object, resource));
+        tuples.push(expected("mcp_servers.sharing", `${orgObject}#member`, "user", object, resource));
+        tuples.push(expected("mcp_servers.sharing", `${orgObject}#member`, "invoker", object, resource));
       }
       tuples.push(expected("mcp_servers.org_admin_manager", `${orgObject}#admin`, "manager", object, resource));
     }

--- a/ui/src/types/dynamic-agent.ts
+++ b/ui/src/types/dynamic-agent.ts
@@ -38,6 +38,9 @@ export type LegacyVisibilityType = VisibilityType | 'private';
 // MCP Server Types
 // =============================================================================
 
+/** Visibility policy for an MCP server. */
+export type MCPServerVisibilityType = 'private' | 'team' | 'global';
+
 export interface MCPServerConfig {
   _id: string;
   name: string;
@@ -57,6 +60,8 @@ export interface MCPServerConfig {
   owner_id?: string;
   owner_subject?: string;
   owner_team_slug?: string;
+  visibility?: MCPServerVisibilityType;
+  shared_with_teams?: string[];
   created_at: string;
   updated_at: string;
 }
@@ -111,6 +116,8 @@ export interface MCPServerConfigCreate {
   credential_sources?: MCPCredentialSource[];
   enabled?: boolean;
   owner_team_slug?: string;
+  visibility?: MCPServerVisibilityType;
+  shared_with_teams?: string[];
 }
 
 export interface MCPServerConfigUpdate {
@@ -124,6 +131,8 @@ export interface MCPServerConfigUpdate {
   env?: Record<string, string>;
   credential_sources?: MCPCredentialSource[];
   enabled?: boolean;
+  visibility?: MCPServerVisibilityType;
+  shared_with_teams?: string[];
 }
 
 export interface MCPToolInfo {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.68.dev6"
+version = "0.5.68.dev7"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Adds first-class access controls to the MCP server editor:

- Private: only the owner and organization admins can discover or invoke the server.
- Teams: selected team members can discover and invoke; team admins can manage.
- Global: every authenticated organization member can discover and invoke.

The BFF persists `visibility` and `shared_with_teams`, validates team slugs, and reconciles OpenFGA grants and revocations on create/update. Existing unclassified servers retain their legacy policy until an owner explicitly selects a scope. AgentGateway sync preserves an explicit policy so a later repair does not remove global or team access. RBAC self-check projections are updated for the new tuples.

Validation:

- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- 102 focused Jest tests across MCP API, editor, AgentGateway sync, OpenFGA reconciliation, and RBAC self-checks

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; no chart changes.

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass