### PR TITLE
refactor(ci): use native architecture prebuilds

### DIFF
--- a/.github/actions/cleanup-prebuild-images/action.yml
+++ b/.github/actions/cleanup-prebuild-images/action.yml
@@ -1,0 +1,215 @@
+name: Clean up prebuild images
+description: Delete branch-tagged prebuild manifests and their untagged architecture manifests.
+
+inputs:
+  owner:
+    description: GitHub organization that owns the container package.
+    required: true
+  package_name:
+    description: Container package path beneath the organization.
+    required: true
+  head_ref:
+    description: Closed prebuild branch ref.
+    required: true
+  registry_username:
+    description: GitHub Container Registry username.
+    required: true
+  registry_token:
+    description: Token with package read and delete access.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.registry_username }}
+        password: ${{ inputs.registry_token }}
+
+    - name: Delete branch image versions
+      uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+      env:
+        OWNER: ${{ inputs.owner }}
+        PACKAGE_NAME: ${{ inputs.package_name }}
+        HEAD_REF: ${{ inputs.head_ref }}
+      with:
+        github-token: ${{ inputs.registry_token }}
+        script: |
+          const owner = process.env.OWNER;
+          const packageName = process.env.PACKAGE_NAME;
+          const rawBranch = process.env.HEAD_REF || '';
+          const branchNoPrefix = rawBranch.startsWith('prebuild/')
+            ? rawBranch.substring('prebuild/'.length)
+            : rawBranch;
+          const branchSanitized = branchNoPrefix.replace(/\//g, '-');
+          const prefix = `${branchSanitized}-`;
+          const packageType = 'container';
+          const isBranchTag = tag =>
+            tag.startsWith(prefix) && /^\d+$/.test(tag.substring(prefix.length));
+
+          const inspectChildren = async (tag) => {
+            const imageRef = `ghcr.io/${owner}/${packageName}:${tag}`;
+            let lastError = '';
+            for (let attempt = 1; attempt <= 3; attempt += 1) {
+              const result = await exec.getExecOutput(
+                'docker',
+                ['buildx', 'imagetools', 'inspect', '--raw', imageRef],
+                {ignoreReturnCode: true, silent: true},
+              );
+              if (result.exitCode === 0) {
+                const manifest = JSON.parse(result.stdout);
+                return new Set((manifest.manifests || []).map(item => item.digest));
+              }
+              lastError = result.stderr || result.stdout || `exit ${result.exitCode}`;
+              if (attempt < 3) {
+                await new Promise(resolve => setTimeout(resolve, attempt * 2000));
+              }
+            }
+            throw new Error(`Could not inspect ${imageRef}: ${lastError}`);
+          };
+
+          const inspectBranchLabel = async (digest) => {
+            const imageRef = `ghcr.io/${owner}/${packageName}@${digest}`;
+            const result = await exec.getExecOutput(
+              'docker',
+              ['buildx', 'imagetools', 'inspect', '--format', '{{json .Image}}', imageRef],
+              {ignoreReturnCode: true, silent: true},
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(
+                `Could not inspect image config for ${imageRef}: ` +
+                (result.stderr || result.stdout || `exit ${result.exitCode}`)
+              );
+            }
+            const image = JSON.parse(result.stdout);
+            const config = image?.config || image?.Config || {};
+            const labels = config.Labels || config.labels || {};
+            return labels['io.cnoe.prebuild.branch'] || '';
+          };
+
+          const inspectOrphan = async (digest) => {
+            let branch = await inspectBranchLabel(digest);
+            if (branch) return {branch, children: new Set()};
+
+            // An untagged multi-architecture index has no image config of its
+            // own. Use one child config to recover the prebuild branch label.
+            const imageRef = `ghcr.io/${owner}/${packageName}@${digest}`;
+            const result = await exec.getExecOutput(
+              'docker',
+              ['buildx', 'imagetools', 'inspect', '--raw', imageRef],
+              {ignoreReturnCode: true, silent: true},
+            );
+            if (result.exitCode !== 0) {
+              throw new Error(
+                `Could not inspect manifest for ${imageRef}: ` +
+                (result.stderr || result.stdout || `exit ${result.exitCode}`)
+              );
+            }
+            const manifest = JSON.parse(result.stdout);
+            const children = new Set((manifest.manifests || []).map(item => item.digest));
+            if (children.size > 0) {
+              branch = await inspectBranchLabel(children.values().next().value);
+            }
+            return {branch, children};
+          };
+
+          try {
+            const versions = await github.paginate(
+              github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg,
+              {
+                org: owner,
+                package_type: packageType,
+                package_name: packageName,
+                per_page: 100,
+              },
+            );
+            const tagsFor = version => version.metadata?.container?.tags || [];
+            const targetParents = versions.filter(version =>
+              tagsFor(version).some(isBranchTag)
+            );
+            if (targetParents.length === 0) {
+              core.info(
+                `No tagged versions found for ${packageName} with tag prefix ${prefix}; ` +
+                'checking for architecture digests from failed or canceled builds.'
+              );
+            }
+
+            const mixedParents = targetParents.filter(version =>
+              tagsFor(version).some(tag => !isBranchTag(tag))
+            );
+            if (mixedParents.length > 0) {
+              throw new Error(
+                `Refusing to delete ${mixedParents.length} ${packageName} version(s) ` +
+                'that also carry a non-prebuild-branch tag.'
+              );
+            }
+
+            const targetChildren = new Set();
+            for (const version of targetParents) {
+              const tag = tagsFor(version).find(isBranchTag);
+              for (const digest of await inspectChildren(tag)) {
+                targetChildren.add(digest);
+              }
+            }
+
+            // Do not remove a child manifest that is still referenced by any
+            // retained tag in the package, even if two builds deduplicated it.
+            const retainedChildren = new Set();
+            const retainedParents = versions.filter(version =>
+              !targetParents.some(target => target.id === version.id) && tagsFor(version).length > 0
+            );
+            for (const version of retainedParents) {
+              for (const digest of await inspectChildren(tagsFor(version)[0])) {
+                retainedChildren.add(digest);
+              }
+            }
+
+            // A failed or canceled architecture build may never acquire a
+            // final branch tag. Its explicit branch label lets cleanup find
+            // and remove that otherwise orphaned package version.
+            const orphanDigests = new Set();
+            const untaggedVersions = versions.filter(version => tagsFor(version).length === 0);
+            for (const version of untaggedVersions) {
+              const orphan = await inspectOrphan(version.name);
+              if (orphan.branch !== branchSanitized) continue;
+              orphanDigests.add(version.name);
+              for (const digest of orphan.children) orphanDigests.add(digest);
+            }
+
+            const deletableDigests = new Set([...targetChildren, ...orphanDigests]);
+            const childVersions = versions.filter(version =>
+              deletableDigests.has(version.name) && !retainedChildren.has(version.name)
+            );
+            const ordered = [...targetParents, ...childVersions];
+            const seen = new Set();
+            for (const version of ordered) {
+              if (seen.has(version.id)) continue;
+              seen.add(version.id);
+              try {
+                await github.rest.packages.deletePackageVersionForOrg({
+                  org: owner,
+                  package_type: packageType,
+                  package_name: packageName,
+                  package_version_id: version.id,
+                });
+              } catch (error) {
+                // Deleting a manifest list can also remove an untagged child.
+                if (error.status !== 404) throw error;
+              }
+            }
+            core.info(
+              `Deleted ${targetParents.length} tagged and ${childVersions.length} ` +
+              `untagged version(s) for ${packageName} with tag prefix ${prefix}`
+            );
+          } catch (error) {
+            if (error.status === 404) {
+              core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
+            } else {
+              throw error;
+            }
+          }

--- a/.github/actions/publish-prebuild-manifest/action.yml
+++ b/.github/actions/publish-prebuild-manifest/action.yml
@@ -1,0 +1,81 @@
+name: Publish prebuild manifest
+description: Merge two native architecture digests into a tagged prebuild image.
+
+inputs:
+  artifact_pattern:
+    description: Artifact pattern containing the AMD64 and ARM64 digest files.
+    required: true
+  image_repository:
+    description: Fully qualified image repository without a tag.
+    required: true
+  image_ref:
+    description: Fully qualified tagged image reference to publish.
+    required: true
+  registry_username:
+    description: Container registry username.
+    required: true
+  registry_token:
+    description: Container registry token.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download architecture digests
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+      with:
+        pattern: ${{ inputs.artifact_pattern }}
+        path: ${{ runner.temp }}/prebuild-digests
+        merge-multiple: true
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.registry_username }}
+        password: ${{ inputs.registry_token }}
+
+    - name: Create and inspect multi-architecture image
+      shell: bash
+      working-directory: ${{ runner.temp }}/prebuild-digests
+      env:
+        IMAGE_REPOSITORY: ${{ inputs.image_repository }}
+        IMAGE_REF: ${{ inputs.image_ref }}
+      run: |
+        set -euo pipefail
+        shopt -s nullglob
+        digests=(*)
+        if [[ "${#digests[@]}" -ne 2 ]]; then
+          echo "Expected two architecture digests, found ${#digests[@]}" >&2
+          exit 1
+        fi
+
+        sources=()
+        for digest in "${digests[@]}"; do
+          if [[ ! "$digest" =~ ^[0-9a-f]{64}$ ]]; then
+            echo "Invalid digest artifact filename: ${digest}" >&2
+            exit 1
+          fi
+          sources+=("${IMAGE_REPOSITORY}@sha256:${digest}")
+        done
+
+        create_log=$(mktemp)
+        trap 'rm -f "$create_log"' EXIT
+        if ! docker buildx imagetools create --tag "$IMAGE_REF" "${sources[@]}" \
+          >"$create_log" 2>&1; then
+          cat "$create_log" >&2
+          exit 1
+        fi
+        manifest=$(docker buildx imagetools inspect --raw "$IMAGE_REF")
+        if ! jq -e \
+          '[.manifests[].platform | select(.os == "linux") | .architecture] | sort == ["amd64", "arm64"]' \
+          <<< "$manifest" >/dev/null; then
+          echo "Published manifest does not contain exactly linux/amd64 and linux/arm64" >&2
+          jq '.manifests[].platform' <<< "$manifest" >&2
+          exit 1
+        fi
+        echo "Validated platforms: linux/amd64, linux/arm64"
+        echo "Published image: ${IMAGE_REF}"

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -129,7 +129,9 @@ jobs:
   build-and-push:
     runs-on: ${{ matrix.runner }}
     needs: determine-changes
