### PR TITLE
feat(ui): standardize searchable agent pickers

### DIFF
--- a/.github/workflows/prebuild-caipe-ui.yml
+++ b/.github/workflows/prebuild-caipe-ui.yml
@@ -90,6 +90,7 @@ jobs:
     if: |
       needs.determine-changes.outputs.should_build == 'true' &&
       startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      (github.event_name == 'workflow_call' || github.event.pull_request.head.repo.full_name == github.repository) &&
       github.event.action != 'closed'
     permissions:
       contents: write
@@ -241,6 +242,7 @@ jobs:
       needs.determine-changes.result == 'success' &&
       needs.determine-changes.outputs.should_build == 'true' &&
       startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
+      (github.event_name == 'workflow_call' || github.event.pull_request.head.repo.full_name == github.repository) &&
       github.event.action != 'closed'
     permissions:
       contents: write

--- a/ui/e2e/rbac/access-explorer.spec.ts
+++ b/ui/e2e/rbac/access-explorer.spec.ts
@@ -412,6 +412,11 @@ test.describe("mocked Access Explorer browser regression", () => {
     await expect(page.getByTestId("access-explorer-search-stage")).toHaveCount(0);
     await expect(page.getByTestId("access-explorer-header")).toBeVisible();
     await expect(page.getByTestId("feature-check-panel")).toBeVisible();
+    const featureAgentPicker = page.getByRole("button", { name: "Feature check agent" });
+    await featureAgentPicker.click();
+    await page.getByRole("textbox", { name: "Search reachable agents..." }).fill("source");
+    await page.getByRole("option", { name: "Source Control Agent" }).click();
+    await expect(featureAgentPicker).toContainText("Source Control Agent");
     await expect(page.getByText("Example User can perform this feature path.")).toBeVisible();
     await expect(page.getByText("Actor can invoke agent")).toBeVisible();
     await expect(page.getByText("Agent can call MCP/tool")).toBeVisible();

--- a/ui/e2e/rbac/dynamic-agents-conversations-superadmin.spec.ts
+++ b/ui/e2e/rbac/dynamic-agents-conversations-superadmin.spec.ts
@@ -16,7 +16,7 @@ const adminSession = {
   canViewAdmin: true,
 };
 
-const agents = [
+const firstPageAgents = [
   {
     _id: "agent-incident",
     name: "Incident Commander",
@@ -29,11 +29,20 @@ const agents = [
       },
     },
   },
+  ...Array.from({ length: 99 }, (_, index) => ({
+    _id: `agent-example-${index + 1}`,
+    name: `Example Agent ${index + 1}`,
+  })),
+];
+
+const secondPageAgents = [
   {
     _id: "agent-finops",
     name: "FinOps Analyst",
   },
 ];
+
+const agents = [...firstPageAgents, ...secondPageAgents];
 
 const conversations = [
   {
@@ -100,12 +109,18 @@ function paginated(items: unknown[], total = items.length, page = 1, pageSize = 
 
 function installConversationRoutes(options: {
   denyConversations?: boolean;
+  onAgentRequest?: (url: URL) => void;
   onConversationRequest?: (url: URL) => void;
   onDeleteRequest?: (conversationId: string) => void;
 } = {}): MockRouteHandler {
   return async ({ route, path, method, url }) => {
     if (path === "/api/dynamic-agents" && method === "GET") {
-      await fulfillJson(route, paginated(agents, agents.length, 1, 100));
+      options.onAgentRequest?.(url);
+      const page = Number(url.searchParams.get("page") ?? "1");
+      await fulfillJson(
+        route,
+        paginated(page === 1 ? firstPageAgents : secondPageAgents, agents.length, page, 100),
+      );
       return true;
     }
 
@@ -198,10 +213,10 @@ test.describe("mocked RBAC Dynamic Agents workspace", () => {
     await expect(page.getByText("3 conversations found")).toBeVisible();
 
     await expect(page.getByText("Slack incident bridge")).toBeVisible();
-    await expect(page.getByText("Incident Commander")).toHaveCount(3);
+    await expect(page.getByText("Incident Commander")).toHaveCount(2);
     await expect(page.getByText("Slack", { exact: true })).toBeVisible();
     await expect(page.getByText("Web cost review")).toBeVisible();
-    await expect(page.getByText("FinOps Analyst")).toHaveCount(2);
+    await expect(page.getByText("FinOps Analyst")).toHaveCount(1);
     await expect(page.getByText("Archived audit trail")).toBeVisible();
     await expect(page.getByText("Archived", { exact: true })).toBeVisible();
     await expect(page.getByText("Showing 1–3 of 3")).toBeVisible();
@@ -288,6 +303,7 @@ test.describe("mocked RBAC Dynamic Agents workspace", () => {
   test("search, agent filter, refresh, and page size use the Conversations API parameters", async ({
     page,
   }) => {
+    const agentRequests: URL[] = [];
     const conversationRequests: URL[] = [];
 
     await installMockedRbacApp(page, {
@@ -296,6 +312,7 @@ test.describe("mocked RBAC Dynamic Agents workspace", () => {
       gates: { audit_logs: false, dynamic_agent_conversations: true },
       handlers: [
         installConversationRoutes({
+          onAgentRequest: (url) => agentRequests.push(new URL(url.toString())),
           onConversationRequest: (url) => conversationRequests.push(new URL(url.toString())),
         }),
       ],
@@ -310,9 +327,15 @@ test.describe("mocked RBAC Dynamic Agents workspace", () => {
     await expect(page.getByText("Web cost review")).toBeVisible();
     await expect(page.getByText("Slack incident bridge")).toHaveCount(0);
 
-    const agentSelect = page.getByLabel("Filter conversations by agent");
-    await agentSelect.selectOption("agent-finops");
+    const agentPicker = page.getByRole("button", { name: "Filter conversations by agent" });
+    await agentPicker.click();
+    await page.getByRole("textbox", { name: "Search agents..." }).fill("finops");
+    await page.getByRole("option", { name: /FinOps Analyst/ }).click();
     await expect(page.getByText("1 conversation found")).toBeVisible();
+    await expect(agentPicker).toContainText("FinOps Analyst");
+    await expect
+      .poll(() => agentRequests.some((request) => request.searchParams.get("page") === "2"))
+      .toBe(true);
 
     const rowsSelect = page.getByLabel("Rows per page");
     await rowsSelect.selectOption("20");
@@ -359,9 +382,18 @@ test.describe("mocked RBAC Dynamic Agents workspace", () => {
       session: adminSession,
       gates: { audit_logs: false, dynamic_agent_conversations: true },
       handlers: [
-        async ({ route, path, method }) => {
+        async ({ route, path, method, url }) => {
           if (path === "/api/dynamic-agents" && method === "GET") {
-            await fulfillJson(route, paginated(agents, agents.length, 1, 100));
+            const requestPage = Number(url.searchParams.get("page") ?? "1");
+            await fulfillJson(
+              route,
+              paginated(
+                requestPage === 1 ? firstPageAgents : secondPageAgents,
+                agents.length,
+                requestPage,
+                100,
+              ),
+            );
             return true;
           }
           if (path === "/api/dynamic-agents/conversations" && method === "GET") {

--- a/ui/e2e/rbac/webex-configure-spaces.spec.ts
+++ b/ui/e2e/rbac/webex-configure-spaces.spec.ts
@@ -584,17 +584,30 @@ test.describe("mocked Webex Configure spaces UI", () => {
     expect(JSON.stringify(state.onboardingRequests)).not.toContain("direct-sri");
   });
 
-  test("loads page 2 agents in the Webex 1:1 routing picker", async ({
+  test("searches page 2 agents in the Webex 1:1 routing picker", async ({
     page,
   }) => {
     const state = await installWebexConfigureApp(page);
     await gotoConfigureSpaces(page);
 
     await page.getByRole("tab", { name: "1:1 Messages" }).click();
-    const selector = page.getByRole("combobox", {
+    await page.getByRole("checkbox", {
+      name: "Allow direct messages for user@example.com",
+    }).check();
+    const picker = page.getByRole("button", {
       name: "Agent for user@example.com",
     });
-    await expect(selector).toContainText("Personal Assistant");
+    await picker.click();
+    await page.getByRole("textbox", { name: "Search agents..." }).fill(
+      "personal assistant",
+    );
+    const matchingOptions = page.getByRole("listbox", {
+      name: "Agent for user@example.com",
+    }).getByRole("option");
+    await expect(matchingOptions).toHaveCount(1);
+    await expect(matchingOptions).toContainText("Personal Assistant");
+    await matchingOptions.click();
+    await expect(picker).toContainText("Personal Assistant");
     await expect
       .poll(() =>
         state.dynamicAgentRequests.some(

--- a/ui/e2e/rbac/webex-configure-spaces.spec.ts
+++ b/ui/e2e/rbac/webex-configure-spaces.spec.ts
@@ -30,9 +30,17 @@ const teams = [
   { _id: "team-ops", slug: "ops", name: "Operations Team" },
 ];
 
-const agents = [
+const firstPageAgents = [
   { _id: "agent-sre", name: "SRE Agent" },
   { _id: "agent-kb", name: "KB Agent" },
+  ...Array.from({ length: 98 }, (_, index) => ({
+    _id: `agent-example-${index + 1}`,
+    name: `Example Agent ${index + 1}`,
+  })),
+];
+
+const secondPageAgents = [
+  { _id: "agent-personal-assistant", name: "Personal Assistant" },
 ];
 
 const webexBot = { id: "primary", name: "Primary bot", available: true };
@@ -50,6 +58,7 @@ type WebexConfigureState = {
   platformConfigPatches: unknown[];
   discoveryRequests: URL[];
   onboardingRequests: unknown[];
+  dynamicAgentRequests: URL[];
   configuredSpaces: Array<{
     bot_id: string;
     workspace_id: string;
@@ -106,6 +115,7 @@ function defaultState(): WebexConfigureState {
     platformConfigPatches: [],
     discoveryRequests: [],
     onboardingRequests: [],
+    dynamicAgentRequests: [],
     configuredSpaces: [
       {
         bot_id: webexBot.id,
@@ -230,7 +240,44 @@ function webexConfigureHandler(state: WebexConfigureState): MockRouteHandler {
     }
 
     if (path === "/api/dynamic-agents" && method === "GET") {
-      await fulfillJson(route, { success: true, data: { items: agents } });
+      state.dynamicAgentRequests.push(url);
+      const page = Number(url.searchParams.get("page") ?? "1");
+      await fulfillJson(route, {
+        success: true,
+        data: {
+          items: page === 1 ? firstPageAgents : secondPageAgents,
+          total: firstPageAgents.length + secondPageAgents.length,
+          page,
+          page_size: 100,
+          has_more: page === 1,
+        },
+      });
+      return true;
+    }
+
+    if (path === "/api/admin/webex/direct-users" && method === "GET") {
+      await fulfillJson(route, {
+        success: true,
+        data: {
+          users: [
+            {
+              keycloak_user_id: "user-1",
+              email: "user@example.com",
+              display_name: "Example User",
+              webex_user_id: null,
+              enabled: false,
+              configured: false,
+              inherited: false,
+              state: "not_allowed",
+              expected_webex_email: "user@example.com",
+              agent_id: "",
+            },
+          ],
+          bot_id: webexBot.id,
+          dm_access_mode: "allowlist",
+          default_agent_id: null,
+        },
+      });
       return true;
     }
 
@@ -535,5 +582,28 @@ test.describe("mocked Webex Configure spaces UI", () => {
       ]),
     );
     expect(JSON.stringify(state.onboardingRequests)).not.toContain("direct-sri");
+  });
+
+  test("loads page 2 agents in the Webex 1:1 routing picker", async ({
+    page,
+  }) => {
+    const state = await installWebexConfigureApp(page);
+    await gotoConfigureSpaces(page);
+
+    await page.getByRole("tab", { name: "1:1 Messages" }).click();
+    const selector = page.getByRole("combobox", {
+      name: "Agent for user@example.com",
+    });
+    await expect(selector).toContainText("Personal Assistant");
+    await expect
+      .poll(() =>
+        state.dynamicAgentRequests.some(
+          (request) =>
+            request.searchParams.get("enabled_only") === "true" &&
+            request.searchParams.get("page") === "2" &&
+            request.searchParams.get("page_size") === "100",
+        ),
+      )
+      .toBe(true);
   });
 });

--- a/ui/src/components/admin/rebac/SlackVictoropsAgentSetting.tsx
+++ b/ui/src/components/admin/rebac/SlackVictoropsAgentSetting.tsx
@@ -13,6 +13,7 @@ import { SaveButton } from "@/components/admin/shared/SaveButton";
 import { AgentPicker,type AgentPickerOption } from "@/components/ui/agent-picker";
 import { Label } from "@/components/ui/label";
 import { useToast } from "@/components/ui/toast";
+import { loadAllDynamicAgents } from "@/lib/dynamic-agent-list";
 
 interface DynamicAgentOption {
   _id: string;
@@ -33,23 +34,8 @@ export function SlackVictoropsAgentSetting({ disabled = false }: { disabled?: bo
   useEffect(() => {
     let cancelled = false;
     (async () => {
-      const loadAllAgents = async (): Promise<DynamicAgentOption[]> => {
-        const items: DynamicAgentOption[] = [];
-        let page = 1;
-        let hasMore = true;
-        while (hasMore) {
-          const agentsRes = await fetch(`/api/dynamic-agents?enabled_only=true&page=${page}&page_size=100`)
-            .then((r) => r.json())
-            .catch(() => ({ data: { items: [] } }));
-          const pageItems: DynamicAgentOption[] = agentsRes?.data?.items ?? agentsRes?.items ?? [];
-          items.push(...pageItems);
-          hasMore = Boolean(agentsRes?.data?.has_more ?? agentsRes?.has_more);
-          page += 1;
-        }
-        return items;
-      };
       const [items, configRes] = await Promise.all([
-        loadAllAgents(),
+        loadAllDynamicAgents<DynamicAgentOption>({ enabledOnly: true }).catch(() => []),
         fetch("/api/admin/platform-config").then((r) => r.json()).catch(() => ({ success: false })),
       ]);
       if (cancelled) return;

--- a/ui/src/components/admin/rebac/WebexDirectUsersPanel.tsx
+++ b/ui/src/components/admin/rebac/WebexDirectUsersPanel.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button";
 import { CAIPESpinner } from "@/components/ui/caipe-spinner";
 import { Input } from "@/components/ui/input";
 import { useToast } from "@/components/ui/toast";
+import { loadAllDynamicAgents } from "@/lib/dynamic-agent-list";
 import type { DynamicAgentOption } from "./connector-admin-adapter";
 
 type DmAccessMode = "disabled" | "allowlist" | "all_users";
@@ -56,31 +57,6 @@ async function responseError(response: Response, fallback: string): Promise<stri
   }
 }
 
-async function loadEnabledAgents(): Promise<DynamicAgentOption[]> {
-  const items: DynamicAgentOption[] = [];
-  let page = 1;
-  let hasMore = true;
-
-  while (hasMore) {
-    const response = await fetch(
-      `/api/dynamic-agents?enabled_only=true&page=${page}&page_size=100`,
-      { cache: "no-store" },
-    );
-    if (!response.ok) {
-      throw new Error(await responseError(response, "Failed to load agents"));
-    }
-    const data = apiData<{
-      items: DynamicAgentOption[];
-      has_more?: boolean;
-    }>(await response.json());
-    items.push(...(data.items ?? []));
-    hasMore = Boolean(data.has_more);
-    page += 1;
-  }
-
-  return items;
-}
-
 export function WebexDirectUsersPanel({ disabled = false }: { disabled?: boolean }) {
   const { toast } = useToast();
   const [bots, setBots] = useState<BotOption[]>([]);
@@ -97,7 +73,7 @@ export function WebexDirectUsersPanel({ disabled = false }: { disabled?: boolean
     let active = true;
     void Promise.all([
       fetch("/api/admin/webex/bots", { cache: "no-store" }),
-      loadEnabledAgents(),
+      loadAllDynamicAgents<DynamicAgentOption>({ enabledOnly: true }),
     ]).then(async ([botsResponse, nextAgents]) => {
       if (!botsResponse.ok) throw new Error(await responseError(botsResponse, "Failed to load Webex bots"));
       const botData = apiData<{ bots: BotOption[] }>(await botsResponse.json());

--- a/ui/src/components/admin/rebac/WebexDirectUsersPanel.tsx
+++ b/ui/src/components/admin/rebac/WebexDirectUsersPanel.tsx
@@ -3,6 +3,7 @@
 import { Loader2, RefreshCw, RotateCcw, Save } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
+import { AgentPicker, type AgentPickerOption } from "@/components/ui/agent-picker";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CAIPESpinner } from "@/components/ui/caipe-spinner";
@@ -147,6 +148,14 @@ export function WebexDirectUsersPanel({ disabled = false }: { disabled?: boolean
     if (!query) return rows;
     return rows.filter((row) => `${row.display_name} ${row.email}`.toLowerCase().includes(query));
   }, [rows, search]);
+
+  const agentOptions = useMemo(
+    () => agents.map<AgentPickerOption>((agent) => ({
+      value: agent._id,
+      label: agent.name || agent._id,
+    })),
+    [agents],
+  );
 
   const updateRow = (userId: string, patch: Partial<DirectUserRow>) => {
     setRows((current) => current.map((row) => row.keycloak_user_id === userId ? { ...row, ...patch } : row));
@@ -312,16 +321,16 @@ export function WebexDirectUsersPanel({ disabled = false }: { disabled?: boolean
                         <div className="mt-1 text-xs text-muted-foreground">{row.webex_user_id ? "Linked" : "Not linked yet"}</div>
                       </td>
                       <td className="px-3 py-2">
-                        <select
-                          className="h-8 min-w-56 rounded-md border bg-background px-2 text-sm"
+                        <AgentPicker
+                          ariaLabel={`Agent for ${row.email}`}
+                          triggerClassName="h-8 min-w-56 px-2 py-1 text-sm"
                           value={row.agent_id}
-                          onChange={(event) => updateRow(row.keycloak_user_id, { agent_id: event.target.value })}
+                          onChange={(agentId) => updateRow(row.keycloak_user_id, { agent_id: agentId })}
                           disabled={disabled || modeDisabled || saving || (!row.enabled && data?.dm_access_mode === "allowlist")}
-                          aria-label={`Agent for ${row.email}`}
-                        >
-                          <option value="">{data?.dm_access_mode === "all_users" ? "Deployment default" : "Select an agent"}</option>
-                          {agents.map((agent) => <option key={agent._id} value={agent._id}>{agent.name || agent._id}</option>)}
-                        </select>
+                          placeholder={data?.dm_access_mode === "all_users" ? "Deployment default" : "Select an agent"}
+                          searchPlaceholder="Search agents..."
+                          options={agentOptions}
+                        />
                       </td>
                       <td className="px-3 py-2">
                         <Badge variant={row.state === "denied" || row.state === "disabled" ? "outline" : "secondary"}>

--- a/ui/src/components/admin/rebac/WebexDirectUsersPanel.tsx
+++ b/ui/src/components/admin/rebac/WebexDirectUsersPanel.tsx
@@ -55,6 +55,31 @@ async function responseError(response: Response, fallback: string): Promise<stri
   }
 }
 
+async function loadEnabledAgents(): Promise<DynamicAgentOption[]> {
+  const items: DynamicAgentOption[] = [];
+  let page = 1;
+  let hasMore = true;
+
+  while (hasMore) {
+    const response = await fetch(
+      `/api/dynamic-agents?enabled_only=true&page=${page}&page_size=100`,
+      { cache: "no-store" },
+    );
+    if (!response.ok) {
+      throw new Error(await responseError(response, "Failed to load agents"));
+    }
+    const data = apiData<{
+      items: DynamicAgentOption[];
+      has_more?: boolean;
+    }>(await response.json());
+    items.push(...(data.items ?? []));
+    hasMore = Boolean(data.has_more);
+    page += 1;
+  }
+
+  return items;
+}
+
 export function WebexDirectUsersPanel({ disabled = false }: { disabled?: boolean }) {
   const { toast } = useToast();
   const [bots, setBots] = useState<BotOption[]>([]);
@@ -71,12 +96,10 @@ export function WebexDirectUsersPanel({ disabled = false }: { disabled?: boolean
     let active = true;
     void Promise.all([
       fetch("/api/admin/webex/bots", { cache: "no-store" }),
-      fetch("/api/dynamic-agents?enabled_only=true", { cache: "no-store" }),
-    ]).then(async ([botsResponse, agentsResponse]) => {
+      loadEnabledAgents(),
+    ]).then(async ([botsResponse, nextAgents]) => {
       if (!botsResponse.ok) throw new Error(await responseError(botsResponse, "Failed to load Webex bots"));
-      if (!agentsResponse.ok) throw new Error(await responseError(agentsResponse, "Failed to load agents"));
       const botData = apiData<{ bots: BotOption[] }>(await botsResponse.json());
-      const agentData = apiData<{ items: DynamicAgentOption[] }>(await agentsResponse.json());
       if (!active) return;
       const nextBots = botData.bots ?? [];
       setBots(nextBots);
@@ -85,7 +108,7 @@ export function WebexDirectUsersPanel({ disabled = false }: { disabled?: boolean
           ? current
           : nextBots.find((bot) => bot.available)?.id ?? "",
       );
-      setAgents(agentData.items ?? []);
+      setAgents(nextAgents);
     }).catch((reason) => {
       if (active) {
         setError(reason instanceof Error ? reason.message : "Failed to load 1:1 settings");

--- a/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
@@ -783,6 +783,44 @@ it("onboards deployment users independently for the bot selected above the table
   })).toBe(true));
 });
 
+it("loads every enabled-agent page for 1:1 routing", async () => {
+  const baseFetch = fetchMock.getMockImplementation();
+  const firstPage = Array.from({ length: 100 }, (_, index) => ({
+    _id: `agent-${index + 1}`,
+    name: `Agent ${index + 1}`,
+  }));
+  fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+    const parsed = new URL(String(url), "http://localhost");
+    if (parsed.pathname === "/api/dynamic-agents") {
+      const page = Number(parsed.searchParams.get("page") ?? "1");
+      return response({
+        data: page === 1
+          ? { items: firstPage, has_more: true }
+          : {
+              items: [{ _id: "agent-personal-assistant", name: "Personal Assistant" }],
+              has_more: false,
+            },
+      });
+    }
+    return baseFetch?.(url, init) ?? response({});
+  });
+
+  render(<WebexSpaceRebacPanel />);
+
+  fireEvent.click(await screen.findByRole("tab", { name: "1:1 Messages" }));
+  const agentSelector = await screen.findByRole("combobox", {
+    name: "Agent for user@example.com",
+  });
+
+  await waitFor(() => {
+    expect(agentSelector).toHaveTextContent("Personal Assistant");
+  });
+  expect(fetchMock).toHaveBeenCalledWith(
+    "/api/dynamic-agents?enabled_only=true&page=2&page_size=100",
+    { cache: "no-store" },
+  );
+});
+
 it("shows inherited defaults and allows overrides in all-users mode", async () => {
   const baseFetch = fetchMock.getMockImplementation();
   fetchMock.mockImplementation(async (url: string, init?: RequestInit) => {

--- a/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
+++ b/ui/src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 
 const mockToast = jest.fn();
 jest.mock("@/components/ui/toast", () => ({
@@ -758,9 +758,7 @@ it("onboards deployment users independently for the bot selected above the table
   expect(screen.queryByRole("combobox", { name: "Webex bot for user@example.com" })).not.toBeInTheDocument();
 
   fireEvent.click(screen.getByRole("checkbox", { name: "Allow direct messages for user@example.com" }));
-  fireEvent.change(screen.getByRole("combobox", { name: "Agent for user@example.com" }), {
-    target: { value: "incident-agent" },
-  });
+  await pickAgent("Agent for user@example.com", "incident-agent");
   fireEvent.click(screen.getByRole("button", { name: "Save 1:1 access for user@example.com" }));
 
   await waitFor(() => {
@@ -783,7 +781,7 @@ it("onboards deployment users independently for the bot selected above the table
   })).toBe(true));
 });
 
-it("loads every enabled-agent page for 1:1 routing", async () => {
+it("loads every enabled-agent page and searches 1:1 routing options", async () => {
   const baseFetch = fetchMock.getMockImplementation();
   const firstPage = Array.from({ length: 100 }, (_, index) => ({
     _id: `agent-${index + 1}`,
@@ -808,13 +806,26 @@ it("loads every enabled-agent page for 1:1 routing", async () => {
   render(<WebexSpaceRebacPanel />);
 
   fireEvent.click(await screen.findByRole("tab", { name: "1:1 Messages" }));
-  const agentSelector = await screen.findByRole("combobox", {
+  fireEvent.click(await screen.findByRole("checkbox", {
+    name: "Allow direct messages for user@example.com",
+  }));
+  const agentPicker = await screen.findByRole("button", {
     name: "Agent for user@example.com",
   });
 
-  await waitFor(() => {
-    expect(agentSelector).toHaveTextContent("Personal Assistant");
+  fireEvent.click(agentPicker);
+  const searchInput = await screen.findByRole("textbox", {
+    name: "Search agents...",
   });
+  fireEvent.change(searchInput, { target: { value: "personal assistant" } });
+  const listbox = screen.getByRole("listbox", {
+    name: "Agent for user@example.com",
+  });
+  const matchingOptions = within(listbox).getAllByRole("option");
+  expect(matchingOptions).toHaveLength(1);
+  expect(matchingOptions[0]).toHaveTextContent("Personal Assistant");
+  fireEvent.click(matchingOptions[0]);
+  expect(agentPicker).toHaveTextContent("Personal Assistant");
   expect(fetchMock).toHaveBeenCalledWith(
     "/api/dynamic-agents?enabled_only=true&page=2&page_size=100",
     { cache: "no-store" },
@@ -868,8 +879,8 @@ it("shows inherited defaults and allows overrides in all-users mode", async () =
     screen.getByLabelText("Allow direct messages for user@example.com"),
   ).toBeChecked();
   expect(screen.queryByRole("combobox", { name: "Team for user@example.com" })).not.toBeInTheDocument();
-  expect(screen.getByRole("combobox", { name: "Agent for user@example.com" })).toHaveValue(
-    "fallback-agent",
+  expect(screen.getByRole("button", { name: "Agent for user@example.com" })).toHaveTextContent(
+    "Fallback Agent",
   );
   expect(screen.getByText("inherited")).toBeInTheDocument();
   expect(

--- a/ui/src/components/admin/security/AccessExplorerTab.tsx
+++ b/ui/src/components/admin/security/AccessExplorerTab.tsx
@@ -48,6 +48,7 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { CAIPESpinner } from "@/components/ui/caipe-spinner";
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { AgentPicker } from "@/components/ui/agent-picker";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { cn } from "@/lib/utils";
 import { RebacGraphFilters, subjectPrefix, type RebacGraphUserOption } from "../rebac/RebacGraphFilters";
@@ -1219,22 +1220,22 @@ function FeatureCheckPanel({
           </select>
         </FeatureSelectField>
         <FeatureSelectField label="Agent">
-          <select
-            className="h-10 w-full rounded-md border bg-background px-3 text-sm disabled:opacity-60"
+          <AgentPicker
+            ariaLabel="Feature check agent"
             value={selectedAgentRef}
-            onChange={(event) => onAgentChange(event.target.value)}
+            onChange={onAgentChange}
+            options={agentOptions.map((option) => ({
+              value: option.id,
+              label: option.label,
+            }))}
             disabled={agentLocked || agentOptions.length === 0}
-          >
-            {agentOptions.length === 0 ? (
-              <option value="">No reachable agents</option>
-            ) : (
-              agentOptions.map((option) => (
-                <option key={option.id} value={option.id}>
-                  {option.label}
-                </option>
-              ))
-            )}
-          </select>
+            placeholder={agentOptions.length === 0 ? "No reachable agents" : "Select an agent"}
+            searchPlaceholder="Search reachable agents..."
+            emptyLabel="No reachable agents match"
+            triggerClassName="h-10"
+            hideIdSuffix
+            allowClear={false}
+          />
         </FeatureSelectField>
         {showResourcePicker && (
           <FeatureSelectField label={activeFeature.targetLabel} className="lg:col-span-3">

--- a/ui/src/components/dynamic-agents/ConversationsTab.tsx
+++ b/ui/src/components/dynamic-agents/ConversationsTab.tsx
@@ -11,7 +11,9 @@ DialogHeader,
 DialogTitle,
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
+import { AgentPicker, type AgentPickerOption } from "@/components/ui/agent-picker";
 import { useToast } from "@/components/ui/toast";
+import { loadAllDynamicAgents } from "@/lib/dynamic-agent-list";
 import type { AgentUIConfig } from "@/types/dynamic-agent";
 import {
 AlertCircle,
@@ -93,23 +95,22 @@ export function ConversationsTab() {
   React.useEffect(() => {
     async function fetchAgents() {
       try {
-        const response = await fetch("/api/dynamic-agents?page_size=100");
-        const data = await response.json();
-        if (data.success && data.data?.items) {
-          const items = data.data.items as AgentInfo[];
-          const agentMap = new Map<string, AgentInfo>();
-          for (const agent of items) {
-            agentMap.set(agent._id, agent);
-          }
-          setAgents(agentMap);
-          setAgentsList(items);
-        }
+        const items = await loadAllDynamicAgents<AgentInfo>();
+        const agentMap = new Map<string, AgentInfo>();
+        for (const agent of items) agentMap.set(agent._id, agent);
+        setAgents(agentMap);
+        setAgentsList(items);
       } catch {
         // Silently fail - we'll just show agent IDs
       }
     }
     fetchAgents();
   }, []);
+
+  const agentOptions = React.useMemo<AgentPickerOption[]>(
+    () => agentsList.map((agent) => ({ value: agent._id, label: agent.name })),
+    [agentsList],
+  );
 
   const fetchConversations = React.useCallback(async () => {
     setLoading(true);
@@ -238,22 +239,19 @@ export function ConversationsTab() {
                 className="pl-10"
               />
             </div>
-            <select
-              aria-label="Filter conversations by agent"
+            <AgentPicker
+              ariaLabel="Filter conversations by agent"
               value={agentFilter}
-              onChange={(e) => {
-                setAgentFilter(e.target.value);
+              onChange={(agentId) => {
+                setAgentFilter(agentId);
                 setPage(1);
               }}
-              className="h-9 text-sm rounded-md border border-input bg-background px-3 py-1 text-foreground"
-            >
-              <option value="">All Agents</option>
-              {agentsList.map((agent) => (
-                <option key={agent._id} value={agent._id}>
-                  {agent.name}
-                </option>
-              ))}
-            </select>
+              options={agentOptions}
+              placeholder="All agents"
+              searchPlaceholder="Search agents..."
+              emptyLabel="No agents match"
+              triggerClassName="h-9 min-w-56 py-1"
+            />
             <Button type="submit" variant="secondary" size="sm">
               Search
             </Button>

--- a/ui/src/components/dynamic-agents/SubagentPicker.tsx
+++ b/ui/src/components/dynamic-agents/SubagentPicker.tsx
@@ -23,7 +23,7 @@ import { AlertCircle,Bot,Globe,Loader2,Trash2,Users } from "lucide-react";
 import React from "react";
 import { AgentAvatar } from "./AgentAvatar";
 
-// Loose shape for items returned by /api/dynamic-agents (the BFF list endpoint).
+// Loose shape for items returned by /api/dynamic-agents/available.
 // We accept LegacyVisibilityType so docs that still carry visibility:"private"
 // (until the migration script rewrites them) can be normalized on read.
 interface RawAgentListItem {
@@ -108,12 +108,11 @@ export function SubagentPicker({ agentId, value, onChange, disabled, parentVisib
     setLoading(true);
     setError(null);
     try {
-      // Use enabled_only=true to filter out disabled agents (important for admins)
-      const response = await fetch("/api/dynamic-agents?enabled_only=true");
+      const response = await fetch("/api/dynamic-agents/available");
       const data = await response.json();
-      if (data.success && data.data?.items) {
+      if (data.success && Array.isArray(data.data)) {
         setAvailableAgents(
-          data.data.items.map((agent: RawAgentListItem) => ({
+          data.data.map((agent: RawAgentListItem) => ({
             id: agent._id,
             name: agent.name,
             description: agent.description,

--- a/ui/src/components/ui/__tests__/agent-picker.test.tsx
+++ b/ui/src/components/ui/__tests__/agent-picker.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen, within } from "@testing-library/react";
+
+import { AgentPicker } from "@/components/ui/agent-picker";
+
+describe("AgentPicker", () => {
+  it("searches by label and selects the matching agent", () => {
+    const onChange = jest.fn();
+    render(
+      <AgentPicker
+        ariaLabel="Example agent"
+        options={[
+          { value: "agent-primary", label: "Primary Agent" },
+          { value: "agent-secondary", label: "Secondary Agent" },
+        ]}
+        value=""
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Example agent" }));
+    fireEvent.change(screen.getByRole("textbox", { name: "Search agents..." }), {
+      target: { value: "secondary" },
+    });
+
+    const listbox = screen.getByRole("listbox", { name: "Example agent" });
+    expect(within(listbox).getAllByRole("option")).toHaveLength(1);
+    fireEvent.click(within(listbox).getByRole("option", { name: /Secondary Agent/ }));
+    expect(onChange).toHaveBeenCalledWith("agent-secondary");
+  });
+
+  it("can require a selection by hiding the clear action", () => {
+    render(
+      <AgentPicker
+        ariaLabel="Required agent"
+        options={[{ value: "agent-primary", label: "Primary Agent" }]}
+        value="agent-primary"
+        onChange={jest.fn()}
+        allowClear={false}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Clear agent selection" })).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/ui/agent-picker.tsx
+++ b/ui/src/components/ui/agent-picker.tsx
@@ -31,6 +31,8 @@ interface AgentPickerProps {
   hideIdSuffix?: boolean;
   /** Value emitted by the clear action. Defaults to an empty selection. */
   clearValue?: string;
+  /** Whether the selected value can be cleared from the trigger. */
+  allowClear?: boolean;
 }
 
 export function AgentPicker({
@@ -47,6 +49,7 @@ export function AgentPicker({
   ariaLabel,
   hideIdSuffix = false,
   clearValue = "",
+  allowClear = true,
 }: AgentPickerProps) {
   const [open, setOpen] = React.useState(false);
   const [query, setQuery] = React.useState("");
@@ -124,7 +127,7 @@ export function AgentPicker({
               <span className="text-muted-foreground">{placeholder}</span>
             )}
           </div>
-          {selected && selected.value !== clearValue && !disabled && (
+          {allowClear && selected && selected.value !== clearValue && !disabled && (
             <X
               role="button"
               aria-label="Clear agent selection"

--- a/ui/src/lib/__tests__/dynamic-agent-list.test.ts
+++ b/ui/src/lib/__tests__/dynamic-agent-list.test.ts
@@ -1,0 +1,67 @@
+import { loadAllDynamicAgents } from "@/lib/dynamic-agent-list";
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe("loadAllDynamicAgents", () => {
+  it("loads and deduplicates every enabled-agent page", async () => {
+    const fetcher = jest
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        data: {
+          items: [
+            { _id: "agent-primary", name: "Primary Agent" },
+            { _id: "agent-shared", name: "Shared Agent" },
+          ],
+          has_more: true,
+        },
+      }))
+      .mockResolvedValueOnce(jsonResponse({
+        success: true,
+        data: {
+          items: [
+            { _id: "agent-shared", name: "Updated Shared Agent" },
+            { _id: "agent-secondary", name: "Secondary Agent" },
+          ],
+          has_more: false,
+        },
+      }));
+
+    await expect(loadAllDynamicAgents({
+      enabledOnly: true,
+      pageSize: 2,
+      fetcher: fetcher as unknown as typeof fetch,
+    })).resolves.toEqual([
+      { _id: "agent-primary", name: "Primary Agent" },
+      { _id: "agent-shared", name: "Updated Shared Agent" },
+      { _id: "agent-secondary", name: "Secondary Agent" },
+    ]);
+
+    expect(fetcher).toHaveBeenNthCalledWith(
+      1,
+      "/api/dynamic-agents?enabled_only=true&page=1&page_size=2",
+      { cache: "no-store" },
+    );
+    expect(fetcher).toHaveBeenNthCalledWith(
+      2,
+      "/api/dynamic-agents?enabled_only=true&page=2&page_size=2",
+      { cache: "no-store" },
+    );
+  });
+
+  it("surfaces the API error from a failed page", async () => {
+    const fetcher = jest.fn().mockResolvedValue(
+      jsonResponse({ error: "Agent catalog unavailable" }, 503),
+    );
+
+    await expect(loadAllDynamicAgents({
+      fetcher: fetcher as unknown as typeof fetch,
+    })).rejects.toThrow("Agent catalog unavailable");
+  });
+});

--- a/ui/src/lib/dynamic-agent-list.ts
+++ b/ui/src/lib/dynamic-agent-list.ts
@@ -1,0 +1,72 @@
+export interface DynamicAgentListItem {
+  _id: string;
+  name?: string;
+}
+
+interface DynamicAgentPage<T extends DynamicAgentListItem> {
+  items?: T[];
+  has_more?: boolean;
+}
+
+interface DynamicAgentPageEnvelope<T extends DynamicAgentListItem> {
+  data?: DynamicAgentPage<T>;
+  items?: T[];
+  has_more?: boolean;
+  error?: string;
+}
+
+interface LoadAllDynamicAgentsOptions {
+  enabledOnly?: boolean;
+  pageSize?: number;
+  cache?: RequestCache;
+  signal?: AbortSignal;
+  fetcher?: typeof fetch;
+}
+
+async function responseError(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { error?: unknown };
+    if (typeof body.error === "string" && body.error.trim()) return body.error;
+  } catch {
+    // Fall back to the HTTP status below when the response is not JSON.
+  }
+  return `Failed to load agents (HTTP ${response.status})`;
+}
+
+/** Load every page from the RBAC-filtered Dynamic Agents list endpoint. */
+export async function loadAllDynamicAgents<
+  T extends DynamicAgentListItem = DynamicAgentListItem,
+>({
+  enabledOnly = false,
+  pageSize = 100,
+  cache = "no-store",
+  signal,
+  fetcher = fetch,
+}: LoadAllDynamicAgentsOptions = {}): Promise<T[]> {
+  const agents = new Map<string, T>();
+  let page = 1;
+  let hasMore = true;
+
+  while (hasMore) {
+    const params = new URLSearchParams();
+    if (enabledOnly) params.set("enabled_only", "true");
+    params.set("page", String(page));
+    params.set("page_size", String(pageSize));
+
+    const init: RequestInit = { cache };
+    if (signal) init.signal = signal;
+
+    const response = await fetcher(`/api/dynamic-agents?${params.toString()}`, init);
+    if (!response.ok) throw new Error(await responseError(response));
+
+    const envelope = (await response.json()) as DynamicAgentPageEnvelope<T>;
+    const payload = envelope.data ?? envelope;
+    const pageItems = payload.items ?? [];
+    for (const agent of pageItems) agents.set(agent._id, agent);
+
+    hasMore = Boolean(payload.has_more);
+    page += 1;
+  }
+
+  return Array.from(agents.values());
+}


### PR DESCRIPTION
# Description

Standardize compact single-agent selection on the shared searchable `AgentPicker` and ensure paginated Dynamic Agent catalogs are loaded completely.

## Root cause

The Webex 1:1 and Conversations screens built picker options from only the first Dynamic Agents API page. Other screens used native or one-off selectors, so search and required-selection behavior were inconsistent.

## What changed

- Add a shared paginated Dynamic Agents loader with page deduplication and API error handling.
- Use it for Webex 1:1 routing, Conversations filtering, and the Slack VictorOps setting.
- Replace the Conversations and Access Explorer native agent selects with the shared searchable picker.
- Add required-selection support to `AgentPicker`.
- Use the complete available-agent endpoint in Workflow Editor and new-agent subagent selection.
- Add unit and mocked Playwright coverage for search, required selections, and agents returned on page 2.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- `npm test -- --runInBand src/lib/__tests__/dynamic-agent-list.test.ts src/components/ui/__tests__/agent-picker.test.tsx src/components/admin/rebac/__tests__/WebexSpaceRebacPanel.test.tsx src/components/admin/security/__tests__/AccessExplorerTab.test.tsx` — 27 passed
- `RUN_RBAC_REGRESSION=1 npx playwright test e2e/rbac/webex-configure-spaces.spec.ts e2e/rbac/dynamic-agents-conversations-superadmin.spec.ts e2e/rbac/access-explorer.spec.ts --config=playwright.rbac.config.ts` — 17 passed
- `npm run lint`
- `npm run build`

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All relevant tests pass
