### PR TITLE
fix(mcp): retry AgentGateway route reconciliation

### DIFF
--- a/ui/src/app/api/mcp-servers/test-tool/__tests__/route.test.ts
+++ b/ui/src/app/api/mcp-servers/test-tool/__tests__/route.test.ts
@@ -212,6 +212,60 @@ describe("POST /api/mcp-servers/test-tool", () => {
     });
   });
 
+  it("retries tool invocation while a new AgentGateway route is reconciling", async () => {
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue({
+        _id: "example-weather",
+        name: "Example Weather",
+        transport: "http",
+        endpoint: "http://agentgateway:4000/mcp/example-weather",
+        source: "agentgateway",
+        enabled: true,
+        credential_sources: [],
+      }),
+    });
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce(
+        new Response("route not found", {
+          status: 404,
+          headers: { "content-type": "text/plain" },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ jsonrpc: "2.0", id: "initialize-2", result: {} }), {
+          status: 200,
+          headers: {
+            "content-type": "application/json",
+            "mcp-session-id": "mcp-session-2",
+          },
+        }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: "tools-call-1",
+            result: { content: [{ type: "text", text: "sunny" }] },
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        ),
+      ) as unknown as typeof fetch;
+
+    const { POST } = await import("../route");
+    const response = await POST(
+      request({ serverId: "example-weather", toolName: "forecast", params: {} }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.success).toBe(true);
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(JSON.parse((global.fetch as jest.Mock).mock.calls[0][1].body).method).toBe("initialize");
+    expect(JSON.parse((global.fetch as jest.Mock).mock.calls[1][1].body).method).toBe("initialize");
+    expect(JSON.parse((global.fetch as jest.Mock).mock.calls[2][1].body).method).toBe("tools/call");
+  });
+
   it("strips an accidental Bearer prefix before forwarding provider credentials through AgentGateway", async () => {
     mockRetrieve.mockResolvedValue({ credential: "Bearer argocd-provider-token" });
     mockGetCollection.mockResolvedValue({

--- a/ui/src/app/api/mcp-servers/test-tool/route.ts
+++ b/ui/src/app/api/mcp-servers/test-tool/route.ts
@@ -25,6 +25,10 @@ import { NextRequest } from "next/server";
 
 const COLLECTION_NAME = "mcp_servers";
 const AGENT_CONTEXT_TTL_SECONDS = 300;
+// AgentGateway routes are reconciled asynchronously after an MCP server is
+// saved. Retry only the transient route-not-found response; authorization and
+// upstream failures must still fail immediately.
+const AGENT_GATEWAY_ROUTE_RETRY_DELAYS_MS = [250, 500, 1_000, 1_500, 2_500] as const;
 
 function readString(value: unknown, field: string): string {
   if (typeof value !== "string" || !value.trim()) {
@@ -178,6 +182,45 @@ async function mcpJsonRpc(input: {
   }
 }
 
+async function initializeMcpSession(input: {
+  endpoint: string;
+  headers: Record<string, string>;
+  viaAgentGateway: boolean;
+}): Promise<{ sessionId: string }> {
+  const initialize = () =>
+    mcpJsonRpc({
+      endpoint: input.endpoint,
+      headers: input.headers,
+      payload: {
+        jsonrpc: "2.0",
+        id: `initialize-${Date.now()}`,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "caipe-ui", version: "0.5.16" },
+        },
+      },
+    });
+
+  let initialized = await initialize();
+  if (input.viaAgentGateway) {
+    for (const delayMs of AGENT_GATEWAY_ROUTE_RETRY_DELAYS_MS) {
+      if (initialized.status !== 404) break;
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+      initialized = await initialize();
+    }
+  }
+  if (!initialized.ok || !initialized.sessionId) {
+    throw new ApiError(
+      `MCP initialize failed with HTTP ${initialized.status}`,
+      502,
+      "MCP_INIT_FAILED",
+    );
+  }
+  return { sessionId: initialized.sessionId };
+}
+
 export const POST = withErrorHandler(async (request: NextRequest) => {
   const { session } = await getAuthFromBearerOrSession(request);
   const body = (await request.json()) as Record<string, unknown>;
@@ -234,23 +277,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       ...buildAgentContextHeaders(diagnosticAgent),
     };
 
-    const initialized = await mcpJsonRpc({
+    const initialized = await initializeMcpSession({
       endpoint: server.endpoint,
       headers,
-      payload: {
-        jsonrpc: "2.0",
-        id: `initialize-${Date.now()}`,
-        method: "initialize",
-        params: {
-          protocolVersion: "2024-11-05",
-          capabilities: {},
-          clientInfo: { name: "caipe-ui", version: "0.5.16" },
-        },
-      },
+      viaAgentGateway,
     });
-    if (!initialized.ok || !initialized.sessionId) {
-      throw new ApiError(`MCP initialize failed with HTTP ${initialized.status}`, 502, "MCP_INIT_FAILED");
-    }
 
     const invoked = await mcpJsonRpc({
       endpoint: server.endpoint,


### PR DESCRIPTION
# Description

Saved MCP servers are registered with AgentGateway asynchronously. A tool test can run before the new Gateway route is installed and receive a transient HTTP 404 even though the server was saved successfully.

Retry MCP initialization only when an AgentGateway-managed endpoint returns 404, using bounded backoff. Other HTTP failures, including authorization and upstream errors, continue to fail immediately.

This is the upstream-compatible product fix adapted from cisco-eti/ai-platform-engineering-mirror#473. Fork-specific live regression infrastructure is intentionally excluded.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

No chart changes.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in code
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing relevant tests pass

## Validation

- `npm test -- --runInBand src/app/api/mcp-servers/test-tool/__tests__/route.test.ts` (5/5)
- `npx tsc --noEmit`
- `npm run lint`
- `npm run build`
- `git diff --check`