-    if: needs.determine-changes.outputs.should_build == 'true'
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'prebuild/'))
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -137,7 +137,9 @@ jobs:
   build-and-push:
     runs-on: ${{ matrix.runner }}
     needs: determine-changes
-    if: needs.determine-changes.outputs.should_build == 'true'
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'prebuild/'))
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-openfga-authz-bridge.yml
+++ b/.github/workflows/ci-openfga-authz-bridge.yml
@@ -66,7 +66,9 @@ jobs:
   build-and-push:
     runs-on: ${{ matrix.runner }}
     needs: determine-changes
-    if: needs.determine-changes.outputs.should_build == 'true'
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'prebuild/'))
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/ci-rag.yml
+++ b/.github/workflows/ci-rag.yml
@@ -112,6 +112,7 @@ jobs:
         env:
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
           EVENT_NAME: ${{ github.event_name }}
+          HEAD_REF: ${{ github.head_ref }}
           FORCE_BUILD: ${{ inputs.force_build }}
           ALL_COMPONENTS: ${{ needs.load-config.outputs.rag_components }}
           SHARED_CHANGED: ${{ steps.filter.outputs.shared }}
@@ -121,8 +122,15 @@ jobs:
         with:
           script: |
             const allComponents = JSON.parse(process.env.ALL_COMPONENTS);
