### PR TITLE
fix(helm): support bridge image pull secrets

### DIFF
--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -124,6 +124,18 @@ jobs:
           --set openfga-authz-bridge.tokenValidation.audiences[0]=agentgateway \
           --set openfga-authz-bridge.tokenValidation.audiences[1]=caipe-platform
 
+    - name: Test OpenFGA bridge private registry credentials
+      run: |
+        cd charts/ai-platform-engineering
+        rendered=$(helm template test-bridge-pull-secret . \
+          --set openfgaAuthzBridge.enabled=true \
+          --set 'openfga-authz-bridge.imagePullSecrets[0].name=example-registry-pull' \
+          --show-only charts/openfga-authz-bridge/templates/deployment.yaml)
+        echo "$rendered" | grep -q 'imagePullSecrets:' \
+          || { echo "ERROR: bridge imagePullSecrets block was not rendered" >&2; exit 1; }
+        echo "$rendered" | grep -q 'name: example-registry-pull' \
+          || { echo "ERROR: bridge pull secret name was not rendered" >&2; exit 1; }
+
     - name: Test ai-platform-engineering installation (dry-run) - AgentGateway static routing (CRD-free, default)
       run: |
         cd charts/ai-platform-engineering

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ include "openfga-authz-bridge.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/values.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/values.yaml
@@ -5,6 +5,8 @@ image:
   tag: ""
   pullPolicy: IfNotPresent
 
+imagePullSecrets: []
+
 nameOverride: ""
 fullnameOverride: ""
 

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -1502,6 +1502,7 @@ openfga-authz-bridge:
     pullPolicy: IfNotPresent
   # Must match caipe-ui.config.CAIPE_ORG_KEY.
   organizationKey: caipe
+  imagePullSecrets: []
   openfga:
     httpUrl: ""
     storeName: caipe-openfga


### PR DESCRIPTION
# Description

Allow the OpenFGA authorization bridge chart to pull images from registries that require Kubernetes image pull secrets.

- adds an `imagePullSecrets` value to the bridge subchart
- renders the configured secrets in the bridge Deployment
- passes the value through the umbrella chart
- exercises the value in the chart-test workflow with a neutral example secret

Sanitized upstream port of cisco-eti/ai-platform-engineering-mirror#464.

Validation:

- bridge subchart `helm lint` passed
- `helm template` rendered the configured pull secret

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

This branch uses the repository's `prebuild/` convention for image-building CI. Maintainers can add `helm-prerelease` if a pre-release chart is desired.

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
