### PR TITLE
fix(mcp): probe managed servers through AgentGateway

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.5.68-dev.7"
+version = "0.5.68-dev.8"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/ui/e2e/rbac/mcp-server-permission-gating.spec.ts
+++ b/ui/e2e/rbac/mcp-server-permission-gating.spec.ts
@@ -319,7 +319,7 @@ test.describe("RBAC e2e — MCP server permission gating", () => {
     await expect(page.getByRole("button", { name: /Probe tools for Argocd/i })).toBeVisible();
   });
 
-  test("shows repair AgentGateway only when list capability is granted", async ({ page }) => {
+  test("never exposes global AgentGateway repair from the MCP list", async ({ page }) => {
     await installMcpPermissionMocks(page, {
       servers: [
         {
@@ -335,7 +335,7 @@ test.describe("RBAC e2e — MCP server permission gating", () => {
     });
 
     await page.goto("/dynamic-agents?tab=mcp-servers", { waitUntil: "domcontentloaded" });
-    await expect(page.getByRole("button", { name: /Repair AgentGateway/i })).toBeVisible();
+    await expect(page.getByRole("button", { name: /Repair AgentGateway/i })).toHaveCount(0);
     await expect(page.getByRole("button", { name: /Delete Managed MCP/i })).toBeVisible();
   });
 

--- a/ui/e2e/rbac/remote-mcp-catalog.spec.ts
+++ b/ui/e2e/rbac/remote-mcp-catalog.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 import {
   gotoMcpServersTab,
   installMcpBrowserMocks,
-  openAddMcpServerEditor,
+  openMcpServerEditor,
   waitForAddMcpServerFormReady,
 } from "./_mcp-browser-fixtures";
 import { fulfillJson, mockedRbacEnabled, postJson } from "./_mocked-rbac";
@@ -106,7 +106,7 @@ test.describe("remote MCP catalog dialog", () => {
 
 test.describe("MCP server credential probe (Test Connection)", () => {
   test("Test Connection button sends POST to credential-probe and shows result", async ({ page }) => {
-    const credProbeRequests: Array<{ url?: string; credential_sources?: unknown[] }> = [];
+    const credProbeRequests: Array<{ server_id?: string; credential_sources?: unknown[] }> = [];
 
     await installMcpBrowserMocks(page, {
       secrets: [
@@ -122,7 +122,7 @@ test.describe("MCP server credential probe (Test Connection)", () => {
     await page.route("**/api/mcp-servers/credential-probe", async (route) => {
       if (route.request().method() === "POST") {
         const body = (await postJson(route)) as {
-          url?: string;
+          server_id?: string;
           credential_sources?: unknown[];
         };
         credProbeRequests.push(body);
@@ -143,12 +143,7 @@ test.describe("MCP server credential probe (Test Connection)", () => {
     });
 
     await gotoMcpServersTab(page);
-    await openAddMcpServerEditor(page);
-
-    // Fill endpoint and add a credential row — Test Connection only renders
-    // once credentialSources.length > 0.
-    await page.getByLabel(/Endpoint URL/i).fill("https://api.example.test/mcp");
-    await page.getByRole("button", { name: "Add Credential" }).click();
+    await openMcpServerEditor(page, "Jira MCP");
 
     await page.getByRole("button", { name: /Test Connection/i }).click();
 
@@ -158,7 +153,8 @@ test.describe("MCP server credential probe (Test Connection)", () => {
     await expect(page.getByText("Connected (HTTP 200)")).toBeVisible({ timeout: 10_000 });
 
     expect(credProbeRequests).toHaveLength(1);
-    expect(credProbeRequests[0]?.url).toMatch(/api\.example\.test\/mcp/);
+    expect(credProbeRequests[0]?.server_id).toBe("mcp-jira");
+    expect(credProbeRequests[0]).not.toHaveProperty("url");
   });
 
   test("Test Connection shows degraded indicator when credentials are missing", async ({ page }) => {
@@ -181,9 +177,7 @@ test.describe("MCP server credential probe (Test Connection)", () => {
     });
 
     await gotoMcpServersTab(page);
-    await openAddMcpServerEditor(page);
-    await page.getByLabel(/Endpoint URL/i).fill("https://api.example.test/mcp");
-    await page.getByRole("button", { name: "Add Credential" }).click();
+    await openMcpServerEditor(page, "Jira MCP");
     await page.getByRole("button", { name: /Test Connection/i }).click();
 
     // "Reachable but credentials not resolved" copy appears. Exact text — a

--- a/ui/e2e/rbac/remote-mcp-catalog.spec.ts
+++ b/ui/e2e/rbac/remote-mcp-catalog.spec.ts
@@ -165,8 +165,7 @@ test.describe("MCP server credential probe (Test Connection)", () => {
         await fulfillJson(route, {
           success: true,
           data: {
-            ok: true,
-            status: 200,
+            ok: false,
             credentialOrigins: [],
             missingCredentials: ["Authorization"],
           },
@@ -180,12 +179,12 @@ test.describe("MCP server credential probe (Test Connection)", () => {
     await openMcpServerEditor(page, "Jira MCP");
     await page.getByRole("button", { name: /Test Connection/i }).click();
 
-    // "Reachable but credentials not resolved" copy appears. Exact text — a
-    // loose /credential/i regex also matches the "Add Credential" button and
-    // "Credentials" section heading.
-    await expect(
-      page.getByText("Reachable (HTTP 200) — credentials not resolved"),
-    ).toBeVisible({ timeout: 10_000 });
+    // The probe stops before contacting AgentGateway when required credentials
+    // are unresolved, so the UI must show the degraded credential state rather
+    // than claiming that the endpoint was reachable.
+    await expect(page.getByText("Credentials not resolved", { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
   });
 });
 

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -130,6 +130,18 @@ jest.mock('@/components/admin/settings/ImportAgentsFromConfigCard', () => ({
   ),
 }));
 
+jest.mock('@/components/admin/settings/AgentGatewayRepairCard', () => ({
+  AgentGatewayRepairCard: (props: { isAdmin?: boolean; readOnly?: boolean }) => (
+    <div
+      data-testid="agentgateway-repair-card"
+      data-admin={String(Boolean(props.isAdmin))}
+      data-read-only={String(Boolean(props.readOnly))}
+    >
+      AgentGatewayRepairCard
+    </div>
+  ),
+}));
+
 jest.mock('@/components/admin/ServiceAccountsTab', () => ({
   ServiceAccountsTab: (props: { readOnly?: boolean }) => (
     <div data-testid="service-accounts-tab" data-read-only={String(Boolean(props.readOnly))}>

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -41,6 +41,7 @@ import { RbacSelfCheckTab } from "@/components/admin/security/RbacSelfCheckTab";
 import { UnifiedAuditTab } from "@/components/admin/security/UnifiedAuditTab";
 import { ImportAgentsFromConfigCard } from "@/components/admin/settings/ImportAgentsFromConfigCard";
 import { MCPCatalogSettingsCard } from "@/components/admin/settings/MCPCatalogSettingsCard";
+import { AgentGatewayRepairCard } from "@/components/admin/settings/AgentGatewayRepairCard";
 import { RagSettingsTab } from "@/components/admin/settings/RagSettingsTab";
 import { CardPagination } from "@/components/admin/shared/CardPagination";
 import { DateRangeFilter,presetToRange,type DateRange,type DateRangePreset } from "@/components/admin/shared/DateRangeFilter";
@@ -1681,6 +1682,10 @@ function AdminPage() {
               {tabGateValues.mcp && (
                 <TabsContent value="mcp" className="space-y-4">
                   <MCPCatalogSettingsCard
+                    isAdmin={effectiveOrganizationAdmin}
+                    readOnly={isSimulationActive}
+                  />
+                  <AgentGatewayRepairCard
                     isAdmin={effectiveOrganizationAdmin}
                     readOnly={isSimulationActive}
                   />

--- a/ui/src/app/api/__tests__/mcp-servers-rbac.test.ts
+++ b/ui/src/app/api/__tests__/mcp-servers-rbac.test.ts
@@ -208,7 +208,7 @@ describe("MCP server per-resource RBAC", () => {
     expect(toArray).toHaveBeenCalledTimes(1);
   });
 
-  it("self-heals AgentGateway-discovered MCP rows before listing an empty discovered set", async () => {
+  it("keeps MCP list reads side-effect free when no discovered rows exist", async () => {
     const items = [{ _id: "knowledge-base", name: "Knowledge Base" }];
     mockFilterResourcesByPermission.mockResolvedValue(items);
     const toArray = jest.fn().mockResolvedValue(items);
@@ -224,8 +224,8 @@ describe("MCP server per-resource RBAC", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(countDocuments).toHaveBeenCalledWith({ source: "agentgateway" });
-    expect(mockSyncSelectedAgentGatewayMcpServers).toHaveBeenCalledTimes(1);
+    expect(countDocuments).not.toHaveBeenCalled();
+    expect(mockSyncSelectedAgentGatewayMcpServers).not.toHaveBeenCalled();
     expect(body.data.items).toEqual([
       {
         _id: "knowledge-base",

--- a/ui/src/app/api/mcp-servers/__tests__/list-permissions.test.ts
+++ b/ui/src/app/api/mcp-servers/__tests__/list-permissions.test.ts
@@ -58,10 +58,6 @@ jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
   deleteAllMcpServerRelationshipTuples: jest.fn(),
 }));
 
-jest.mock("../agentgateway/_lib", () => ({
-  syncSelectedAgentGatewayMcpServers: jest.fn(),
-}));
-
 function request(path: string): NextRequest {
   return new NextRequest(new URL(path, "http://localhost:3000"));
 }

--- a/ui/src/app/api/mcp-servers/credential-probe/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/credential-probe/__tests__/route.test.ts
@@ -1,0 +1,214 @@
+/**
+ * @jest-environment node
+ */
+
+import { NextRequest } from "next/server";
+
+const mockGetAuthFromBearerOrSession = jest.fn();
+const mockRequireResourcePermission = jest.fn();
+const mockResolveMcpHeaderCredentials = jest.fn();
+const mockIsAgentGatewayEndpoint = jest.fn();
+const mockListHttpMcpTools = jest.fn();
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/api-middleware", () => {
+  class ApiError extends Error {
+    status: number;
+    code?: string;
+
+    constructor(message: string, status = 500, code?: string) {
+      super(message);
+      this.status = status;
+      this.code = code;
+    }
+  }
+  return {
+    ApiError,
+    getAuthFromBearerOrSession: (...args: unknown[]) =>
+      mockGetAuthFromBearerOrSession(...args),
+    successResponse: (data: unknown, status = 200) =>
+      Response.json({ success: true, data }, { status }),
+    withErrorHandler:
+      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      async (request: NextRequest) => {
+        try {
+          return await handler(request);
+        } catch (error) {
+          const typed = error as { status?: number; message: string };
+          return Response.json(
+            { success: false, error: typed.message },
+            { status: typed.status ?? 500 },
+          );
+        }
+      },
+  };
+});
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+}));
+
+jest.mock("@/lib/mcp-credential-headers", () => ({
+  isMcpCredentialUnavailableError: () => false,
+  resolveMcpHeaderCredentials: (...args: unknown[]) =>
+    mockResolveMcpHeaderCredentials(...args),
+}));
+
+jest.mock("@/lib/mcp-http-server-client", () => ({
+  isAgentGatewayEndpoint: (...args: unknown[]) => mockIsAgentGatewayEndpoint(...args),
+  listHttpMcpTools: (...args: unknown[]) => mockListHttpMcpTools(...args),
+}));
+
+const savedServer = {
+  _id: "mcp-example",
+  name: "Example",
+  endpoint: "http://agentgateway:4000/mcp/mcp-example",
+  agentgateway_target_endpoint: "https://upstream.example.test/mcp",
+  source: "agentgateway" as const,
+  transport: "http" as const,
+  credential_sources: [],
+  enabled: true,
+  created_at: "2026-08-15T00:00:00.000Z",
+  updated_at: "2026-08-15T00:00:00.000Z",
+};
+
+function request(body: Record<string, unknown> = {}): NextRequest {
+  return new NextRequest("http://localhost:3000/api/mcp-servers/credential-probe", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      server_id: "mcp-example",
+      // A client-supplied URL must never select the probe destination.
+      url: "https://untrusted.example.test/mcp",
+      credential_sources: [
+        {
+          kind: "provider_connection",
+          target: "header",
+          name: "X-CAIPE-Provider-Token",
+          provider: "example",
+        },
+      ],
+      ...body,
+    }),
+  });
+}
+
+describe("POST /api/mcp-servers/credential-probe", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetAuthFromBearerOrSession.mockResolvedValue({
+      session: { sub: "test-user", accessToken: "caller-token" },
+    });
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue(savedServer),
+    });
+    mockIsAgentGatewayEndpoint.mockReturnValue(true);
+    mockResolveMcpHeaderCredentials.mockResolvedValue({
+      headers: {
+        Authorization: "Bearer caller-token",
+        "X-CAIPE-Provider-Token": "provider-token",
+      },
+      sources: [
+        {
+          name: "X-CAIPE-Provider-Token",
+          kind: "provider_connection",
+          origin: "provider_connection",
+          provider: "example",
+        },
+      ],
+    });
+    mockListHttpMcpTools.mockResolvedValue({
+      tools: [{ name: "example_search", namespaced_name: "example_search" }],
+      sessionId: "session-123",
+    });
+  });
+
+  it("tests the saved server through its AgentGateway route", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data).toMatchObject({ ok: true, status: 200, missingCredentials: [] });
+    expect(mockRequireResourcePermission).toHaveBeenCalledWith(
+      { sub: "test-user", accessToken: "caller-token" },
+      { type: "mcp_server", id: "mcp-example", action: "manage" },
+    );
+    expect(mockResolveMcpHeaderCredentials).toHaveBeenCalledWith(
+      expect.objectContaining({
+        viaAgentGateway: true,
+        server: expect.objectContaining({
+          endpoint: "http://agentgateway:4000/mcp/mcp-example",
+          agentgateway_target_endpoint: "https://upstream.example.test/mcp",
+          credential_sources: [expect.objectContaining({ provider: "example" })],
+        }),
+      }),
+    );
+    expect(mockListHttpMcpTools).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverId: "mcp-example",
+        server: expect.objectContaining({
+          endpoint: "http://agentgateway:4000/mcp/mcp-example",
+        }),
+        credentialResolution: expect.objectContaining({
+          headers: expect.objectContaining({ Authorization: "Bearer caller-token" }),
+        }),
+      }),
+    );
+  });
+
+  it("requires the server to be saved before testing", async () => {
+    const { POST } = await import("../route");
+
+    const response = await POST(request({ server_id: "" }));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/save the MCP server/i);
+    expect(mockGetCollection).not.toHaveBeenCalled();
+    expect(mockListHttpMcpTools).not.toHaveBeenCalled();
+  });
+
+  it("rejects a saved HTTP server that has no AgentGateway route", async () => {
+    mockIsAgentGatewayEndpoint.mockReturnValue(false);
+    const { POST } = await import("../route");
+
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toMatch(/registered AgentGateway route/i);
+    expect(mockResolveMcpHeaderCredentials).not.toHaveBeenCalled();
+    expect(mockListHttpMcpTools).not.toHaveBeenCalled();
+  });
+
+  it("does not contact AgentGateway when a credential is unresolved", async () => {
+    mockResolveMcpHeaderCredentials.mockResolvedValue({
+      headers: { Authorization: "Bearer caller-token" },
+      sources: [
+        {
+          name: "X-CAIPE-Provider-Token",
+          kind: "provider_connection",
+          origin: "none",
+          provider: "example",
+        },
+      ],
+    });
+    const { POST } = await import("../route");
+
+    const response = await POST(request());
+    const body = await response.json();
+
+    expect(body.data).toMatchObject({
+      ok: false,
+      missingCredentials: ["X-CAIPE-Provider-Token"],
+    });
+    expect(mockListHttpMcpTools).not.toHaveBeenCalled();
+  });
+});

--- a/ui/src/app/api/mcp-servers/credential-probe/route.ts
+++ b/ui/src/app/api/mcp-servers/credential-probe/route.ts
@@ -10,12 +10,15 @@ import {
   successResponse,
   withErrorHandler,
 } from "@/lib/api-middleware";
-import { caipeOrgKey } from "@/lib/rbac/organization";
-import { requireResourcePermission } from "@/lib/rbac/resource-authz";
 import { isMcpCredentialUnavailableError, resolveMcpHeaderCredentials } from "@/lib/mcp-credential-headers";
+import { isAgentGatewayEndpoint, listHttpMcpTools } from "@/lib/mcp-http-server-client";
+import { getCollection } from "@/lib/mongodb";
+import { requireResourcePermission } from "@/lib/rbac/resource-authz";
 import type { McpCredentialResolution } from "@/lib/mcp-credential-headers";
-import type { MCPCredentialSource } from "@/types/dynamic-agent";
+import type { MCPCredentialSource, MCPServerConfig } from "@/types/dynamic-agent";
 import { NextRequest } from "next/server";
+
+const COLLECTION_NAME = "mcp_servers";
 
 interface CredentialProbeResult {
   ok: boolean;
@@ -25,44 +28,50 @@ interface CredentialProbeResult {
   missingCredentials: string[];
 }
 
-function normalizedUrl(value: unknown): string {
+function requiredServerId(value: unknown): string {
   if (typeof value !== "string" || !value.trim()) {
-    throw new ApiError("Endpoint URL is required", 400);
+    throw new ApiError(
+      "Save the MCP server before testing its AgentGateway connection",
+      400,
+      "MCP_SERVER_SAVE_REQUIRED",
+    );
   }
-  let parsed: URL;
-  try {
-    parsed = new URL(value.trim());
-  } catch {
-    throw new ApiError("Endpoint URL must be a valid URL", 400);
-  }
-  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-    throw new ApiError("Endpoint URL must use http or https", 400);
-  }
-  return parsed.toString().replace(/\/$/, "");
+  return value.trim();
 }
 
 export const POST = withErrorHandler(async (request: NextRequest) => {
   const { session } = await getAuthFromBearerOrSession(request);
+  const body = await request.json();
+  const serverId = requiredServerId(body.server_id);
   await requireResourcePermission(
     session,
-    { type: "organization", id: caipeOrgKey(), action: "use" },
-    { bypassForOrgAdmin: true },
+    { type: "mcp_server", id: serverId, action: "manage" },
   );
 
-  const body = await request.json();
-  const url = normalizedUrl(body.url);
-  const credentialSources = (body.credential_sources ?? []) as MCPCredentialSource[];
+  const collection = await getCollection<MCPServerConfig>(COLLECTION_NAME);
+  const server = await collection.findOne({ _id: serverId });
+  if (!server) throw new ApiError("MCP server not found", 404);
+  if (!server.enabled) throw new ApiError("MCP server is disabled", 400);
+  if (server.transport !== "http" || !server.endpoint) {
+    throw new ApiError(
+      "Connection testing requires a saved Streamable HTTP MCP server",
+      400,
+      "MCP_PROBE_UNSUPPORTED_TRANSPORT",
+    );
+  }
+  if (!isAgentGatewayEndpoint(server)) {
+    throw new ApiError(
+      "Connection testing requires a registered AgentGateway route",
+      409,
+      "MCP_GATEWAY_ROUTE_REQUIRED",
+    );
+  }
 
-  // Build a minimal MCPServerConfig shape for credential resolution
-  const fakeServer = {
-    _id: "probe",
-    name: "probe",
-    endpoint: url,
-    transport: "http" as const,
+  const credentialSources = (body.credential_sources ?? []) as MCPCredentialSource[];
+  const diagnosticServer: MCPServerConfig & { endpoint: string } = {
+    ...server,
+    endpoint: server.endpoint,
     credential_sources: credentialSources,
-    enabled: true,
-    created_at: new Date().toISOString(),
-    updated_at: new Date().toISOString(),
   };
 
   let resolution: McpCredentialResolution;
@@ -70,8 +79,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     resolution = await resolveMcpHeaderCredentials({
       request,
       session,
-      server: fakeServer,
-      viaAgentGateway: false,
+      server: diagnosticServer,
+      viaAgentGateway: true,
       retrievalCaller: "mcp-credential-probe",
     });
   } catch (error) {
@@ -90,44 +99,32 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     .filter((s) => s.origin === "none")
     .map((s) => s.name);
 
-  // Make the probe request with resolved headers
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), 8000);
-  let probeResult: CredentialProbeResult;
-  try {
-    const headers = new Headers({ accept: "application/json, text/event-stream;q=0.9, */*;q=0.1" });
-    for (const [key, value] of Object.entries(resolution.headers)) {
-      headers.set(key, value);
-    }
-    const response = await fetch(url, {
-      method: "GET",
-      signal: controller.signal,
-      headers,
-    });
-    probeResult = {
-      ok: response.status < 500 && response.status !== 404,
-      status: response.status,
-      credentialOrigins: resolution.sources.map((s) => ({
-        name: s.name,
-        origin: s.origin,
-        ...(s.provider ? { provider: s.provider } : {}),
-      })),
-      missingCredentials,
-    };
-  } catch (error) {
-    probeResult = {
+  const credentialOrigins = resolution.sources.map((s) => ({
+    name: s.name,
+    origin: s.origin,
+    ...(s.provider ? { provider: s.provider } : {}),
+  }));
+  if (missingCredentials.length > 0) {
+    return successResponse<CredentialProbeResult>({
       ok: false,
-      error: error instanceof Error ? error.message : "Could not connect",
-      credentialOrigins: resolution.sources.map((s) => ({
-        name: s.name,
-        origin: s.origin,
-        ...(s.provider ? { provider: s.provider } : {}),
-      })),
+      error: "One or more credentials could not be resolved. Check that connected apps are authorized.",
+      credentialOrigins,
       missingCredentials,
-    };
-  } finally {
-    clearTimeout(timeout);
+    });
   }
 
-  return successResponse(probeResult);
+  await listHttpMcpTools({
+    request,
+    session,
+    server: diagnosticServer,
+    serverId,
+    credentialResolution: resolution,
+  });
+
+  return successResponse<CredentialProbeResult>({
+    ok: true,
+    status: 200,
+    credentialOrigins,
+    missingCredentials,
+  });
 });

--- a/ui/src/app/api/mcp-servers/probe/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/probe/__tests__/route.test.ts
@@ -81,11 +81,12 @@ function request(path: string, init?: RequestInit): NextRequest {
   return new NextRequest(new URL(path, "http://localhost:3000"), init);
 }
 
-const session = { sub: "bob-sub", role: "user" };
+const session = { sub: "test-user", role: "user", accessToken: "caller-token" };
 
 describe("POST /api/mcp-servers/probe", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.CAIPE_AGENT_CONTEXT_HMAC_SECRET;
     mockGetAuthFromBearerOrSession.mockResolvedValue({ session });
     mockRequireResourcePermission.mockResolvedValue(undefined);
     mockGetCollection.mockResolvedValue({
@@ -96,8 +97,8 @@ describe("POST /api/mcp-servers/probe", () => {
       }),
     });
     mockAuthenticateRequest.mockResolvedValue({
-      subject: "bob-sub",
-      email: "bob@example.com",
+      subject: "test-user",
+      email: "test-user@example.com",
       role: "user",
       bearerToken: "token",
     });
@@ -212,7 +213,7 @@ describe("POST /api/mcp-servers/probe", () => {
     });
   });
 
-  it("runs a safe no-argument MCP tool after direct tools/list when one is available", async () => {
+  it("only lists tools and never invokes one during discovery", async () => {
     mockGetCollection.mockResolvedValueOnce({
       findOne: jest.fn().mockResolvedValue({
         _id: "mcp-netutils",
@@ -222,61 +223,130 @@ describe("POST /api/mcp-servers/probe", () => {
         enabled: true,
       }),
     });
-    global.fetch = jest
-      .fn()
-      .mockResolvedValueOnce(
-        Response.json({
-          jsonrpc: "2.0",
-          id: "tools-list",
-          result: {
-            tools: [
-              {
-                name: "version",
-                description: "Return server version",
-                inputSchema: { type: "object", properties: {}, required: [] },
-              },
-            ],
-          },
-        }),
-      )
-      .mockResolvedValueOnce(
-        Response.json({
-          jsonrpc: "2.0",
-          id: "tools-call",
-          result: { content: [{ type: "text", text: "1.2.3" }] },
-        }),
-      ) as unknown as typeof fetch;
+    global.fetch = jest.fn().mockResolvedValueOnce(
+      Response.json({
+        jsonrpc: "2.0",
+        id: "tools-list",
+        result: {
+          tools: [
+            {
+              name: "version",
+              description: "Return server version",
+              inputSchema: { type: "object", properties: {}, required: [] },
+            },
+          ],
+        },
+      }),
+    ) as unknown as typeof fetch;
     const { POST } = await import("../route");
 
     const response = await POST(
       request("/api/mcp-servers/probe?id=mcp-netutils", { method: "POST" }),
     );
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(String((global.fetch as jest.Mock).mock.calls[0][1].body)).toContain('"method":"tools/list"');
+    expect(String((global.fetch as jest.Mock).mock.calls[0][1].body)).not.toContain('"method":"tools/call"');
+  });
+
+  it("discovers managed tools through AgentGateway without calling the upstream endpoint", async () => {
+    process.env.CAIPE_AGENT_CONTEXT_HMAC_SECRET = "internal-test-secret";
+    mockGetCollection.mockResolvedValueOnce({
+      findOne: jest.fn().mockResolvedValue({
+        _id: "mcp-example",
+        name: "Example",
+        transport: "http",
+        endpoint: "http://agentgateway:4000/mcp/mcp-example",
+        agentgateway_target_endpoint: "https://example.test/mcp",
+        source: "agentgateway",
+        agentgateway_discovered: true,
+        enabled: true,
+      }),
+    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        Response.json(
+          {
+            jsonrpc: "2.0",
+            id: "initialize",
+            result: { protocolVersion: "2024-11-05", capabilities: {} },
+          },
+          { headers: { "mcp-session-id": "session-123" } },
+        ),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          jsonrpc: "2.0",
+          id: "tools-list",
+          result: { tools: [{ name: "example_search", description: "Search" }] },
+        }),
+      ) as unknown as typeof fetch;
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/mcp-servers/probe?id=mcp-example", { method: "POST" }),
+    );
     const body = await response.json();
 
     expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(2);
     expect(global.fetch).toHaveBeenNthCalledWith(
-      2,
-      "http://mcp-netutils:8000/mcp",
+      1,
+      "http://agentgateway:4000/mcp/mcp-example",
       expect.objectContaining({
         method: "POST",
-        body: expect.stringContaining('"method":"tools/call"'),
+        headers: expect.objectContaining({
+          Authorization: "Bearer caller-token",
+          "X-CAIPE-Agent-Context": expect.anything(),
+          "X-CAIPE-Agent-Context-Signature": expect.anything(),
+        }),
+        body: expect.stringContaining('"method":"initialize"'),
       }),
     );
     expect(global.fetch).toHaveBeenNthCalledWith(
       2,
-      "http://mcp-netutils:8000/mcp",
+      "http://agentgateway:4000/mcp/mcp-example",
       expect.objectContaining({
-        body: expect.stringContaining('"name":"version"'),
+        headers: expect.objectContaining({ "mcp-session-id": "session-123" }),
+        body: expect.stringContaining('"method":"tools/list"'),
       }),
     );
+    expect(global.fetch).not.toHaveBeenCalledWith("https://example.test/mcp", expect.anything());
+    for (const call of (global.fetch as jest.Mock).mock.calls) {
+      expect(String(call[1].body)).not.toContain('"method":"tools/call"');
+    }
     expect(body.data).toMatchObject({
+      server_id: "mcp-example",
       success: true,
-      source: "direct",
-      tool_test: {
-        toolName: "version",
-        success: true,
-      },
+      source: "agentgateway",
+      tools: [{ name: "example_search" }],
     });
+  });
+
+  it("fails closed when a managed server does not contain an AgentGateway route", async () => {
+    mockGetCollection.mockResolvedValueOnce({
+      findOne: jest.fn().mockResolvedValue({
+        _id: "mcp-example",
+        name: "Example",
+        transport: "http",
+        endpoint: "https://example.test/mcp",
+        agentgateway_target_endpoint: "https://example.test/mcp",
+        source: "agentgateway",
+        enabled: true,
+      }),
+    });
+    global.fetch = jest.fn() as unknown as typeof fetch;
+    const { POST } = await import("../route");
+
+    const response = await POST(
+      request("/api/mcp-servers/probe?id=mcp-example", { method: "POST" }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(502);
+    expect(body.error).toMatch(/missing its Gateway route/i);
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it("initializes Streamable HTTP MCP sessions before listing tools when required", async () => {

--- a/ui/src/app/api/mcp-servers/probe/route.ts
+++ b/ui/src/app/api/mcp-servers/probe/route.ts
@@ -34,13 +34,6 @@ interface DirectToolsResult {
   sessionId?: string;
 }
 
-interface ToolSmokeTest {
-  toolName: string;
-  success: boolean;
-  skipped?: boolean;
-  error?: string;
-}
-
 function isHttpMcpServer(server: MCPServerConfig): server is MCPServerConfig & { endpoint: string } {
   return server.transport === "http" && typeof server.endpoint === "string" && server.endpoint.trim().length > 0;
 }
@@ -184,53 +177,6 @@ async function listToolsDirect(server: MCPServerConfig & { endpoint: string }): 
   return tools ? { tools, sessionId: initialized.sessionId } : null;
 }
 
-function hasRequiredArguments(tool: DirectMcpToolInfo): boolean {
-  const schema = tool.inputSchema;
-  if (!schema || typeof schema !== "object") return false;
-  const required = (schema as { required?: unknown }).required;
-  return Array.isArray(required) && required.length > 0;
-}
-
-function pickSafeNoArgumentTool(tools: DirectMcpToolInfo[]): DirectMcpToolInfo | null {
-  const noArgTools = tools.filter((tool) => !hasRequiredArguments(tool));
-  const preferred = noArgTools.find((tool) => /(version|health|ping|status|about|info)/i.test(tool.name));
-  return preferred ?? null;
-}
-
-async function smokeTestNoArgumentTool(
-  server: MCPServerConfig & { endpoint: string },
-  tools: DirectMcpToolInfo[],
-  sessionId?: string,
-): Promise<ToolSmokeTest | undefined> {
-  const tool = pickSafeNoArgumentTool(tools);
-  if (!tool) return undefined;
-  const response = await mcpJsonRpc(
-    server.endpoint,
-    {
-      jsonrpc: "2.0",
-      id: `tools-call-${Date.now()}`,
-      method: "tools/call",
-      params: {
-        name: tool.name,
-        arguments: {},
-      },
-    },
-    sessionId,
-  );
-  if (!response.ok) {
-    return { toolName: tool.name, success: false, error: "Tool call failed" };
-  }
-  const payload = response.payload as { error?: { message?: unknown } } | null;
-  if (payload?.error) {
-    return {
-      toolName: tool.name,
-      success: false,
-      error: typeof payload.error.message === "string" ? payload.error.message : "Tool call failed",
-    };
-  }
-  return { toolName: tool.name, success: true };
-}
-
 /**
  * POST /api/mcp-servers/probe?id=<server_id>
  * Probe an MCP server to discover available tools.
@@ -283,7 +229,6 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
             server,
             serverId: id,
           });
-          const toolTest = await smokeTestNoArgumentTool(server, listed.tools, listed.sessionId);
           try {
             await cacheMcpToolCatalog({
               serverId: id,
@@ -298,13 +243,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
             success: true,
             tools: listed.tools,
             source: "agentgateway",
-            ...(toolTest ? { tool_test: toolTest } : {}),
           });
         }
 
         const directResult = await listToolsDirect(server);
         if (directResult) {
-          const toolTest = await smokeTestNoArgumentTool(server, directResult.tools, directResult.sessionId);
           try {
             await cacheMcpToolCatalog({
               serverId: id,
@@ -322,7 +265,6 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
             success: true,
             tools: directResult.tools,
             source: "direct",
-            ...(toolTest ? { tool_test: toolTest } : {}),
           });
         }
       }

--- a/ui/src/app/api/mcp-servers/route.ts
+++ b/ui/src/app/api/mcp-servers/route.ts
@@ -213,26 +213,6 @@ function normalizeCredentialSourcesForAgentGateway(value: unknown): MCPCredentia
     });
 }
 
-async function selfHealAgentGatewayMcpServersForList(
-  collection: Awaited<ReturnType<typeof getCollection<MCPServerConfig>>>,
-): Promise<void> {
-  try {
-    const discoveredCount = await collection.countDocuments({ source: "agentgateway" } as never);
-    if (discoveredCount > 0) return;
-
-    // assisted-by Codex Codex-sonnet-4-6
-    // Startup self-heal can miss AgentGateway readiness; list-time recovery
-    // keeps built-in routes like knowledge-base visible in MCP pickers.
-    const { syncSelectedAgentGatewayMcpServers } = await import("./agentgateway/_lib");
-    await syncSelectedAgentGatewayMcpServers();
-  } catch (error) {
-    console.warn(
-      "[mcp-servers] AgentGateway MCP list self-heal skipped:",
-      error instanceof Error ? error.message : error,
-    );
-  }
-}
-
 // ═══════════════════════════════════════════════════════════════
 // GET — list MCP servers
 // ═══════════════════════════════════════════════════════════════
@@ -245,8 +225,6 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const { session } = await getAuthFromBearerOrSession(request);
 
     const collection = await getCollection<MCPServerConfig>(COLLECTION_NAME);
-    await selfHealAgentGatewayMcpServersForList(collection);
-
     const listTarget = {
       type: "mcp_server" as const,
       action: "read" as const,

--- a/ui/src/components/admin/settings/AgentGatewayRepairCard.tsx
+++ b/ui/src/components/admin/settings/AgentGatewayRepairCard.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { AdminBadge } from "@/components/admin/shared/AdminBadge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { AlertCircle, AlertTriangle, CheckCircle2, Loader2, Wrench } from "lucide-react";
+import { useState } from "react";
+
+interface AgentGatewayRepairCardProps {
+  isAdmin: boolean;
+  readOnly?: boolean;
+}
+
+interface RepairWarning {
+  id: string;
+  message: string;
+}
+
+interface RepairResult {
+  added: number;
+  migrated: number;
+  refreshed: number;
+  skipped: number;
+  warnings: RepairWarning[];
+}
+
+function itemCount(value: unknown): number {
+  return Array.isArray(value) ? value.length : 0;
+}
+
+export function AgentGatewayRepairCard({
+  isAdmin,
+  readOnly = false,
+}: AgentGatewayRepairCardProps) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [repairing, setRepairing] = useState(false);
+  const [result, setResult] = useState<RepairResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  if (!isAdmin) return null;
+
+  const handleRepair = async () => {
+    if (readOnly || repairing) return;
+    setRepairing(true);
+    setError(null);
+    setResult(null);
+    try {
+      const response = await fetch("/api/mcp-servers/agentgateway/sync", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload.success) {
+        throw new Error(payload.error || "AgentGateway repair failed");
+      }
+      const data = payload.data ?? {};
+      setResult({
+        added: itemCount(data.added),
+        migrated: itemCount(data.migrated),
+        refreshed: itemCount(data.refreshed),
+        skipped: itemCount(data.skipped),
+        warnings: Array.isArray(data.migration_warnings) ? data.migration_warnings : [],
+      });
+      setConfirmOpen(false);
+    } catch (repairError) {
+      setError(repairError instanceof Error ? repairError.message : "AgentGateway repair failed");
+      setConfirmOpen(false);
+    } finally {
+      setRepairing(false);
+    }
+  };
+
+  return (
+    <>
+      <Card>
+        <CardHeader>
+          <div className="flex items-center gap-2">
+            <CardTitle>AgentGateway MCP registration repair</CardTitle>
+            <AdminBadge />
+          </div>
+          <CardDescription>
+            Reconcile GRID&apos;s MCP registrations with every MCP target currently configured in AgentGateway.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="rounded-md border border-amber-500/30 bg-amber-500/10 p-4 text-sm">
+            <div className="flex items-start gap-2">
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600 dark:text-amber-400" />
+              <div className="space-y-2">
+                <p className="font-medium text-amber-800 dark:text-amber-300">
+                  This is a global maintenance action, not a connection test.
+                </p>
+                <p className="text-amber-700 dark:text-amber-400">
+                  It reads all AgentGateway MCP targets, adds missing registrations, safely migrates legacy direct
+                  registrations, and reconciles OpenFGA grants for existing targets. Conflicting registrations are
+                  skipped and reported.
+                </p>
+                <p className="text-amber-700 dark:text-amber-400">
+                  It does not change AgentGateway listeners or JWT policy, invoke MCP tools, delete registrations, or
+                  overwrite an existing credential during migration.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          {result && (
+            <div className="rounded-md border border-green-500/30 bg-green-500/10 p-3 text-sm">
+              <div className="flex items-start gap-2">
+                <CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-green-600" />
+                <div className="space-y-1">
+                  <p className="font-medium text-green-700 dark:text-green-400">Repair completed</p>
+                  <p className="text-green-700 dark:text-green-400">
+                    Added {result.added}, migrated {result.migrated}, refreshed {result.refreshed}, and skipped{" "}
+                    {result.skipped} MCP registrations.
+                  </p>
+                  {result.warnings.map((warning) => (
+                    <p key={warning.id} className="text-xs text-amber-700 dark:text-amber-400">
+                      {warning.id}: {warning.message}
+                    </p>
+                  ))}
+                </div>
+              </div>
+            </div>
+          )}
+
+          {error && (
+            <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/10 p-3 text-sm text-destructive">
+              <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+              <p>{error}</p>
+            </div>
+          )}
+
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setConfirmOpen(true)}
+            disabled={readOnly || repairing}
+          >
+            {repairing ? (
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            ) : (
+              <Wrench className="mr-2 h-4 w-4" />
+            )}
+            Repair AgentGateway
+          </Button>
+          {readOnly && (
+            <p className="text-xs text-muted-foreground">
+              Repair is disabled while previewing another user&apos;s Admin access.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Dialog open={confirmOpen} onOpenChange={setConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Repair all AgentGateway MCP registrations?</DialogTitle>
+            <DialogDescription>
+              This will inspect every configured AgentGateway MCP target and may change shared MCP registration and
+              OpenFGA access state. It is not limited to a selected server.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2 text-sm text-muted-foreground">
+            <p>Use this only when registrations are missing or stale after an AgentGateway configuration change.</p>
+            <p>Conflicts will be skipped for manual review; existing registrations will not be deleted.</p>
+          </div>
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setConfirmOpen(false)} disabled={repairing}>
+              Cancel
+            </Button>
+            <Button type="button" onClick={handleRepair} disabled={repairing}>
+              {repairing && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+              Repair all discovered targets
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/ui/src/components/admin/settings/__tests__/AgentGatewayRepairCard.test.tsx
+++ b/ui/src/components/admin/settings/__tests__/AgentGatewayRepairCard.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { AgentGatewayRepairCard } from "../AgentGatewayRepairCard";
+
+describe("AgentGatewayRepairCard", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue(
+      {
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: {
+            added: ["primary"],
+            migrated: ["secondary"],
+            refreshed: ["existing"],
+            skipped: [{ id: "conflict", reason: "conflict" }],
+            migration_warnings: [
+              {
+                id: "conflict",
+                message: "A conflicting registration requires manual review.",
+              },
+            ],
+          },
+        }),
+      } as Response,
+    ) as unknown as typeof fetch;
+  });
+
+  it("explains the global repair scope and requires confirmation", async () => {
+    render(<AgentGatewayRepairCard isAdmin />);
+
+    expect(screen.getByText(/global maintenance action, not a connection test/i)).toBeInTheDocument();
+    expect(screen.getByText(/adds missing registrations/i)).toBeInTheDocument();
+    expect(screen.getByText(/reconciles OpenFGA grants/i)).toBeInTheDocument();
+    expect(screen.getByText(/does not change AgentGateway listeners or JWT policy/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Repair AgentGateway" }));
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(screen.getByRole("heading", { name: /Repair all AgentGateway MCP registrations/i })).toBeInTheDocument();
+    expect(screen.getByText(/not limited to a selected server/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Repair all discovered targets" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/mcp-servers/agentgateway/sync",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({}),
+        }),
+      );
+    });
+    expect(await screen.findByText("Repair completed")).toBeInTheDocument();
+    expect(screen.getByText(/Added 1, migrated 1, refreshed 1, and skipped 1/i)).toBeInTheDocument();
+    expect(screen.getByText(/conflict: A conflicting registration requires manual review/i)).toBeInTheDocument();
+  });
+
+  it("disables repair during Admin access preview", () => {
+    render(<AgentGatewayRepairCard isAdmin readOnly />);
+
+    expect(screen.getByRole("button", { name: "Repair AgentGateway" })).toBeDisabled();
+    expect(screen.getByText(/disabled while previewing another user's Admin access/i)).toBeInTheDocument();
+  });
+
+  it("does not render for non-admin users", () => {
+    const { container } = render(<AgentGatewayRepairCard isAdmin={false} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -24,6 +24,7 @@ import { normalizeCustomProviderCredentialSource } from "@/lib/mcp-credential-sc
 import type {
 MCPCredentialSource,
 MCPServerConfig,
+MCPServerConfigWithPermissions,
 MCPServerConfigCreate,
 MCPServerConfigUpdate,
 TransportType,
@@ -39,7 +40,7 @@ export interface MCPServerInitialValues {
 }
 
 interface MCPServerEditorProps {
-  server: MCPServerConfig | null; // null = creating new
+  server: MCPServerConfig | MCPServerConfigWithPermissions | null; // null = creating new
   readOnly?: boolean;
   onSave: () => void;
   onCancel: () => void;
@@ -186,6 +187,9 @@ function normalizedCredentialSource(
 
 export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialValues }: MCPServerEditorProps) {
   const isEditing = !!server;
+  const canManageServer = server && "permissions" in server
+    ? server.permissions.can_manage
+    : !readOnly;
 
   // Form state
   const [id, setId] = React.useState(server?._id || "");
@@ -463,17 +467,45 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
   };
 
   const handleProbeCredentials = async () => {
+    if (!server) {
+      setError("Save the MCP server before testing its AgentGateway connection");
+      return;
+    }
     setCredentialProbeLoading(true);
     setCredentialProbe(null);
     setError(null);
     try {
+      if (!canManageServer) {
+        const response = await fetch(
+          `/api/mcp-servers/probe?id=${encodeURIComponent(server._id)}`,
+          { method: "POST" },
+        );
+        const payload = (await response.json()) as {
+          success?: boolean;
+          data?: { success?: boolean };
+          error?: string;
+        };
+        if (!response.ok || payload.success === false || payload.data?.success !== true) {
+          throw new Error(payload.error || "Could not test connection");
+        }
+        setCredentialProbe({
+          ok: true,
+          status: response.status || 200,
+          credentialOrigins: [],
+          missingCredentials: [],
+        });
+        return;
+      }
       const normalizedSources = credentialSources
         .map((source) => normalizedCredentialSource(source, providerConnectionOptions))
         .filter((source): source is MCPCredentialSource => source !== null);
       const response = await fetch("/api/mcp-servers/credential-probe", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ url: endpoint, credential_sources: normalizedSources }),
+        body: JSON.stringify({
+          server_id: server._id,
+          credential_sources: normalizedSources,
+        }),
       });
       const payload = (await response.json()) as {
         success?: boolean;
@@ -1021,6 +1053,7 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
                     >
                       <option value="secret_ref">Saved secret</option>
                       <option value="provider_connection">Connected app</option>
+                      <option value="caller_token">Caller token</option>
                     </select>
                     <select
                       aria-label="Credential target"
@@ -1167,45 +1200,9 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
             )}
           </div>
 
-          {/* Test Connection */}
-          {credentialSources.length > 0 && endpoint.trim() && (
+          {/* Test Connection details */}
+          {credentialProbe && (
             <div className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  onClick={handleProbeCredentials}
-                  disabled={loading || readOnly || credentialProbeLoading || !endpoint.trim()}
-                >
-                  {credentialProbeLoading ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-1 animate-spin" />
-                      Testing...
-                    </>
-                  ) : (
-                    "Test Connection"
-                  )}
-                </Button>
-                {credentialProbe && (() => {
-                  const hasMissing = credentialProbe.missingCredentials.length > 0;
-                  const fullyOk = credentialProbe.ok && !hasMissing;
-                  const reachableButAuth = credentialProbe.ok && hasMissing;
-                  const colorClass = fullyOk
-                    ? "text-green-600 dark:text-green-400"
-                    : reachableButAuth
-                      ? "text-yellow-600 dark:text-yellow-400"
-                      : "text-destructive";
-                  const label = fullyOk
-                    ? `Connected (HTTP ${credentialProbe.status})`
-                    : reachableButAuth
-                      ? `Reachable (HTTP ${credentialProbe.status}) — credentials not resolved`
-                      : credentialProbe.error
-                        ? credentialProbe.error
-                        : `Failed (HTTP ${credentialProbe.status})`;
-                  return <span className={`text-sm font-medium ${colorClass}`}>{label}</span>;
-                })()}
-              </div>
               {credentialProbe && credentialProbe.missingCredentials.length > 0 && (() => {
                 const providerSources = credentialSources.filter(
                   (s) => s.kind === "provider_connection" && s.provider,
@@ -1284,29 +1281,67 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
           </fieldset>
 
           {/* Actions */}
-          <div className="flex items-center justify-end gap-2 pt-4 border-t">
-            {readOnly && (
-              <span className="text-xs text-muted-foreground mr-auto">
-                Config-driven — managed by configuration file
-              </span>
-            )}
-            <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
-              {readOnly ? "Close" : "Cancel"}
-            </Button>
-            {!readOnly && (
-              <Button type="submit" disabled={loading || !isValid}>
-                {loading ? (
+          <div className="flex flex-col gap-3 pt-4 border-t sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="outline"
+                className="border-violet-400 bg-violet-500/15 text-foreground hover:border-violet-300 hover:bg-violet-500/25"
+                onClick={handleProbeCredentials}
+                disabled={loading || credentialProbeLoading || !endpoint.trim() || !server}
+                title={!server ? "Save this server before testing through AgentGateway" : undefined}
+              >
+                {credentialProbeLoading ? (
                   <>
                     <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                    {isEditing ? "Saving..." : "Creating..."}
+                    Testing...
                   </>
-                ) : isEditing ? (
-                  "Save Changes"
                 ) : (
-                  "Create Server"
+                  "Test Connection"
                 )}
               </Button>
-            )}
+              {credentialProbe && (() => {
+                const hasMissing = credentialProbe.missingCredentials.length > 0;
+                const fullyOk = credentialProbe.ok && !hasMissing;
+                const colorClass = fullyOk
+                  ? "text-green-600 dark:text-green-400"
+                  : hasMissing
+                    ? "text-yellow-600 dark:text-yellow-400"
+                    : "text-destructive";
+                const label = fullyOk
+                  ? `Connected (HTTP ${credentialProbe.status})`
+                  : hasMissing
+                    ? "Credentials not resolved"
+                    : credentialProbe.error
+                      ? credentialProbe.error
+                      : `Failed (HTTP ${credentialProbe.status})`;
+                return <span className={`text-sm font-medium ${colorClass}`}>{label}</span>;
+              })()}
+            </div>
+            <div className="flex items-center justify-end gap-2">
+              {readOnly && (
+                <span className="mr-2 text-xs text-muted-foreground">
+                  Config-driven — managed by configuration file
+                </span>
+              )}
+              <Button type="button" variant="outline" onClick={onCancel} disabled={loading}>
+                {readOnly ? "Close" : "Cancel"}
+              </Button>
+              {!readOnly && (
+                <Button type="submit" disabled={loading || !isValid}>
+                  {loading ? (
+                    <>
+                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+                      {isEditing ? "Saving..." : "Creating..."}
+                    </>
+                  ) : isEditing ? (
+                    "Save Changes"
+                  ) : (
+                    "Create Server"
+                  )}
+                </Button>
+              )}
+            </div>
           </div>
         </form>
       </CardContent>

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -48,10 +48,6 @@ const DEFAULT_ROW_PERMISSIONS = {
   can_discover: false,
 } as const;
 
-const DEFAULT_LIST_CAPABILITIES = {
-  repair_agentgateway: false,
-} as const;
-
 interface ProbeResult {
   server_id: string;
   loading: boolean;
@@ -60,14 +56,6 @@ interface ProbeResult {
 }
 
 type ToolHealthStatus = "healthy" | "degraded" | "checking" | "unknown" | "disabled";
-
-interface AgentGatewayMigrationWarning {
-  id: string;
-  endpoint: string;
-  target_endpoint?: string;
-  existing_endpoint?: string;
-  message: string;
-}
 
 interface FetchServersOptions {
   showLoading?: boolean;
@@ -203,7 +191,6 @@ export function MCPServersTab({
   onSelectedServerChange,
 }: MCPServersTabProps = {}) {
   const [servers, setServers] = React.useState<MCPServerConfigWithPermissions[]>([]);
-  const [listCapabilities, setListCapabilities] = React.useState(DEFAULT_LIST_CAPABILITIES);
   const [loading, setLoading] = React.useState(true);
   const [error, setError] = React.useState<string | null>(null);
   const [editingServer, setEditingServer] = React.useState<MCPServerConfigWithPermissions | null>(null);
@@ -215,12 +202,6 @@ export function MCPServersTab({
   const [showCatalog, setShowCatalog] = React.useState(false);
   const [catalogInitialValues, setCatalogInitialValues] = React.useState<MCPServerInitialValues | null>(null);
   const [probeResults, setProbeResults] = React.useState<Record<string, ProbeResult>>({});
-  const [agentGatewayMigrationWarnings, setAgentGatewayMigrationWarnings] = React.useState<
-    AgentGatewayMigrationWarning[]
-  >([]);
-  const [agentGatewaySyncing, setAgentGatewaySyncing] = React.useState(false);
-  const [agentGatewayMessage, setAgentGatewayMessage] = React.useState<string | null>(null);
-  const [agentGatewayError, setAgentGatewayError] = React.useState<string | null>(null);
   const [testingServer, setTestingServer] = React.useState<MCPServerConfigWithPermissions | null>(null);
   const [pendingDeleteServerId, setPendingDeleteServerId] = React.useState<string | null>(null);
   const [deletingServerId, setDeletingServerId] = React.useState<string | null>(null);
@@ -247,7 +228,6 @@ export function MCPServersTab({
             permissions: server.permissions ?? DEFAULT_ROW_PERMISSIONS,
           })),
         );
-        setListCapabilities(data.data.capabilities ?? DEFAULT_LIST_CAPABILITIES);
         setError(null);
       } else {
         if (!preserveListOnError) {
@@ -464,38 +444,6 @@ export function MCPServersTab({
     }
   };
 
-  const handleSyncAgentGateway = async () => {
-    setAgentGatewaySyncing(true);
-    setAgentGatewayError(null);
-    setAgentGatewayMessage(null);
-    setAgentGatewayMigrationWarnings([]);
-    try {
-      const response = await fetch("/api/mcp-servers/agentgateway/sync", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-      const data = await response.json();
-      if (!data.success) {
-        throw new Error(data.error || "Failed to sync AgentGateway MCP servers");
-      }
-      const addedCount = data.data.added?.length || 0;
-      const migratedCount = data.data.migrated?.length || 0;
-      const refreshedCount = data.data.refreshed?.length || 0;
-      setAgentGatewayMessage(
-        `Added ${addedCount}, migrated ${migratedCount}, and refreshed ${refreshedCount} MCP server${
-          addedCount + migratedCount + refreshedCount === 1 ? "" : "s"
-        } from AgentGateway.`,
-      );
-      setAgentGatewayMigrationWarnings(data.data.migration_warnings || []);
-      await fetchServers();
-    } catch (err: unknown) {
-      setAgentGatewayError(errorMessage(err, "Failed to sync AgentGateway MCP servers"));
-    } finally {
-      setAgentGatewaySyncing(false);
-    }
-  };
-
   /**
    * Export server configuration as YAML file
    */
@@ -633,22 +581,6 @@ export function MCPServersTab({
       />
       <WorkspacePageActions>
         <div className="flex flex-wrap items-center justify-end gap-2">
-            {listCapabilities.repair_agentgateway && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleSyncAgentGateway}
-                disabled={agentGatewaySyncing}
-                title="Admin repair: re-import built-in AgentGateway MCP routes and repair stale registrations"
-              >
-                {agentGatewaySyncing ? (
-                  <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                ) : (
-                  <Globe className="h-4 w-4 mr-2" />
-                )}
-                Repair AgentGateway
-              </Button>
-            )}
             <Button variant="outline" size="sm" onClick={() => fetchServers()} disabled={loading}>
               <RefreshCw className={`h-4 w-4 mr-2 ${loading ? "animate-spin" : ""}`} />
               Refresh
@@ -661,56 +593,6 @@ export function MCPServersTab({
       </WorkspacePageActions>
       <Card className="rounded-none border-0 bg-transparent shadow-none">
         <CardContent className="px-0 pt-0">
-        {agentGatewayError && (
-          <div className="mb-4 flex items-start gap-2 rounded-lg bg-destructive/10 border border-destructive/30 p-3">
-            <AlertCircle className="h-4 w-4 text-destructive mt-0.5 flex-shrink-0" />
-            <p className="text-sm text-destructive">{agentGatewayError}</p>
-          </div>
-        )}
-
-        {agentGatewayMessage && (
-          <div className="mb-4 flex items-start gap-2 rounded-lg bg-green-500/10 border border-green-500/30 p-3">
-            <CheckCircle2 className="h-4 w-4 text-green-500 mt-0.5 flex-shrink-0" />
-            <p className="text-sm text-green-700 dark:text-green-400">{agentGatewayMessage}</p>
-          </div>
-        )}
-
-        {agentGatewayMigrationWarnings.length > 0 && (
-          <div className="mb-6 rounded-lg border border-amber-500/30 bg-amber-500/10 p-4">
-            <div className="flex items-start gap-2">
-              <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 mt-0.5 flex-shrink-0" />
-              <div className="space-y-3">
-                <div>
-                  <h3 className="text-sm font-semibold text-amber-800 dark:text-amber-300">
-                    {agentGatewayMigrationWarnings.length} legacy MCP server
-                    {agentGatewayMigrationWarnings.length === 1 ? "" : "s"} conflict
-                    {agentGatewayMigrationWarnings.length === 1 ? "s" : ""} with AgentGateway targets.
-                  </h3>
-                  <p className="text-sm text-amber-700 dark:text-amber-400">
-                    Remove or rename the legacy MCP server to let AgentGateway manage it. Use the row actions below to
-                    delete the legacy entry after you confirm it is no longer needed.
-                  </p>
-                </div>
-                <div className="space-y-2">
-                  {agentGatewayMigrationWarnings.map((warning) => (
-                    <div key={warning.id} className="rounded-md border border-amber-500/20 bg-background/70 p-3">
-                      <div className="font-mono text-xs font-semibold">{warning.id}</div>
-                      {warning.existing_endpoint && (
-                        <p className="text-xs text-muted-foreground">
-                          Current: {warning.existing_endpoint}
-                        </p>
-                      )}
-                      <p className="text-xs text-muted-foreground">
-                        AgentGateway: {warning.target_endpoint || warning.endpoint}
-                      </p>
-                    </div>
-                  ))}
-                </div>
-              </div>
-            </div>
-          </div>
-        )}
-
         {loading ? (
           <div className="flex items-center justify-center py-12">
             <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />

--- a/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
@@ -285,6 +285,209 @@ describe("MCPServerEditor credential sources", () => {
     expect(screen.getByLabelText(/upstream url|endpoint url/i)).toHaveValue("http://mcp-argocd:8000/mcp");
   });
 
+  it("preserves the managed caller-token credential when testing a connection", async () => {
+    (global.fetch as jest.Mock).mockImplementation(async (url: string) => {
+      if (url === "/api/mcp-servers/agentgateway/discover") {
+        return response({
+          targets: [{
+            id: "mcp-example",
+            name: "Example",
+            endpoint: "http://agentgateway:4000/mcp/mcp-example",
+            target_endpoint: "https://upstream.example.test/mcp",
+          }],
+        });
+      }
+      if (url === "/api/mcp-servers/credential-probe") {
+        return response({
+          ok: true,
+          status: 200,
+          credentialOrigins: [{ name: "X-CAIPE-Provider-Token", origin: "user_jwt" }],
+          missingCredentials: [],
+        });
+      }
+      if (
+        url === "/api/credentials/secrets" ||
+        url === "/api/credentials/connections" ||
+        url === "/api/credentials/oauth-connectors"
+      ) {
+        return response([]);
+      }
+      return response({});
+    });
+    const user = userEvent.setup();
+    render(
+      <MCPServerEditor
+        server={{
+          _id: "mcp-example",
+          name: "Example",
+          transport: "http",
+          endpoint: "http://agentgateway:4000/mcp/mcp-example",
+          agentgateway_endpoint: "http://agentgateway:4000/mcp/mcp-example",
+          agentgateway_target_endpoint: "https://upstream.example.test/mcp",
+          source: "agentgateway",
+          credential_sources: [{
+            kind: "caller_token",
+            target: "header",
+            name: "X-CAIPE-Provider-Token",
+          }],
+          enabled: true,
+          created_at: "2026-08-15T00:00:00.000Z",
+          updated_at: "2026-08-15T00:00:00.000Z",
+        }}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    expect(await screen.findByRole("option", { name: "Caller token" })).toBeInTheDocument();
+    expect(screen.getByLabelText(/credential kind/i)).toHaveValue("caller_token");
+    await user.click(screen.getByRole("button", { name: /test connection/i }));
+
+    await waitFor(() => {
+      const probeCall = (global.fetch as jest.Mock).mock.calls.find(
+        ([url]) => url === "/api/mcp-servers/credential-probe",
+      );
+      expect(probeCall).toBeDefined();
+      expect(JSON.parse(String(probeCall?.[1]?.body))).toEqual({
+        server_id: "mcp-example",
+        credential_sources: [{
+          kind: "caller_token",
+          target: "header",
+          name: "X-CAIPE-Provider-Token",
+        }],
+      });
+    });
+  });
+
+  it("requires new servers to be saved before testing through AgentGateway", async () => {
+    const user = userEvent.setup();
+    render(<MCPServerEditor server={null} onSave={jest.fn()} onCancel={jest.fn()} />);
+
+    await user.type(screen.getByLabelText(/display name/i), "New MCP");
+    await user.type(screen.getByLabelText(/upstream url|endpoint url/i), "https://example.test/mcp");
+
+    expect(screen.getByRole("button", { name: /test connection/i }))
+      .toHaveAttribute("title", "Save this server before testing through AgentGateway");
+    expect(screen.getByRole("button", { name: /test connection/i })).toBeDisabled();
+  });
+
+  it("always shows Test Connection before the form actions and probes saved servers without credentials", async () => {
+    (global.fetch as jest.Mock).mockImplementation(async (url: string) => {
+      if (url === "/api/mcp-servers/credential-probe") {
+        return response({
+          ok: true,
+          status: 200,
+          credentialOrigins: [],
+          missingCredentials: [],
+        });
+      }
+      if (url === "/api/mcp-servers/agentgateway/discover") return response({ targets: [] });
+      if (url === "/api/dynamic-agents/teams") return response([]);
+      if (
+        url === "/api/credentials/secrets" ||
+        url === "/api/credentials/connections" ||
+        url === "/api/credentials/oauth-connectors"
+      ) {
+        return response([]);
+      }
+      return response({});
+    });
+    const user = userEvent.setup();
+    render(
+      <MCPServerEditor
+        server={{
+          _id: "mcp-example",
+          name: "Example MCP",
+          transport: "http",
+          endpoint: "http://agentgateway:4000/mcp/mcp-example",
+          source: "agentgateway",
+          credential_sources: [],
+        }}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    const testConnection = screen.getByRole("button", { name: /test connection/i });
+    const cancel = screen.getByRole("button", { name: /^cancel$/i });
+    const save = screen.getByRole("button", { name: /save changes/i });
+    expect(testConnection).toBeEnabled();
+    expect(testConnection).toHaveClass("border-violet-400", "bg-violet-500/15", "text-foreground");
+    expect(testConnection.compareDocumentPosition(cancel)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(testConnection.compareDocumentPosition(save)).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    const actionRow = testConnection.parentElement?.parentElement;
+    expect(actionRow?.firstElementChild).toBe(testConnection.parentElement);
+    expect(actionRow?.lastElementChild).toContainElement(cancel);
+    expect(actionRow?.lastElementChild).toContainElement(save);
+
+    await user.click(testConnection);
+    await waitFor(() => {
+      const probeCall = (global.fetch as jest.Mock).mock.calls.find(
+        ([url]) => url === "/api/mcp-servers/credential-probe",
+      );
+      expect(JSON.parse(String(probeCall?.[1]?.body))).toEqual({
+        server_id: "mcp-example",
+        credential_sources: [],
+      });
+    });
+    expect(await screen.findByText("Connected (HTTP 200)")).toBeInTheDocument();
+  });
+
+  it("tests read-only config-driven servers through the AgentGateway health probe", async () => {
+    (global.fetch as jest.Mock).mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === "/api/mcp-servers/probe?id=argocd" && init?.method === "POST") {
+        return response({ success: true, tools: [{ name: "list_applications" }] });
+      }
+      if (url === "/api/mcp-servers/agentgateway/discover") return response({ targets: [] });
+      if (url === "/api/dynamic-agents/teams") return response([]);
+      if (
+        url === "/api/credentials/secrets" ||
+        url === "/api/credentials/connections" ||
+        url === "/api/credentials/oauth-connectors"
+      ) {
+        return response([]);
+      }
+      return response({});
+    });
+    const user = userEvent.setup();
+    render(
+      <MCPServerEditor
+        readOnly
+        server={{
+          _id: "argocd",
+          name: "ArgoCD",
+          transport: "http",
+          endpoint: "http://agentgateway:4000/mcp/argocd",
+          source: "agentgateway",
+          config_driven: true,
+          credential_sources: [],
+          permissions: { can_manage: false, can_invoke: false, can_discover: true },
+        }}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    const testConnection = screen.getByRole("button", { name: /test connection/i });
+    const close = screen.getByRole("button", { name: /^close$/i });
+    const actionRow = testConnection.parentElement?.parentElement;
+    expect(actionRow?.firstElementChild).toBe(testConnection.parentElement);
+    expect(actionRow?.lastElementChild).toContainElement(close);
+
+    await user.click(testConnection);
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith(
+        "/api/mcp-servers/probe?id=argocd",
+        { method: "POST" },
+      );
+    });
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "/api/mcp-servers/credential-probe",
+      expect.anything(),
+    );
+    expect(await screen.findByText("Connected (HTTP 200)")).toBeInTheDocument();
+  });
+
   it("submits the picked AgentGateway upstream when creating a new server", async () => {
     (global.fetch as jest.Mock).mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === "/api/mcp-servers/agentgateway/discover") {

--- a/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
@@ -64,28 +64,6 @@ describe("MCPServersTab AgentGateway repair", () => {
           json: async () => ({ success: true, data: jiraServer }),
         } as Response);
       }
-      if (url === "/api/mcp-servers/agentgateway/sync" && init?.method === "POST") {
-        return Promise.resolve({
-          json: async () => ({
-            success: true,
-            data: {
-              added: ["rag"],
-              skipped: [{ id: "jira", reason: "conflict" }],
-              summary: { added: 1, existing: 0, conflicts: 1, skipped: 1 },
-              migration_warnings: [
-                {
-                  id: "jira",
-                  endpoint: "http://agentgateway:4000/mcp",
-                  target_endpoint: "http://mcp-jira:8000/mcp",
-                  existing_endpoint: "http://legacy-jira:8000/mcp",
-                  message:
-                    "Legacy MCP server conflicts with AgentGateway target \"jira\". Remove or rename the legacy MCP server to let AgentGateway manage it.",
-                },
-              ],
-            },
-          }),
-        } as Response);
-      }
       if (url === "/api/mcp-servers/probe?id=jira" && init?.method === "POST") {
         return Promise.resolve({
           json: async () => ({
@@ -146,34 +124,15 @@ describe("MCPServersTab AgentGateway repair", () => {
     }) as unknown as typeof fetch;
   });
 
-  it("repairs AgentGateway MCP server registrations and shows migration conflicts", async () => {
+  it("does not expose the global AgentGateway repair action", async () => {
     render(<MCPServersTab />);
 
     await screen.findByText("Jira");
-    fireEvent.click(screen.getByRole("button", { name: /Repair AgentGateway/i }));
-
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith(
-        "/api/mcp-servers/agentgateway/sync",
-        expect.objectContaining({
-          method: "POST",
-          body: JSON.stringify({}),
-        }),
-      );
-    });
-
-    // Message format changed to break down counts:
-    //   "Added 1, migrated 0, and refreshed 0 MCP server from AgentGateway."
-    expect(
-      await screen.findByText(/Added 1, migrated 0, and refreshed 0 MCP server/i),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByText(/1 legacy MCP server conflicts with AgentGateway targets/i),
-    ).toBeInTheDocument();
-    expect(screen.getByText(/Remove or rename the legacy MCP server/i)).toBeInTheDocument();
-    expect(screen.getAllByText("jira").length).toBeGreaterThan(0);
-    expect(screen.getByText(/Current: http:\/\/legacy-jira:8000\/mcp/i)).toBeInTheDocument();
-    expect(screen.getByText(/AgentGateway: http:\/\/mcp-jira:8000\/mcp/i)).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Repair AgentGateway/i })).not.toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "/api/mcp-servers/agentgateway/sync",
+      expect.anything(),
+    );
   });
 
   it("marks AgentGateway-registered MCP servers in the table", async () => {
@@ -384,7 +343,7 @@ describe("MCPServersTab AgentGateway repair", () => {
     jest.useRealTimers();
   });
 
-  it("hides repair, probe, test, and delete actions when row permissions deny them", async () => {
+  it("hides probe, test, and delete actions when row permissions deny them", async () => {
     serverItems = [
       {
         ...jiraServer,
@@ -423,11 +382,11 @@ describe("MCPServersTab AgentGateway repair", () => {
     expect(await screen.findByText("Add MCP Server")).toBeInTheDocument();
   });
 
-  it("shows repair, probe, test, and delete when list permissions allow them", async () => {
+  it("shows permitted row actions without exposing global AgentGateway repair", async () => {
     render(<MCPServersTab />);
 
     await screen.findByText("Jira");
-    expect(screen.getByRole("button", { name: /Repair AgentGateway/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /Repair AgentGateway/i })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Probe tools for Jira/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /test mcp tools for jira/i })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: /Delete Jira/i })).toBeInTheDocument();

--- a/ui/src/lib/__tests__/mcp-credential-headers.test.ts
+++ b/ui/src/lib/__tests__/mcp-credential-headers.test.ts
@@ -172,6 +172,31 @@ describe("mcp-credential-headers", () => {
     ]);
   });
 
+  it("preserves non-provider caller-token headers for direct upstreams", async () => {
+    const request = new NextRequest("http://localhost:3000/api/mcp-servers/probe", { method: "POST" });
+    const resolution = await resolveMcpHeaderCredentials({
+      request,
+      session: { sub: "user-sub", accessToken: "user-jwt" },
+      viaAgentGateway: false,
+      server: {
+        _id: "scheduler",
+        id: "scheduler",
+        name: "Scheduler",
+        transport: "http",
+        enabled: true,
+        credential_sources: [
+          {
+            kind: "caller_token",
+            target: "header",
+            name: "X-CAIPE-Caller-Token",
+          },
+        ],
+      },
+    });
+
+    expect(resolution.headers).toEqual({ "X-CAIPE-Caller-Token": "Bearer user-jwt" });
+  });
+
   it("uses caller_token client-credentials fallback when no user JWT is available", async () => {
     process.env.MCP_SERVICE_OIDC_TOKEN_URL = "http://keycloak/token";
     process.env.MCP_SERVICE_OIDC_CLIENT_ID = "caipe-platform";

--- a/ui/src/lib/__tests__/mcp-http-server-client.test.ts
+++ b/ui/src/lib/__tests__/mcp-http-server-client.test.ts
@@ -1,0 +1,121 @@
+jest.mock("@/lib/api-middleware", () => ({
+  ApiError: class ApiError extends Error {
+    constructor(
+      message: string,
+      public statusCode: number = 500,
+      public code?: string,
+    ) {
+      super(message);
+    }
+  },
+}));
+
+jest.mock("@/lib/mcp-credential-headers", () => ({
+  resolveMcpHeaderCredentials: jest.fn(),
+}));
+
+import { listHttpMcpTools } from "@/lib/mcp-http-server-client";
+
+function response(input: {
+  status: number;
+  body: unknown;
+  sessionId?: string;
+}): Response {
+  return {
+    ok: input.status >= 200 && input.status < 300,
+    status: input.status,
+    headers: new Headers({
+      "content-type": typeof input.body === "string" ? "text/plain" : "application/json",
+      ...(input.sessionId ? { "mcp-session-id": input.sessionId } : {}),
+    }),
+    json: async () => input.body,
+    text: async () => typeof input.body === "string" ? input.body : JSON.stringify(input.body),
+  } as Response;
+}
+
+describe("listHttpMcpTools", () => {
+  const originalFetch = global.fetch;
+  const originalGatewayUrl = process.env.AGENT_GATEWAY_URL;
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    process.env.AGENT_GATEWAY_URL = originalGatewayUrl;
+    jest.restoreAllMocks();
+  });
+
+  it("retries a transient AgentGateway route-registration 404", async () => {
+    process.env.AGENT_GATEWAY_URL = "http://gateway:4000";
+    const fetchMock = jest.fn()
+      .mockResolvedValueOnce(response({ status: 404, body: "route not found" }))
+      .mockResolvedValueOnce(response({
+        status: 200,
+        sessionId: "session-1",
+        body: { jsonrpc: "2.0", id: "initialize", result: { protocolVersion: "2024-11-05" } },
+      }))
+      .mockResolvedValueOnce(response({
+        status: 200,
+        sessionId: "session-1",
+        body: {
+          jsonrpc: "2.0",
+          id: "tools-list",
+          result: { tools: [{ name: "echo", description: "Harmless test tool" }] },
+        },
+      }));
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const result = await listHttpMcpTools({
+      request: {} as never,
+      session: { sub: "test-user" },
+      server: {
+        _id: "example",
+        name: "Example",
+        transport: "http",
+        endpoint: "http://gateway:4000/mcp/example",
+        enabled: true,
+        source: "agentgateway",
+      } as never,
+      serverId: "example",
+      credentialResolution: {
+        headers: { Authorization: "Bearer test-token" },
+        sources: [],
+      },
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(result.tools).toEqual([
+      expect.objectContaining({ name: "echo", namespaced_name: "echo" }),
+    ]);
+  });
+
+  it("does not retry an AgentGateway authorization denial", async () => {
+    process.env.AGENT_GATEWAY_URL = "http://gateway:4000";
+    const fetchMock = jest.fn().mockResolvedValue(
+      response({ status: 403, body: "forbidden" }),
+    );
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(listHttpMcpTools({
+      request: {} as never,
+      session: { sub: "test-user" },
+      server: {
+        _id: "example",
+        name: "Example",
+        transport: "http",
+        endpoint: "http://gateway:4000/mcp/example",
+        enabled: true,
+        source: "agentgateway",
+      } as never,
+      serverId: "example",
+      credentialResolution: {
+        headers: { Authorization: "Bearer test-token" },
+        sources: [],
+      },
+    })).rejects.toMatchObject({
+      statusCode: 502,
+      code: "MCP_INIT_FAILED",
+      message: "MCP initialize failed with HTTP 403",
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/src/lib/mcp-http-server-client.ts
+++ b/ui/src/lib/mcp-http-server-client.ts
@@ -7,8 +7,10 @@
 import crypto from "crypto";
 
 import { ApiError } from "@/lib/api-middleware";
-import { resolveMcpHeaderCredentials } from "@/lib/mcp-credential-headers";
-import { writeOpenFgaTuples, type OpenFgaTupleKey } from "@/lib/rbac/openfga";
+import {
+  resolveMcpHeaderCredentials,
+  type McpCredentialResolution,
+} from "@/lib/mcp-credential-headers";
 import type { MCPServerConfig, MCPToolInfo } from "@/types/dynamic-agent";
 import type { NextRequest } from "next/server";
 
@@ -28,6 +30,12 @@ const AGENT_CONTEXT_TTL_SECONDS: Record<AgentContextKind, number> = {
   dynamic: 300,
   local: 60 * 60 * 8,
 };
+
+// Saved AgentGateway routes are reconciled asynchronously by the config
+// bridge. A connection test can therefore reach the Gateway just before the
+// new route is installed and receive a transient 404. Retry only that status;
+// upstream failures and authorization denials must still fail immediately.
+const AGENT_GATEWAY_ROUTE_RETRY_DELAYS_MS = [250, 500, 1_000, 1_500, 2_500] as const;
 
 type AuthSession = {
   sub?: string;
@@ -94,49 +102,17 @@ export function isAgentGatewayEndpoint(server: MCPServerConfig): boolean {
   if (server.source === "agentgateway" || server.agentgateway_discovered) return true;
   if (!server.endpoint) return false;
 
+  return isAgentGatewayRouteEndpoint(server.endpoint);
+}
+
+function isAgentGatewayRouteEndpoint(endpoint: string): boolean {
   const base = stripTrailingSlash(process.env.AGENT_GATEWAY_URL || "http://agentgateway:4000");
   try {
-    const endpointUrl = new URL(server.endpoint);
+    const endpointUrl = new URL(endpoint);
     const baseUrl = new URL(base);
     return endpointUrl.origin === baseUrl.origin && endpointUrl.pathname.startsWith("/mcp");
   } catch {
     return false;
-  }
-}
-
-function diagnosticOpenFgaTuples(
-  serverId: string,
-  agentId: string,
-  session: AuthSession,
-): OpenFgaTupleKey[] {
-  const subject = typeof session?.sub === "string" ? session.sub.trim() : "";
-  if (!subject) return [];
-  return [
-    { user: `user:${subject}`, relation: "user", object: `agent:${agentId}` },
-    { user: `agent:${agentId}`, relation: "caller", object: `tool:${serverId}/*` },
-  ];
-}
-
-export async function grantDiagnosticAgentAccess(
-  serverId: string,
-  agentId: string,
-  session: AuthSession,
-): Promise<OpenFgaTupleKey[]> {
-  const writes = diagnosticOpenFgaTuples(serverId, agentId, session);
-  if (!writes.length) return [];
-  await writeOpenFgaTuples({ writes, deletes: [] });
-  return writes;
-}
-
-export async function revokeDiagnosticAgentAccess(
-  tuples: OpenFgaTupleKey[],
-  logLabel = "mcp-http-server-client",
-): Promise<void> {
-  if (!tuples.length) return;
-  try {
-    await writeOpenFgaTuples({ writes: [], deletes: tuples });
-  } catch (error) {
-    console.warn(`[${logLabel}] failed to remove diagnostic AgentGateway tuples`, error);
   }
 }
 
@@ -185,6 +161,10 @@ async function mcpJsonRpc(input: {
   }
 }
 
+async function wait(delayMs: number): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
 function normalizeTool(tool: unknown): MCPToolInfo | null {
   if (!tool || typeof tool !== "object") return null;
   const candidate = tool as {
@@ -226,18 +206,23 @@ async function buildMcpRequestHeaders(input: {
   server: MCPServerConfig;
   viaAgentGateway: boolean;
   serverId: string;
+  credentialResolution?: McpCredentialResolution;
 }): Promise<Record<string, string>> {
   try {
-    const { headers } = await resolveMcpHeaderCredentials({
-      request: input.request,
-      session: input.session,
-      server: input.server,
-      viaAgentGateway: input.viaAgentGateway,
-      retrievalCaller: "mcp-http-server-client",
-    });
+    const resolution =
+      input.credentialResolution ??
+      (await resolveMcpHeaderCredentials({
+        request: input.request,
+        session: input.session,
+        server: input.server,
+        viaAgentGateway: input.viaAgentGateway,
+        retrievalCaller: "mcp-http-server-client",
+      }));
     return {
-      ...headers,
-      ...buildAgentContextHeaders(diagnosticAgentId(input.serverId, input.session)),
+      ...resolution.headers,
+      ...(input.viaAgentGateway
+        ? buildAgentContextHeaders(diagnosticAgentId(input.serverId, input.session))
+        : {}),
     };
   } catch (error) {
     if (error instanceof Error && error.message === "MCP_AUTH_REQUIRED") {
@@ -256,80 +241,73 @@ export async function listHttpMcpTools(input: {
   session: AuthSession;
   server: MCPServerConfig & { endpoint: string };
   serverId: string;
+  credentialResolution?: McpCredentialResolution;
 }): Promise<{ tools: MCPToolInfo[]; sessionId?: string }> {
-  const viaAgentGateway = isAgentGatewayEndpoint(input.server);
-  const diagnosticAgent = diagnosticAgentId(input.serverId, input.session);
-  const diagnosticTuples = viaAgentGateway
-    ? await grantDiagnosticAgentAccess(input.serverId, diagnosticAgent, input.session)
-    : [];
-
-  try {
-    const headers = await buildMcpRequestHeaders({
-      request: input.request,
-      session: input.session,
-      server: input.server,
-      viaAgentGateway,
-      serverId: input.serverId,
-    });
-
-    const first = await mcpJsonRpc({
-      endpoint: input.server.endpoint,
-      headers,
-      payload: {
-        jsonrpc: "2.0",
-        id: `tools-list-${Date.now()}`,
-        method: "tools/list",
-        params: {},
-      },
-      timeoutMs: 5_000,
-    });
-    if (first.ok) {
-      const tools = extractTools(first.payload);
-      if (tools) return { tools, sessionId: first.sessionId };
-    }
-
-    const initialized = await mcpJsonRpc({
-      endpoint: input.server.endpoint,
-      headers,
-      payload: {
-        jsonrpc: "2.0",
-        id: `initialize-${Date.now()}`,
-        method: "initialize",
-        params: {
-          protocolVersion: "2024-11-05",
-          capabilities: {},
-          clientInfo: { name: "caipe-ui", version: "0.5.16" },
-        },
-      },
-      timeoutMs: 5_000,
-    });
-    if (!initialized.ok || !initialized.sessionId) {
-      throw new ApiError(`MCP initialize failed with HTTP ${initialized.status}`, 502, "MCP_INIT_FAILED");
-    }
-
-    const listed = await mcpJsonRpc({
-      endpoint: input.server.endpoint,
-      headers,
-      sessionId: initialized.sessionId,
-      payload: {
-        jsonrpc: "2.0",
-        id: `tools-list-${Date.now()}`,
-        method: "tools/list",
-        params: {},
-      },
-      timeoutMs: 5_000,
-    });
-    if (!listed.ok) {
-      throw new ApiError(`MCP tools/list failed with HTTP ${listed.status}`, 502, "MCP_LIST_FAILED");
-    }
-    const tools = extractTools(listed.payload);
-    if (!tools) {
-      throw new ApiError("MCP tools/list returned an unexpected payload", 502, "MCP_LIST_INVALID");
-    }
-    return { tools, sessionId: initialized.sessionId };
-  } finally {
-    await revokeDiagnosticAgentAccess(diagnosticTuples, "mcp-http-server-client");
+  const agentGatewayManaged = isAgentGatewayEndpoint(input.server);
+  const endpoint = input.server.endpoint.trim();
+  if (agentGatewayManaged && !isAgentGatewayRouteEndpoint(endpoint)) {
+    throw new ApiError(
+      "AgentGateway-managed MCP server is missing its Gateway route",
+      502,
+      "MCP_GATEWAY_ROUTE_MISSING",
+    );
   }
+  const headers = await buildMcpRequestHeaders({
+    request: input.request,
+    session: input.session,
+    server: input.server,
+    viaAgentGateway: agentGatewayManaged,
+    serverId: input.serverId,
+    credentialResolution: input.credentialResolution,
+  });
+
+  const initialize = () => mcpJsonRpc({
+    endpoint,
+    headers,
+    payload: {
+      jsonrpc: "2.0",
+      id: `initialize-${Date.now()}`,
+      method: "initialize",
+      params: {
+        protocolVersion: "2024-11-05",
+        capabilities: {},
+        clientInfo: { name: "caipe-ui", version: "0.5.16" },
+      },
+    },
+    timeoutMs: 5_000,
+  });
+  let initialized = await initialize();
+  if (agentGatewayManaged) {
+    for (const delayMs of AGENT_GATEWAY_ROUTE_RETRY_DELAYS_MS) {
+      if (initialized.status !== 404) break;
+      await wait(delayMs);
+      initialized = await initialize();
+    }
+  }
+  if (!initialized.ok || !initialized.sessionId) {
+    throw new ApiError(`MCP initialize failed with HTTP ${initialized.status}`, 502, "MCP_INIT_FAILED");
+  }
+
+  const listed = await mcpJsonRpc({
+    endpoint,
+    headers,
+    sessionId: initialized.sessionId,
+    payload: {
+      jsonrpc: "2.0",
+      id: `tools-list-${Date.now()}`,
+      method: "tools/list",
+      params: {},
+    },
+    timeoutMs: 5_000,
+  });
+  if (!listed.ok) {
+    throw new ApiError(`MCP tools/list failed with HTTP ${listed.status}`, 502, "MCP_LIST_FAILED");
+  }
+  const tools = extractTools(listed.payload);
+  if (!tools) {
+    throw new ApiError("MCP tools/list returned an unexpected payload", 502, "MCP_LIST_INVALID");
+  }
+  return { tools, sessionId: initialized.sessionId };
 }
 
 export async function listDirectHttpMcpTools(input: {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.5.68.dev7"
+version = "0.5.68.dev8"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Make managed MCP connection checks exercise the saved AgentGateway route instead of probing an untrusted or direct upstream URL.

- resolves credentials for the saved server and forwards them through AgentGateway
- retries newly registered routes while AgentGateway reconciles configuration
- supports connection tests for read-only managed servers
- moves the global repair operation to the admin settings surface
- keeps fixtures and behavior provider-neutral

Sanitized upstream port of cisco-eti/ai-platform-engineering-mirror#468.

Validation:

- 72 focused Jest tests passed
- ESLint passed for all changed TypeScript files

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable.

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