-            // Extra image variants per component (must mirror the build matrix below).
-            const variantMap = {
+            // Prebuild publishes the default variants on prebuild/* PRs, so CI
+            // validates only variants that do not have a prebuild image.
+            const isPrebuildPr = process.env.EVENT_NAME === 'pull_request' &&
+              (process.env.HEAD_REF || '').startsWith('prebuild/');
+            const variantMap = isPrebuildPr ? {
+              'agent-ontology': [],
+              'server': ['huggingface'],
+              'ingestors': ['slim'],
+            } : {
               'agent-ontology': ['default'],
               'server': ['default', 'huggingface'],
               'ingestors': ['default', 'slim'],
@@ -192,10 +200,12 @@ jobs:
               }
             }
 
-            core.setOutput('build_matrix', JSON.stringify({ include: expandPlatforms(buildComponents) }));
-            core.setOutput('build_groups', JSON.stringify({ include: expand(buildComponents) }));
+            const buildMatrix = expandPlatforms(buildComponents);
+            const buildGroups = expand(buildComponents);
+            core.setOutput('build_matrix', JSON.stringify({ include: buildMatrix }));
+            core.setOutput('build_groups', JSON.stringify({ include: buildGroups }));
             core.setOutput('retag_matrix', JSON.stringify({ include: expand(retagComponents) }));
-            core.setOutput('should_build', String(buildComponents.length > 0));
+            core.setOutput('should_build', String(buildGroups.length > 0));
             core.setOutput('should_retag', String(retagComponents.length > 0));
             core.setOutput('image_prefix', imagePrefix);
 

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -171,7 +171,9 @@ jobs:
   build-and-push:
     runs-on: ${{ matrix.runner }}
     needs: determine-changes
-    if: needs.determine-changes.outputs.should_build == 'true'
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      (github.event_name != 'pull_request' || !startsWith(github.head_ref, 'prebuild/'))
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/prebuild-audit-service.yml
+++ b/.github/workflows/prebuild-audit-service.yml
@@ -2,8 +2,11 @@ name: "[Prebuild] Audit Service Docker Build and Push"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
+      - '.github/workflows/prebuild-audit-service.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
       - 'ai_platform_engineering/audit_service/**'
       - 'build/Dockerfile.audit-service'
   workflow_call:
