### PR TITLE
ci(deps): Optimize dependabot for gh-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,13 @@ version: 2
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
-    groups:
-      github:
-        patterns:
-          - "actions/*"
-          - "github/*"
     schedule:
       interval: "weekly"
+    groups:
+      # Grouping minor and patch updates for GitHub Actions
+      github-actions-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
# Description

Grouping minor and patch depandabot updates related to GitHub Actions to a single PR. This reduces:
- multiple rebase/merging of code before review
- CI cycle
- PR/review noise

A trade-off will be that if the CI checks fail, identifying the problematic change/commit will be tricky. 

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass
