### PR TITLE
fix(ci): remove unused Helm publish app token

### DIFF
--- a/.github/workflows/ci-helm.yml
+++ b/.github/workflows/ci-helm.yml
@@ -145,16 +145,6 @@ jobs:
         with:
           version: v3.14.0
 
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-packages: write
-
       - name: Login to GHCR
         if: steps.detect.outputs.rag-stack-changed == 'true' || steps.detect.outputs.ai-platform-changed == 'true'
         env:


### PR DESCRIPTION
# Description

Remove the unused GitHub App token-generation step from the Helm publish workflow. The generated token is never consumed by a later step, so the workflow can use the permissions and credentials it already has without minting an extra installation token.

Sanitized upstream port of cisco-eti/ai-platform-engineering-mirror#412.

Validation:

- patch whitespace validation passed
- full `actionlint` remains blocked by pre-existing workflow-schema and ShellCheck findings outside this change

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; this changes the publishing workflow only.

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