@@ -42,8 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
       (
@@ -54,6 +57,16 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Harden runner
@@ -66,16 +79,6 @@ jobs:
         with:
           ref: ${{ inputs.head_sha || github.ref }}
           fetch-depth: 0
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
-
-      - name: Log in to GitHub Container Registry
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
 
       - name: Compute prebuild tag
         id: compute_tag
@@ -101,6 +104,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Upload building prebuild status
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -115,6 +119,16 @@ jobs:
           status: building
           artifact_suffix: start
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
@@ -123,23 +137,90 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push Audit Service Docker image
+      - name: Build and push Audit Service image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: build/Dockerfile.audit-service
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-audit-service-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-audit-service-${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-caipe-audit-service--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: build
+    if: |
+      always() &&
+      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          PREBUILD_TAG="${BRANCH_SANITIZED}-${COMMIT_COUNT}"
+          echo "prebuild_tag=${PREBUILD_TAG}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-caipe-audit-service--*
+          image_repository: ghcr.io/${{ env.IMAGE_NAME }}
+          image_ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -154,53 +235,5 @@ jobs:
           repository: ghcr.io/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/caipe-audit-service
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }

--- a/.github/workflows/prebuild-caipe-ui.yml
+++ b/.github/workflows/prebuild-caipe-ui.yml
@@ -3,8 +3,11 @@ description: "Build and push CAIPE UI Docker image for prebuild branches"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
+      - '.github/workflows/prebuild-caipe-ui.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
       - 'ui/**'
       - 'build/Dockerfile.caipe-ui'
   workflow_call:
@@ -34,26 +37,74 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/prebuild/caipe-ui
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
+  determine-changes:
     runs-on: ubuntu-latest
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
-      (
-        startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
-        github.event.action != 'closed'
-      )
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    outputs:
+      should_build: ${{ steps.eligibility.outputs.should_build }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Check build eligibility
+        id: eligibility
+        shell: bash
+        env:
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE="$BASE_SHA"
+          else
+            BASE="origin/${BASE_REF}"
+          fi
+
+          if git diff --name-only "$BASE..HEAD" -- \
+              .github/workflows/prebuild-caipe-ui.yml \
+              .github/actions/prebuild-status \
+              .github/actions/publish-prebuild-manifest \
+              ui \
+              build/Dockerfile.caipe-ui | grep -q .; then
+            echo "should_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    runs-on: ${{ matrix.runner }}
+    needs: determine-changes
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
     permissions:
       contents: write
       packages: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: 🔒 Harden runner
@@ -89,33 +140,9 @@ jobs:
           ref: ${{ inputs.head_sha || github.ref }}
           fetch-depth: 0
 
-      - name: Check build eligibility
-        id: eligibility
-        shell: bash
-        env:
-          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
-          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
-        run: |
-          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
-          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
-            BASE="$BASE_SHA"
-          else
-            BASE="origin/${BASE_REF}"
-          fi
-
-          if git diff --name-only "$BASE..HEAD" -- \
-              ui \
-              build/Dockerfile.caipe-ui | grep -q .; then
-            echo "should_build=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_build=false" >> "$GITHUB_OUTPUT"
-          fi
-
       - name: Set up Docker Buildx
-        if: steps.eligibility.outputs.should_build == 'true'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to GitHub Container Registry
-        if: steps.eligibility.outputs.should_build == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
@@ -123,7 +150,6 @@ jobs:
           password: ${{ github.token }}
 
       - name: Compute prebuild tag
-        if: steps.eligibility.outputs.should_build == 'true'
         id: compute_tag
         shell: bash
         env:
@@ -146,7 +172,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Upload building prebuild status
-        if: steps.eligibility.outputs.should_build == 'true'
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -162,7 +188,6 @@ jobs:
           artifact_suffix: start
 
       - name: Extract metadata for Docker
-        if: steps.eligibility.outputs.should_build == 'true'
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
@@ -170,23 +195,20 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        if: steps.eligibility.outputs.should_build == 'true'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push CAIPE UI Docker image
-        if: steps.eligibility.outputs.should_build == 'true'
+      - name: Build and push CAIPE UI image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./build/Dockerfile.caipe-ui
           target: runner
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-caipe-ui-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-caipe-ui-${{ matrix.arch }}
           build-args: |
             CAIPE_URL=http://caipe-supervisor:8000
             BUILDKIT_INLINE_CACHE=1
@@ -195,6 +217,75 @@ jobs:
             BUILD_DATE=${{ github.event.head_commit.timestamp }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-caipe-ui--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build]
+    if: |
+      always() &&
+      needs.determine-changes.result == 'success' &&
+      needs.determine-changes.outputs.should_build == 'true' &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-caipe-ui--*
+          image_repository: ghcr.io/${{ env.IMAGE_NAME }}
+          image_ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -209,53 +300,5 @@ jobs:
           repository: ghcr.io/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/caipe-ui
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }

--- a/.github/workflows/prebuild-dynamic-agents.yml
+++ b/.github/workflows/prebuild-dynamic-agents.yml
@@ -3,8 +3,11 @@ description: "Build and push Dynamic Agents Docker image for prebuild branches"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
+      - '.github/workflows/prebuild-dynamic-agents.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
       - 'ai_platform_engineering/dynamic_agents/**'
   workflow_call:
     inputs:
@@ -34,34 +37,22 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/prebuild/caipe-dynamic-agents
 
 permissions:
-  contents: write
-  packages: write
+  contents: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
+  determine-changes:
     runs-on: ubuntu-latest
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
-      (
-        startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
-        github.event.action != 'closed'
-      )
-    permissions:
-      contents: write
-      packages: write
-      pull-requests: write
-
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    outputs:
+      should_build: ${{ steps.eligibility.outputs.should_build }}
     steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
-        with:
-          egress-policy: audit
-
-
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
         with:
@@ -83,17 +74,53 @@ jobs:
           fi
 
           if git diff --name-only "$BASE..HEAD" -- \
+              .github/workflows/prebuild-dynamic-agents.yml \
+              .github/actions/prebuild-status \
+              .github/actions/publish-prebuild-manifest \
               ai_platform_engineering/dynamic_agents | grep -q .; then
             echo "should_build=true" >> "$GITHUB_OUTPUT"
           else
             echo "should_build=false" >> "$GITHUB_OUTPUT"
           fi
 
+  build:
+    runs-on: ${{ matrix.runner }}
+    needs: determine-changes
+    if: |
+      needs.determine-changes.outputs.should_build == 'true' &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
+
+    steps:
+      - name: 🔒 Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40  # v2.20.1
+        with:
+          egress-policy: audit
+
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
       - name: Set up Docker Buildx
-        if: steps.eligibility.outputs.should_build == 'true'
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
       - name: Log in to GitHub Container Registry
-        if: steps.eligibility.outputs.should_build == 'true'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ghcr.io
@@ -101,7 +128,6 @@ jobs:
           password: ${{ github.token }}
 
       - name: Compute prebuild tag
-        if: steps.eligibility.outputs.should_build == 'true'
         id: compute_tag
         shell: bash
         env:
@@ -124,7 +150,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Upload building prebuild status
-        if: steps.eligibility.outputs.should_build == 'true'
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -140,7 +166,6 @@ jobs:
           artifact_suffix: start
 
       - name: Extract metadata for Docker
-        if: steps.eligibility.outputs.should_build == 'true'
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
         with:
@@ -148,24 +173,90 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        if: steps.eligibility.outputs.should_build == 'true'
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push Dynamic Agents Docker image
-        if: steps.eligibility.outputs.should_build == 'true'
+      - name: Build and push Dynamic Agents image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ai_platform_engineering/dynamic_agents
           file: ai_platform_engineering/dynamic_agents/build/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-dynamic-agents-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-dynamic-agents-${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-caipe-dynamic-agents--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: [determine-changes, build]
+    if: |
+      always() &&
+      needs.determine-changes.result == 'success' &&
+      needs.determine-changes.outputs.should_build == 'true' &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-caipe-dynamic-agents--*
+          image_repository: ghcr.io/${{ env.IMAGE_NAME }}
+          image_ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -180,53 +271,5 @@ jobs:
           repository: ghcr.io/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/caipe-dynamic-agents
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }

--- a/.github/workflows/prebuild-image-cleanup.yml
+++ b/.github/workflows/prebuild-image-cleanup.yml
@@ -1,0 +1,86 @@
+name: "[Prebuild] Docker Image Cleanup"
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  load-packages:
+    runs-on: ubuntu-latest
+    if: startsWith(github.event.pull_request.head.ref, 'prebuild/')
+    outputs:
+      packages: ${{ steps.packages.outputs.packages }}
+    steps:
+      - name: Checkout head package configuration
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: head
+          sparse-checkout: .github/agents.json
+          sparse-checkout-cone-mode: false
+
+      - name: Checkout base package configuration
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base
+          sparse-checkout: .github/agents.json
+          sparse-checkout-cone-mode: false
+
+      - name: Load every Docker prebuild package
+        id: packages
+        shell: bash
+        run: |
+          packages=$(jq -sc '
+            (
+              [
+                "prebuild/caipe-audit-service",
+                "prebuild/caipe-ui",
+                "prebuild/caipe-dynamic-agents",
+                "prebuild/openfga-authz-bridge",
+                "prebuild/caipe-rag-agent-ontology",
+                "prebuild/caipe-rag-ingestors",
+                "prebuild/caipe-rag-server",
+                "prebuild/caipe-scheduler",
+                "prebuild/caipe-cron-runner",
+                "prebuild/skill-scanner",
+                "prebuild/caipe-slack-bot",
+                "prebuild/caipe-webex-bot"
+              ] + ([.[].mcp_agents[]] | unique | map("prebuild/mcp-\(.)"))
+              | unique
+            )
+          ' head/.github/agents.json base/.github/agents.json)
+          echo "packages=${packages}" >> "$GITHUB_OUTPUT"
+
+  cleanup-images:
+    runs-on: ubuntu-latest
+    needs: load-packages
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      max-parallel: 10
+      matrix:
+        package: ${{ fromJson(needs.load-packages.outputs.packages) }}
+    steps:
+      - name: Checkout cleanup action
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Delete prebuild images for branch
+        uses: ./.github/actions/cleanup-prebuild-images
+        with:
+          owner: ${{ github.repository_owner }}
+          package_name: ${{ matrix.package }}
+          head_ref: ${{ github.event.pull_request.head.ref }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}

--- a/.github/workflows/prebuild-mcp-servers.yml
+++ b/.github/workflows/prebuild-mcp-servers.yml
@@ -3,7 +3,7 @@ description: "Build and push MCP server Docker images"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
       - 'ai_platform_engineering/mcp/**'
       - '.github/**'
@@ -94,6 +94,10 @@ jobs:
             let filters = 'shared_inputs:\n';
             filters += '  - \'build/agents/Dockerfile.mcp\'\n';
             filters += '  - \'ai_platform_engineering/mcp/common/**\'\n';
+            filters += '  - \'.github/agents.json\'\n';
+            filters += '  - \'.github/workflows/prebuild-mcp-servers.yml\'\n';
+            filters += '  - \'.github/actions/prebuild-status/**\'\n';
+            filters += '  - \'.github/actions/publish-prebuild-manifest/**\'\n';
             agents.forEach(agent => {
               filters += `${agent}:\n`;
               filters += `  - 'ai_platform_engineering/mcp/${agent}/**'\n`;
@@ -128,8 +132,8 @@ jobs:
             core.setOutput('agents', JSON.stringify(selected));
             core.setOutput('should_build', String(selected.length > 0));
 
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     needs: determine-agents
     if: |
       needs.determine-agents.outputs.should_build == 'true' &&
@@ -143,6 +147,14 @@ jobs:
     strategy:
       matrix:
         agent: ${{ fromJson(needs.determine-agents.outputs.agents) }}
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
       fail-fast: false
 
     env:
@@ -193,6 +205,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Upload building prebuild status
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -215,9 +228,6 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
       - name: Resolve per-agent MCP build args
         id: mcp_build_args
         env:
@@ -231,21 +241,100 @@ jobs:
             echo 'EOF'
           } >> "$GITHUB_OUTPUT"
 
-      - name: Build and Push MCP Docker image
+      - name: Build and push MCP image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: build/agents/Dockerfile.mcp
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
           build-args: |
             AGENT_NAME=${{ matrix.agent }}
             ${{ steps.mcp_build_args.outputs.extra }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-${{ matrix.agent }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-${{ matrix.agent }}-${{ matrix.arch }}
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.agent }}--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: [determine-agents, build]
+    if: |
+      always() &&
+      needs.determine-agents.result == 'success' &&
+      needs.determine-agents.outputs.should_build == 'true' &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    strategy:
+      matrix:
+        agent: ${{ fromJson(needs.determine-agents.outputs.agents) }}
+      fail-fast: false
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/prebuild/mcp-${{ matrix.agent }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-${{ matrix.agent }}--*
+          image_repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          image_ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -260,76 +349,5 @@ jobs:
           repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
-
-  load-config-cleanup:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    outputs:
-      all_agents: ${{ steps.read-config.outputs.all_agents }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          sparse-checkout: .github/agents.json
-          sparse-checkout-cone-mode: false
-
-      - name: Read agents config
-        id: read-config
-        run: |
-          ALL_AGENTS=$(jq -c '.mcp_agents' .github/agents.json)
-          echo "all_agents=$ALL_AGENTS" >> $GITHUB_OUTPUT
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    needs: load-config-cleanup
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        agent: ${{ fromJson(needs.load-config-cleanup.outputs.all_agents) }}
-      fail-fast: false
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/mcp-${{ matrix.agent }}
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }

--- a/.github/workflows/prebuild-openfga-authz-bridge.yml
+++ b/.github/workflows/prebuild-openfga-authz-bridge.yml
@@ -2,10 +2,12 @@ name: "[Prebuild] OpenFGA Authz Bridge Docker Build and Push"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
       - 'deploy/openfga/bridge/**'
       - '.github/workflows/prebuild-openfga-authz-bridge.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
   workflow_call:
     inputs:
       pr_number:
@@ -42,8 +44,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
       (
@@ -54,6 +56,16 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Harden runner
@@ -101,6 +113,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Upload building prebuild status
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -123,23 +136,89 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push OpenFGA Authz Bridge Docker image
+      - name: Build and push OpenFGA Authz Bridge image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: deploy/openfga/bridge
           file: deploy/openfga/bridge/Dockerfile
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-openfga-authz-bridge-${{ matrix.arch }}
+          cache-to: type=gha,mode=min,scope=prebuild-openfga-authz-bridge-${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-openfga-authz-bridge--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: build
+    if: |
+      always() &&
+      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-openfga-authz-bridge--*
+          image_repository: ghcr.io/${{ env.IMAGE_NAME }}
+          image_ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -154,53 +233,5 @@ jobs:
           repository: ghcr.io/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/openfga-authz-bridge
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }

--- a/.github/workflows/prebuild-rag.yml
+++ b/.github/workflows/prebuild-rag.yml
@@ -3,8 +3,11 @@ description: "Build and push CAIPE RAG Docker image"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
+      - '.github/workflows/prebuild-rag.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
       - 'ai_platform_engineering/knowledge_bases/rag/**'
   workflow_dispatch:
   workflow_call:
@@ -103,8 +106,8 @@ jobs:
             core.setOutput('components', JSON.stringify(selected));
             core.setOutput('should_build', String(selected.length > 0));
 
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     needs: determine-components
     if: |
       needs.determine-components.outputs.should_build == 'true' &&
@@ -118,6 +121,14 @@ jobs:
     strategy:
       matrix:
         component: ${{ fromJson(needs.determine-components.outputs.components) }}
+        platform: [linux/amd64, linux/arm64]
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
       fail-fast: false
 
     env:
@@ -200,6 +211,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Upload building prebuild status
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -222,8 +234,6 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
       - name: Clean up before build
         run: |
           echo "Cleaning up Docker system before build..."
@@ -231,18 +241,97 @@ jobs:
           echo "Current disk usage:"
           df -h
 
-      - name: Build and Push Docker image
+      - name: Build and push image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ${{ env.BUILD_CTX }}
           file: ${{ env.DOCKERFILE }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-${{ matrix.component }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-${{ matrix.component }}-${{ matrix.arch }}
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.component }}--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: [determine-components, build]
+    if: |
+      always() &&
+      needs.determine-components.result == 'success' &&
+      needs.determine-components.outputs.should_build == 'true' &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    strategy:
+      matrix:
+        component: ${{ fromJson(needs.determine-components.outputs.components) }}
+      fail-fast: false
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository_owner }}/prebuild/caipe-rag-${{ matrix.component }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-${{ matrix.component }}--*
+          image_repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          image_ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -257,57 +346,5 @@ jobs:
           repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      matrix:
-        component: ['ingestors', 'agent-ontology', 'server']
-      fail-fast: false
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/caipe-rag-${{ matrix.component }}
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }

--- a/.github/workflows/prebuild-scheduler.yml
+++ b/.github/workflows/prebuild-scheduler.yml
@@ -3,8 +3,11 @@ description: "Build and push caipe-scheduler and caipe-cron-runner images for pr
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
+      - '.github/workflows/prebuild-scheduler.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
       - 'ai_platform_engineering/scheduler/**'
       - 'ai_platform_engineering/cron-runner/**'
       - 'build/Dockerfile.scheduler'
@@ -42,8 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
       (
@@ -62,10 +65,30 @@ jobs:
             image: caipe-scheduler
             context: .
             dockerfile: build/Dockerfile.scheduler
+            platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - name: scheduler
+            image: caipe-scheduler
+            context: .
+            dockerfile: build/Dockerfile.scheduler
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
           - name: cron-runner
             image: caipe-cron-runner
             context: .
             dockerfile: build/Dockerfile.cron-runner
+            platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - name: cron-runner
+            image: caipe-cron-runner
+            context: .
+            dockerfile: build/Dockerfile.cron-runner
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
     env:
       IMAGE_NAME: ${{ github.repository_owner }}/prebuild/${{ matrix.image }}
 
@@ -115,6 +138,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Upload building prebuild status
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -137,23 +161,99 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push Docker image
+      - name: Build and push image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha,scope=prebuild-${{ matrix.name }}
-          cache-to: type=gha,mode=max,scope=prebuild-${{ matrix.name }}
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-${{ matrix.name }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-${{ matrix.name }}-${{ matrix.arch }}
           provenance: false
           sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-${{ matrix.name }}--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: build
+    if: |
+      always() &&
+      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: scheduler
+            image: caipe-scheduler
+          - name: cron-runner
+            image: caipe-cron-runner
+    env:
+      IMAGE_NAME: ${{ github.repository_owner }}/prebuild/${{ matrix.image }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-${{ matrix.name }}--*
+          image_repository: ghcr.io/${{ env.IMAGE_NAME }}
+          image_ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -168,59 +268,5 @@ jobs:
           repository: ghcr.io/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: ${{ matrix.name }}-final
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    strategy:
-      fail-fast: false
-      matrix:
-        package:
-          - prebuild/caipe-scheduler
-          - prebuild/caipe-cron-runner
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: ${{ matrix.package }}
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }

--- a/.github/workflows/prebuild-skill-scanner.yml
+++ b/.github/workflows/prebuild-skill-scanner.yml
@@ -10,8 +10,11 @@ description: "Build and push Skill Scanner Docker image for prebuild branches"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
+      - '.github/workflows/prebuild-skill-scanner.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
       # Build only when something the image actually packages changes:
       #   - the Dockerfile itself (base image, pinned scanner version, etc.)
       # Note: there is no first-party scanner source in this repo — the image
@@ -54,8 +57,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
       (
@@ -66,6 +69,16 @@ jobs:
       contents: read
       packages: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: 🔒 Harden runner
@@ -129,6 +142,7 @@ jobs:
           COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
           echo "BRANCH_BARE=${BRANCH_SANITIZED}" >> $GITHUB_ENV
           echo "PREBUILD_TAG=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> $GITHUB_ENV
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
 
       - name: Read pinned upstream scanner version
         id: scanner_version
@@ -146,6 +160,22 @@ jobs:
           echo "SKILL_SCANNER_VERSION=${PINNED}" >> $GITHUB_ENV
           echo "Resolved upstream scanner version: ${PINNED}"
 
+      - name: Upload building prebuild status
+        if: matrix.arch == 'amd64'
+        uses: ./.github/actions/prebuild-status
+        with:
+          pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
+          head_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
+          head_ref: ${{ inputs.head_ref || github.head_ref }}
+          source: skill-scanner
+          type: docker
+          name: skill-scanner
+          repository: ghcr.io/${{ env.IMAGE_NAME }}
+          tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
+          ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          status: building
+          artifact_suffix: start
+
       - name: Extract metadata for Docker
         id: meta
         uses: docker/metadata-action@dc802804100637a589fabce1cb79ff13a1411302 # v6
@@ -154,19 +184,19 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push Skill Scanner Docker image
+      - name: Build and push Skill Scanner image by digest
+        id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ./build/Dockerfile.skill-scanner
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-skill-scanner-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-skill-scanner-${{ matrix.arch }}
           build-args: |
             SKILL_SCANNER_VERSION=${{ env.SKILL_SCANNER_VERSION }}
             BUILDKIT_INLINE_CACHE=1
@@ -176,101 +206,86 @@ jobs:
           provenance: false
           sbom: false
 
-      - name: 💬 Comment on PR
-        if: inputs.pr_number || github.event_name == 'pull_request'
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          PR_NUMBER: ${{ inputs.pr_number || github.event.pull_request.number }}
-          IMAGE_REPO: ghcr.io/${{ env.IMAGE_NAME }}
-          IMAGE_REF: ghcr.io/${{ env.IMAGE_NAME }}:${{ env.PREBUILD_TAG }}
-          PREBUILD_TAG: ${{ env.PREBUILD_TAG }}
-          SCANNER_VERSION: ${{ env.SKILL_SCANNER_VERSION }}
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
-          script: |
-            const body = `## 🐳 Prebuild Skill Scanner Docker Image Published
+          name: digests-skill-scanner--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
 
-            **Repository:** \`${process.env.IMAGE_REPO}\`
-            **Tag:** \`${process.env.PREBUILD_TAG}\`
-            **Upstream scanner:** \`cisco-ai-skill-scanner==${process.env.SCANNER_VERSION}\`
-
-            ### Usage
-            \`\`\`bash
-            docker pull ${process.env.IMAGE_REF}
-            \`\`\`
-
-            ### Test in docker-compose
-            \`\`\`bash
-            # Update docker-compose.dev.yaml
-            skill-scanner:
-              image: ${process.env.IMAGE_REF}
-              # ... rest of config
-            \`\`\`
-
-            ### Test against the Helm chart
-            \`\`\`yaml
-            # values.yaml override
-            global:
-              skillScanner:
-                enabled: true
-            skill-scanner:
-              image:
-                repository: ${process.env.IMAGE_REPO}
-                tag: ${process.env.PREBUILD_TAG}
-            \`\`\`
-
-            > **Note:** This prebuild image will be automatically cleaned up when the PR is closed or merged.`;
-
-            github.rest.issues.createComment({
-              issue_number: Number(process.env.PR_NUMBER || context.issue.number),
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body
-            });
-
-  cleanup-images:
+  build-and-push:
     runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
+    needs: build
+    if: |
+      always() &&
+      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
     permissions:
-      contents: read
+      contents: write
       packages: write
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/skill-scanner
+      pull-requests: write
     steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
         with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-skill-scanner--*
+          image_repository: ghcr.io/${{ env.IMAGE_NAME }}
+          image_ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
+
+      - name: Upload final prebuild status
+        if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
+        uses: ./.github/actions/prebuild-status
+        with:
+          pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
+          head_sha: ${{ inputs.head_sha || github.event.pull_request.head.sha }}
+          head_ref: ${{ inputs.head_ref || github.head_ref }}
+          source: skill-scanner
+          type: docker
+          name: skill-scanner
+          repository: ghcr.io/${{ env.IMAGE_NAME }}
+          tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
+          ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
+          artifact_suffix: final

--- a/.github/workflows/prebuild-slack-bot.yml
+++ b/.github/workflows/prebuild-slack-bot.yml
@@ -3,8 +3,11 @@ description: "Build and push Slack Bot Docker image for prebuild branches"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
+      - '.github/workflows/prebuild-slack-bot.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
       - 'ai_platform_engineering/integrations/slack_bot/**'
   workflow_call:
     inputs:
@@ -42,8 +45,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
       (
@@ -54,6 +57,16 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: 🔒 Harden runner
@@ -100,6 +113,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Upload building prebuild status
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -122,20 +136,89 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-      - name: Build and Push Slack Bot Docker image
+      - name: Build and push Slack Bot image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: build/Dockerfile.slack-bot
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-slack-bot-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-slack-bot-${{ matrix.arch }}
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-caipe-slack-bot--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: build
+    if: |
+      always() &&
+      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-caipe-slack-bot--*
+          image_repository: ghcr.io/${{ env.IMAGE_NAME }}
+          image_ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -150,53 +233,5 @@ jobs:
           repository: ghcr.io/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/caipe-slack-bot
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }

--- a/.github/workflows/prebuild-webex-bot.yml
+++ b/.github/workflows/prebuild-webex-bot.yml
@@ -3,9 +3,11 @@ description: "Build and push Webex Bot Docker image for prebuild branches"
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, closed]
+    types: [opened, synchronize, reopened]
     paths:
       - '.github/workflows/prebuild-webex-bot.yml'
+      - '.github/actions/prebuild-status/**'
+      - '.github/actions/publish-prebuild-manifest/**'
       - 'ai_platform_engineering/integrations/webex_bot/**'
       - 'build/Dockerfile.webex-bot'
   workflow_call:
@@ -44,8 +46,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  build:
+    runs-on: ${{ matrix.runner }}
     if: |
       (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
       (
@@ -56,6 +58,16 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+            arch: amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            arch: arm64
 
     steps:
       - name: Harden runner
@@ -97,10 +109,12 @@ jobs:
           fi
           COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
           PREBUILD_TAG="${BRANCH_SANITIZED}-${COMMIT_COUNT}"
+          echo "BRANCH_BARE=${BRANCH_SANITIZED}" >> "$GITHUB_ENV"
           echo "PREBUILD_TAG=${PREBUILD_TAG}" >> "$GITHUB_ENV"
           echo "prebuild_tag=${PREBUILD_TAG}" >> "$GITHUB_OUTPUT"
 
       - name: Upload building prebuild status
+        if: matrix.arch == 'amd64'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -123,21 +137,89 @@ jobs:
           tags: |
             type=raw,value=${{ env.PREBUILD_TAG }}
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4
-
-      - name: Build and Push Webex Bot Docker image
+      - name: Build and push Webex Bot image by digest
         id: build
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: build/Dockerfile.webex-bot
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          labels: |
+            ${{ steps.meta.outputs.labels }}
+            io.cnoe.prebuild.branch=${{ env.BRANCH_BARE }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=ghcr.io/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          cache-from: type=gha,scope=prebuild-webex-bot-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=prebuild-webex-bot-${{ matrix.arch }}
+          provenance: false
+          sbom: false
+
+      - name: Export digest
+        shell: bash
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: digests-caipe-webex-bot--${{ matrix.arch }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  build-and-push:
+    runs-on: ubuntu-latest
+    needs: build
+    if: |
+      always() &&
+      (github.actor != 'github-actions[bot]' && github.actor != 'caipe-ci-release[bot]') &&
+      startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      github.event.action != 'closed'
+    permissions:
+      contents: write
+      packages: write
+      pull-requests: write
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@b09bb98e06d4d774595224525879c09bc6e98c40 # v2.20.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.head_sha || github.ref }}
+          fetch-depth: 0
+
+      - name: Compute prebuild tag
+        id: compute_tag
+        shell: bash
+        env:
+          HEAD_REF: ${{ inputs.head_ref || github.head_ref }}
+          BASE_REF: ${{ inputs.base_ref || github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ inputs.base_sha || github.event.pull_request.base.sha }}
+        run: |
+          BRANCH_NO_PREFIX="${HEAD_REF#prebuild/}"
+          BRANCH_SANITIZED="${BRANCH_NO_PREFIX//\//-}"
+          git fetch origin "+refs/heads/${BASE_REF}:refs/remotes/origin/${BASE_REF}"
+          if [[ -n "$BASE_SHA" ]] && git cat-file -e "${BASE_SHA}^{commit}" 2>/dev/null; then
+            BASE_COMMIT="$BASE_SHA"
+          else
+            BASE_COMMIT="origin/${BASE_REF}"
+          fi
+          COMMIT_COUNT=$(git rev-list --count "${BASE_COMMIT}..HEAD")
+          echo "prebuild_tag=${BRANCH_SANITIZED}-${COMMIT_COUNT}" >> "$GITHUB_OUTPUT"
+
+      - name: Publish multi-architecture image
+        id: publish
+        uses: ./.github/actions/publish-prebuild-manifest
+        with:
+          artifact_pattern: digests-caipe-webex-bot--*
+          image_repository: ghcr.io/${{ env.IMAGE_NAME }}
+          image_ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
+          registry_username: ${{ github.actor }}
+          registry_token: ${{ github.token }}
 
       - name: Upload final prebuild status
         if: ${{ always() && steps.compute_tag.outputs.prebuild_tag != '' }}
@@ -152,53 +234,5 @@ jobs:
           repository: ghcr.io/${{ env.IMAGE_NAME }}
           tag: ${{ steps.compute_tag.outputs.prebuild_tag }}
           ref: ghcr.io/${{ env.IMAGE_NAME }}:${{ steps.compute_tag.outputs.prebuild_tag }}
-          status: ${{ steps.build.outcome == 'success' && 'published' || 'failed' }}
+          status: ${{ steps.publish.outcome == 'success' && 'published' || 'failed' }}
           artifact_suffix: final
-
-  cleanup-images:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'closed' && startsWith(github.event.pull_request.head.ref, 'prebuild/')
-    permissions:
-      contents: read
-      packages: write
-    env:
-      OWNER: ${{ github.repository_owner }}
-      PACKAGE_NAME: prebuild/caipe-webex-bot
-    steps:
-      - name: Delete prebuild images for branch
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        env:
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-        with:
-          script: |
-            const owner = process.env.OWNER;
-            const rawBranch = process.env.HEAD_REF || '';
-            const branchNoPrefix = rawBranch.startsWith('prebuild/') ? rawBranch.substring('prebuild/'.length) : rawBranch;
-            const sanitized = branchNoPrefix.replace(/\//g, '-');
-            const prefix = `${sanitized}-`;
-            const packageName = process.env.PACKAGE_NAME;
-            const packageType = 'container';
-            try {
-              const versions = await github.paginate(github.rest.packages.getAllPackageVersionsForPackageOwnedByOrg, {
-                org: owner,
-                package_type: packageType,
-                package_name: packageName,
-                per_page: 100,
-              });
-              const toDelete = versions.filter(v => (v.metadata?.container?.tags || []).some(t => t.startsWith(prefix)));
-              for (const v of toDelete) {
-                await github.rest.packages.deletePackageVersionForOrg({
-                  org: owner,
-                  package_type: packageType,
-                  package_name: packageName,
-                  package_version_id: v.id,
-                });
-              }
-              core.info(`Deleted ${toDelete.length} versions for ${packageName} with tag prefix ${prefix}`);
-            } catch (e) {
-              if (e.status === 404) {
-                core.info(`Package ${packageName} not found in org ${owner}, skipping.`);
-              } else {
-                throw e;
-              }
-            }


### PR DESCRIPTION
## Description

- Build Docker prebuild images natively on ubuntu-latest for AMD64 and ubuntu-24.04-arm for ARM64.
- Push each architecture by digest and publish the existing prebuild tag from the final build-and-push manifest job.
- Skip duplicate default Docker variants in CI only for prebuild pull requests while retaining RAG server:huggingface and ingestors:slim.
- Preserve existing image names, tags, changed-component detection, unified Prebuild Artifacts reporting, and Helm behavior.
- Consolidate Docker cleanup into one pull-request close workflow covering every current prebuild package and orphaned architecture digests.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- [x] actionlint passes for every changed workflow
- [x] Existing tag calculations, Docker build inputs, and status artifact identities match origin/main
- [x] Non-prebuild RAG tag, release, dispatch, retag, and pull-request matrices match origin/main
- [x] Cleanup logic covers tagged indexes, architecture children, shared digests, and failed-build orphans in local mock validation
- [x] Live prebuild workflows publish one AMD64 and one ARM64 digest per expected image (52/52 native architecture jobs)
- [x] All 26 published tags contain exactly linux/amd64 and linux/arm64
- [x] Unified PR artifact comment reports all 26 Docker images as Published
- [x] prebuild-deploy --resolve-only resolves a newly recreated published image without deploying
- [x] Close and reopen validation confirms automatic cleanup and recreation (26/26 tags plus representative child digests removed)

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New workflow behavior is covered by validation
- [x] All relevant local tests pass
