### PR TITLE
feat(ui): add agent completion browser alerts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.3"
+version = "1.0.0-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/public/caipe-notification-sw.js
+++ b/ui/public/caipe-notification-sw.js
@@ -3,10 +3,13 @@
 self.addEventListener("notificationclick",(event) => {
   event.notification.close();
 
+  const href = event.notification.data?.href;
   const conversationId = event.notification.data?.conversationId;
-  const targetPath = conversationId
-    ? `/chat/${encodeURIComponent(conversationId)}`
-    : "/chat";
+  const targetPath = typeof href === "string" && href.startsWith("/") && !href.startsWith("//")
+    ? href
+    : conversationId
+      ? `/chat/${encodeURIComponent(conversationId)}`
+      : "/chat";
 
   event.waitUntil((async () => {
     const windows = await self.clients.matchAll({

--- a/ui/public/caipe-notification-sw.js
+++ b/ui/public/caipe-notification-sw.js
@@ -1,0 +1,25 @@
+/* CAIPE completion notification click handling. This worker intentionally has
+ * no fetch listener, so it does not intercept or cache application traffic. */
+self.addEventListener("notificationclick",(event) => {
+  event.notification.close();
+
+  const conversationId = event.notification.data?.conversationId;
+  const targetPath = conversationId
+    ? `/chat/${encodeURIComponent(conversationId)}`
+    : "/chat";
+
+  event.waitUntil((async () => {
+    const windows = await self.clients.matchAll({
+      type: "window",
+      includeUncontrolled: true,
+    });
+    const targetUrl = new URL(targetPath,self.location.origin).href;
+
+    for (const client of windows) {
+      if ("navigate" in client) await client.navigate(targetUrl);
+      if ("focus" in client) return client.focus();
+    }
+
+    return self.clients.openWindow(targetUrl);
+  })());
+});

--- a/ui/src/app/layout.tsx
+++ b/ui/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { AuthProvider } from "@/components/auth-provider";
+import { AgentCompletionNotifier } from "@/components/notifications/AgentCompletionNotifier";
 import { ThemeInjector } from "@/components/theme-injector";
 import { ThemeProvider } from "@/components/theme-provider";
 import { TokenExpiryGuard } from "@/components/token-expiry-guard";
@@ -122,6 +123,7 @@ export default async function RootLayout({
             <ToastProvider>
               <ThemeInjector />
               <TokenExpiryGuard />
+              <AgentCompletionNotifier />
               {children}
             </ToastProvider>
           </ThemeProvider>

--- a/ui/src/components/notifications/AgentCompletionNotifier.tsx
+++ b/ui/src/components/notifications/AgentCompletionNotifier.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import {
+  deliverAgentCompletionAlert,
+  loadAgentCompletionPreferences,
+  primeCompletionChime,
+} from "@/lib/agent-completion-notifications";
+import { useChatStore } from "@/store/chat-store";
+import type { ChatMessage } from "@/types/a2a";
+import { useEffect,useRef } from "react";
+
+function latestAssistantMessage(messages: ChatMessage[]): ChatMessage | undefined {
+  return [...messages].reverse().find((message) => message.role === "assistant");
+}
+
+/**
+ * Observes the protocol-neutral chat store rather than any provider stream.
+ * Dynamic Agents, AG-UI, and Harness Gateway runs all converge on this state.
+ */
+export function AgentCompletionNotifier(): null {
+  const conversations = useChatStore((state) => state.conversations);
+  const streamingConversations = useChatStore((state) => state.streamingConversations);
+  const previousStreamingIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    let disposed = false;
+    let removeUnlockListeners: (() => void) | undefined;
+
+    void loadAgentCompletionPreferences().then((preferences) => {
+      if (disposed || !preferences.chimeEnabled) return;
+      const unlock = () => {
+        void primeCompletionChime();
+        removeUnlockListeners?.();
+      };
+      removeUnlockListeners = () => {
+        window.removeEventListener("pointerdown",unlock);
+        window.removeEventListener("keydown",unlock);
+      };
+      window.addEventListener("pointerdown",unlock,{ once: true });
+      window.addEventListener("keydown",unlock,{ once: true });
+    });
+
+    return () => {
+      disposed = true;
+      removeUnlockListeners?.();
+    };
+  }, []);
+
+  useEffect(() => {
+    const currentStreamingIds = new Set(streamingConversations.keys());
+
+    for (const conversationId of previousStreamingIdsRef.current) {
+      if (currentStreamingIds.has(conversationId)) continue;
+      const conversation = conversations.find((item) => item.id === conversationId);
+      const message = conversation ? latestAssistantMessage(conversation.messages) : undefined;
+      if (!conversation || !message || message.turnStatus !== "done" || message.isFinal === false) continue;
+
+      void deliverAgentCompletionAlert({
+        agentName: message.agentName,
+        conversationId,
+        messageId: message.id,
+      });
+    }
+
+    previousStreamingIdsRef.current = currentStreamingIds;
+  }, [conversations,streamingConversations]);
+
+  return null;
+}

--- a/ui/src/components/notifications/AgentCompletionNotifier.tsx
+++ b/ui/src/components/notifications/AgentCompletionNotifier.tsx
@@ -3,6 +3,7 @@
 import {
   deliverAgentCompletionAlert,
   loadAgentCompletionPreferences,
+  prepareBrowserNotificationDelivery,
   primeCompletionChime,
 } from "@/lib/agent-completion-notifications";
 import { useChatStore } from "@/store/chat-store";
@@ -27,7 +28,9 @@ export function AgentCompletionNotifier(): null {
     let removeUnlockListeners: (() => void) | undefined;
 
     void loadAgentCompletionPreferences().then((preferences) => {
-      if (disposed || !preferences.chimeEnabled) return;
+      if (disposed) return;
+      if (preferences.browserEnabled) void prepareBrowserNotificationDelivery();
+      if (!preferences.chimeEnabled) return;
       const unlock = () => {
         void primeCompletionChime();
         removeUnlockListeners?.();

--- a/ui/src/components/notifications/__tests__/AgentCompletionNotifier.test.tsx
+++ b/ui/src/components/notifications/__tests__/AgentCompletionNotifier.test.tsx
@@ -1,0 +1,91 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { render,waitFor } from "@testing-library/react";
+
+const mockDeliverAgentCompletionAlert = jest.fn(async () => ({
+  chimePlayed: false,
+  notificationShown: true,
+}));
+const mockLoadPreferences = jest.fn(async () => ({
+  browserEnabled: true,
+  chimeEnabled: false,
+}));
+
+let mockChatState: {
+  conversations: Array<Record<string,unknown>>;
+  streamingConversations: Map<string,Record<string,unknown>>;
+};
+
+jest.mock("@/lib/agent-completion-notifications",() => ({
+  deliverAgentCompletionAlert: (...args: unknown[]) => mockDeliverAgentCompletionAlert(...args),
+  loadAgentCompletionPreferences: () => mockLoadPreferences(),
+  primeCompletionChime: jest.fn(async () => true),
+}));
+
+jest.mock("@/store/chat-store",() => ({
+  useChatStore: (selector: (state: typeof mockChatState) => unknown) => selector(mockChatState),
+}));
+
+import { AgentCompletionNotifier } from "../AgentCompletionNotifier";
+
+function conversation(turnStatus: "done" | "interrupted" | "waiting_for_input") {
+  return {
+    id: "conversation-primary",
+    title: "Example conversation",
+    messages: [{
+      id: "message-primary",
+      role: "assistant",
+      content: "Finished",
+      isFinal: turnStatus === "done",
+      turnStatus,
+      agentName: "Example agent",
+    }],
+  };
+}
+
+describe("AgentCompletionNotifier",() => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockChatState = {
+      conversations: [conversation("done")],
+      streamingConversations: new Map([["conversation-primary",{}]]),
+    };
+  });
+
+  it("emits one alert when a successful stream leaves the shared streaming map",async () => {
+    const view = render(<AgentCompletionNotifier />);
+
+    mockChatState = {
+      conversations: [conversation("done")],
+      streamingConversations: new Map(),
+    };
+    view.rerender(<AgentCompletionNotifier />);
+
+    await waitFor(() => {
+      expect(mockDeliverAgentCompletionAlert).toHaveBeenCalledWith({
+        agentName: "Example agent",
+        conversationId: "conversation-primary",
+        messageId: "message-primary",
+      });
+    });
+    expect(mockDeliverAgentCompletionAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it.each(["interrupted","waiting_for_input"] as const)(
+    "does not alert for a %s turn",
+    async (turnStatus) => {
+      const view = render(<AgentCompletionNotifier />);
+
+      mockChatState = {
+        conversations: [conversation(turnStatus)],
+        streamingConversations: new Map(),
+      };
+      view.rerender(<AgentCompletionNotifier />);
+
+      await Promise.resolve();
+      expect(mockDeliverAgentCompletionAlert).not.toHaveBeenCalled();
+    },
+  );
+});

--- a/ui/src/components/notifications/__tests__/AgentCompletionNotifier.test.tsx
+++ b/ui/src/components/notifications/__tests__/AgentCompletionNotifier.test.tsx
@@ -21,6 +21,7 @@ let mockChatState: {
 jest.mock("@/lib/agent-completion-notifications",() => ({
   deliverAgentCompletionAlert: (...args: unknown[]) => mockDeliverAgentCompletionAlert(...args),
   loadAgentCompletionPreferences: () => mockLoadPreferences(),
+  prepareBrowserNotificationDelivery: jest.fn(async () => true),
   primeCompletionChime: jest.fn(async () => true),
 }));
 

--- a/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -15,10 +15,13 @@ import {
   requestBrowserNotificationPermission,
   type BrowserNotificationCapability,
 } from "@/lib/agent-completion-notifications";
-import { Bell,BellRing,Loader2,Volume2 } from "lucide-react";
+import { Bell,BellRing,ChevronsDownUp,ChevronsUpDown,Loader2,Volume2 } from "lucide-react";
 import { useEffect,useRef,useState } from "react";
 
 type NotificationKey = "release-notes" | "browser-completions" | "completion-chime";
+type NotificationSection = "agent-completions" | "release-notes";
+
+const NOTIFICATION_SECTIONS: NotificationSection[] = ["agent-completions","release-notes"];
 
 interface NotificationPreferences {
   browserEnabled: boolean;
@@ -73,6 +76,9 @@ export function NotificationsSettings(): React.ReactElement {
   const [loading,setLoading] = useState(true);
   const [loadError,setLoadError] = useState<string | null>(null);
   const [testMessage,setTestMessage] = useState<string | null>(null);
+  const [expandedSections,setExpandedSections] = useState<Set<NotificationSection>>(
+    () => new Set(NOTIFICATION_SECTIONS),
+  );
   const committedRef = useRef(preferences);
 
   const cacheCompletionPreferences = (next: NotificationPreferences): void => {
@@ -228,6 +234,16 @@ export function NotificationsSettings(): React.ReactElement {
     }
     autoSave.retry(key);
   };
+  const setSectionExpanded = (section: NotificationSection,expanded: boolean): void => {
+    setExpandedSections((current) => {
+      const next = new Set(current);
+      if (expanded) next.add(section);
+      else next.delete(section);
+      return next;
+    });
+  };
+  const allExpanded = expandedSections.size === NOTIFICATION_SECTIONS.length;
+  const allCollapsed = expandedSections.size === 0;
 
   if (loading) {
     return (
@@ -246,8 +262,32 @@ export function NotificationsSettings(): React.ReactElement {
         </div>
       ) : null}
 
+      <div className="flex justify-end gap-2">
+        <Button
+          disabled={allExpanded}
+          onClick={() => setExpandedSections(new Set(NOTIFICATION_SECTIONS))}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <ChevronsUpDown className="mr-2 h-4 w-4" />Expand all
+        </Button>
+        <Button
+          disabled={allCollapsed}
+          onClick={() => setExpandedSections(new Set())}
+          size="sm"
+          type="button"
+          variant="ghost"
+        >
+          <ChevronsDownUp className="mr-2 h-4 w-4" />Collapse all
+        </Button>
+      </div>
+
       <SettingsCard
+        collapsibleLabel="Agent completions"
         description="Get a quiet signal when a background agent turn finishes. No message content is included in the desktop alert."
+        expanded={expandedSections.has("agent-completions")}
+        onExpandedChange={(expanded) => setSectionExpanded("agent-completions",expanded)}
         title={<span className="flex items-center gap-2"><BellRing className="h-5 w-5 text-primary" />Agent completions</span>}
       >
         <div className="space-y-3">
@@ -309,7 +349,10 @@ export function NotificationsSettings(): React.ReactElement {
       </SettingsCard>
 
       <SettingsCard
+        collapsibleLabel="Release notes"
         description="Choose whether CAIPE announces a new release after you sign in."
+        expanded={expandedSections.has("release-notes")}
+        onExpandedChange={(expanded) => setSectionExpanded("release-notes",expanded)}
         title={<span className="flex items-center gap-2"><Bell className="h-5 w-5 text-primary" />Release notes</span>}
       >
         <div className="space-y-4">

--- a/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -4,36 +4,112 @@ import { ReleaseNotesPreview } from "@/components/settings/ReleaseNotesPreview";
 import { AutoSaveStatus } from "@/components/settings/shared/AutoSaveStatus";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
 import { SettingsSwitch } from "@/components/settings/shared/SettingsSwitch";
+import { Button } from "@/components/ui/button";
 import { useKeyedAutoSave } from "@/hooks/use-keyed-auto-save";
-import { Bell,Loader2 } from "lucide-react";
+import {
+  cacheAgentCompletionPreferences,
+  deliverAgentCompletionAlert,
+  getBrowserNotificationCapability,
+  primeCompletionChime,
+  requestBrowserNotificationPermission,
+  type BrowserNotificationCapability,
+} from "@/lib/agent-completion-notifications";
+import { Bell,BellRing,Loader2,Volume2 } from "lucide-react";
 import { useEffect,useRef,useState } from "react";
 
-type NotificationKey = "release-notes";
+type NotificationKey = "release-notes" | "browser-completions" | "completion-chime";
 
-async function persistReleaseNotesPreference(_: NotificationKey,value: boolean): Promise<void> {
-  const response = await fetch("/api/settings/preferences",{
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ releaseNotesNotificationsEnabled: value }),
-  });
+interface NotificationPreferences {
+  browserEnabled: boolean;
+  chimeEnabled: boolean;
+  releaseNotesEnabled: boolean;
+}
+
+async function persistNotificationPreference(key: NotificationKey,value: boolean): Promise<void> {
+  const isReleaseNotes = key === "release-notes";
+  const response = await fetch(
+    isReleaseNotes ? "/api/settings/preferences" : "/api/settings/notifications",
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(
+        isReleaseNotes
+          ? { releaseNotesNotificationsEnabled: value }
+          : key === "browser-completions"
+            ? { agent_completion_browser_enabled: value }
+            : { agent_completion_chime_enabled: value },
+      ),
+    },
+  );
   const data = await response.json();
   if (!response.ok || !data.success) {
-    throw new Error(data.error || "Could not save the release-notes preference");
+    throw new Error(data.error || "Could not save the notification preference");
+  }
+}
+
+function permissionDescription(capability: BrowserNotificationCapability): string {
+  switch (capability) {
+    case "granted":
+      return "Allowed by this browser. Alerts appear only when CAIPE is hidden or unfocused.";
+    case "denied":
+      return "Blocked by this browser. Allow notifications for this site in browser settings to enable alerts.";
+    case "unsupported":
+      return "This browser does not support desktop notifications.";
+    default:
+      return "Your browser will ask for permission when you turn this on.";
   }
 }
 
 export function NotificationsSettings(): React.ReactElement {
-  const [enabled,setEnabled] = useState(true);
+  const [preferences,setPreferences] = useState<NotificationPreferences>({
+    browserEnabled: false,
+    chimeEnabled: false,
+    releaseNotesEnabled: true,
+  });
+  const [capability,setCapability] = useState<BrowserNotificationCapability>(() => (
+    getBrowserNotificationCapability()
+  ));
   const [loading,setLoading] = useState(true);
   const [loadError,setLoadError] = useState<string | null>(null);
-  const committedRef = useRef(true);
+  const [testMessage,setTestMessage] = useState<string | null>(null);
+  const committedRef = useRef(preferences);
+
+  const cacheCompletionPreferences = (next: NotificationPreferences): void => {
+    cacheAgentCompletionPreferences({
+      browserEnabled: next.browserEnabled,
+      chimeEnabled: next.chimeEnabled,
+    });
+  };
+
   const autoSave = useKeyedAutoSave<NotificationKey,boolean>({
-    persist: persistReleaseNotesPreference,
-    onSuccess: (_,value) => {
-      committedRef.current = value;
+    persist: persistNotificationPreference,
+    onSuccess: (key,value) => {
+      const next = {
+        ...committedRef.current,
+        ...(key === "release-notes" ? { releaseNotesEnabled: value } : {}),
+        ...(key === "browser-completions" ? { browserEnabled: value } : {}),
+        ...(key === "completion-chime" ? { chimeEnabled: value } : {}),
+      };
+      committedRef.current = next;
+      cacheCompletionPreferences(next);
     },
-    onError: () => {
-      setEnabled(committedRef.current);
+    onError: (key) => {
+      setPreferences((current) => {
+        const next = {
+          ...current,
+          ...(key === "release-notes"
+            ? { releaseNotesEnabled: committedRef.current.releaseNotesEnabled }
+            : {}),
+          ...(key === "browser-completions"
+            ? { browserEnabled: committedRef.current.browserEnabled }
+            : {}),
+          ...(key === "completion-chime"
+            ? { chimeEnabled: committedRef.current.chimeEnabled }
+            : {}),
+        };
+        cacheCompletionPreferences(next);
+        return next;
+      });
     },
   });
 
@@ -46,9 +122,15 @@ export function NotificationsSettings(): React.ReactElement {
           throw new Error(data.error || "Could not load notification preferences");
         }
         if (cancelled) return;
-        const value = data.data?.preferences?.releaseNotesNotificationsEnabled !== false;
-        committedRef.current = value;
-        setEnabled(value);
+        const next = {
+          browserEnabled: data.data?.notifications?.agent_completion_browser_enabled === true,
+          chimeEnabled: data.data?.notifications?.agent_completion_chime_enabled === true,
+          releaseNotesEnabled: data.data?.preferences?.releaseNotesNotificationsEnabled !== false,
+        };
+        committedRef.current = next;
+        setPreferences(next);
+        cacheCompletionPreferences(next);
+        setCapability(getBrowserNotificationCapability());
       })
       .catch((reason: unknown) => {
         if (!cancelled) {
@@ -63,33 +145,166 @@ export function NotificationsSettings(): React.ReactElement {
     };
   }, []);
 
-  const change = (value: boolean) => {
-    setEnabled(value);
-    autoSave.enqueue("release-notes",value);
-  };
-  const retry = () => {
-    const pendingValue = autoSave.pendingValueFor("release-notes");
-    if (pendingValue !== undefined) setEnabled(pendingValue);
-    autoSave.retry("release-notes");
+  const setPreference = (key: NotificationKey,value: boolean): void => {
+    setPreferences((current) => {
+      const next = {
+        ...current,
+        ...(key === "release-notes" ? { releaseNotesEnabled: value } : {}),
+        ...(key === "browser-completions" ? { browserEnabled: value } : {}),
+        ...(key === "completion-chime" ? { chimeEnabled: value } : {}),
+      };
+      cacheCompletionPreferences(next);
+      return next;
+    });
+    autoSave.enqueue(key,value);
   };
 
+  const changeBrowserNotifications = async (value: boolean): Promise<void> => {
+    setTestMessage(null);
+    if (!value) {
+      setPreference("browser-completions",false);
+      return;
+    }
+
+    const permission = await requestBrowserNotificationPermission();
+    setCapability(permission);
+    if (permission !== "granted") return;
+    setPreference("browser-completions",true);
+  };
+
+  const changeCompletionChime = (value: boolean): void => {
+    setTestMessage(null);
+    if (value) void primeCompletionChime();
+    setPreference("completion-chime",value);
+  };
+
+  const testCompletionAlert = async (): Promise<void> => {
+    setTestMessage("Sending test alert…");
+    let currentCapability = getBrowserNotificationCapability();
+    if (preferences.browserEnabled && currentCapability === "default") {
+      currentCapability = await requestBrowserNotificationPermission();
+      setCapability(currentCapability);
+    }
+    const result = await deliverAgentCompletionAlert(
+      {
+        agentName: "Example agent",
+        conversationId: "example",
+        messageId: `test-${Date.now()}`,
+      },
+      {
+        force: true,
+        preferences: {
+          browserEnabled: preferences.browserEnabled,
+          chimeEnabled: preferences.chimeEnabled,
+        },
+      },
+    );
+    if (result.notificationShown || result.chimePlayed) {
+      setTestMessage("Test alert sent.");
+    } else if (preferences.browserEnabled && currentCapability !== "granted") {
+      setTestMessage(permissionDescription(currentCapability));
+    } else {
+      setTestMessage("The browser blocked the test alert. Check this site's notification and audio permissions.");
+    }
+  };
+
+  const retry = (key: NotificationKey): void => {
+    const pendingValue = autoSave.pendingValueFor(key);
+    if (pendingValue !== undefined) {
+      setPreferences((current) => ({
+        ...current,
+        ...(key === "release-notes" ? { releaseNotesEnabled: pendingValue } : {}),
+        ...(key === "browser-completions" ? { browserEnabled: pendingValue } : {}),
+        ...(key === "completion-chime" ? { chimeEnabled: pendingValue } : {}),
+      }));
+    }
+    autoSave.retry(key);
+  };
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
+        <Loader2 className="h-4 w-4 animate-spin" />
+        Loading notification preferences…
+      </div>
+    );
+  }
+
   return (
-    <SettingsCard
-      description="Choose whether CAIPE announces a new release after you sign in."
-      title={<span className="flex items-center gap-2"><Bell className="h-5 w-5 text-primary" />Release notes</span>}
-    >
-      {loading ? (
-        <div className="flex items-center gap-2 py-4 text-sm text-muted-foreground">
-          <Loader2 className="h-4 w-4 animate-spin" />
-          Loading notification preferences…
+    <div className="space-y-6">
+      {loadError ? (
+        <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
+          {loadError}
         </div>
-      ) : (
-        <div className="space-y-4">
-          {loadError ? (
-            <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
-              {loadError}
+      ) : null}
+
+      <SettingsCard
+        description="Get a quiet signal when a background agent turn finishes. No message content is included in the desktop alert."
+        title={<span className="flex items-center gap-2"><BellRing className="h-5 w-5 text-primary" />Agent completions</span>}
+      >
+        <div className="space-y-3">
+          <div className="flex items-center gap-4 rounded-lg border border-border/70 p-4">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium">Browser notifications</p>
+              <p className="text-xs text-muted-foreground">{permissionDescription(capability)}</p>
+              <AutoSaveStatus
+                className="mt-1"
+                onRetry={() => retry("browser-completions")}
+                state={autoSave.stateFor("browser-completions")}
+              />
             </div>
-          ) : null}
+            <SettingsSwitch
+              checked={preferences.browserEnabled}
+              disabled={capability === "unsupported"}
+              label="Browser notifications for agent completions"
+              onCheckedChange={(value) => { void changeBrowserNotifications(value); }}
+              testId="agent-completion-browser-toggle"
+            />
+          </div>
+
+          <div className="flex items-center gap-4 rounded-lg border border-border/70 p-4">
+            <div className="min-w-0 flex-1">
+              <p className="flex items-center gap-1.5 text-sm font-medium"><Volume2 className="h-4 w-4" />Completion chime</p>
+              <p className="text-xs text-muted-foreground">Play a short two-note chime with background completion alerts.</p>
+              <AutoSaveStatus
+                className="mt-1"
+                onRetry={() => retry("completion-chime")}
+                state={autoSave.stateFor("completion-chime")}
+              />
+            </div>
+            <SettingsSwitch
+              checked={preferences.chimeEnabled}
+              label="Completion chime"
+              onCheckedChange={changeCompletionChime}
+              testId="agent-completion-chime-toggle"
+            />
+          </div>
+
+          <div className="flex flex-wrap items-center gap-3">
+            <Button
+              disabled={!preferences.browserEnabled && !preferences.chimeEnabled}
+              onClick={() => { void testCompletionAlert(); }}
+              size="sm"
+              type="button"
+              variant="secondary"
+            >
+              <BellRing className="mr-2 h-4 w-4" />
+              Send test alert
+            </Button>
+            {testMessage ? <p aria-live="polite" className="text-xs text-muted-foreground">{testMessage}</p> : null}
+          </div>
+
+          <p className="text-xs text-muted-foreground">
+            Alerts work while a CAIPE tab remains open. They are independent of the selected agent harness.
+          </p>
+        </div>
+      </SettingsCard>
+
+      <SettingsCard
+        description="Choose whether CAIPE announces a new release after you sign in."
+        title={<span className="flex items-center gap-2"><Bell className="h-5 w-5 text-primary" />Release notes</span>}
+      >
+        <div className="space-y-4">
           <div className="flex items-center gap-4 rounded-lg border border-border/70 p-4">
             <div className="min-w-0 flex-1">
               <p className="text-sm font-medium">Notify me about new releases</p>
@@ -98,20 +313,20 @@ export function NotificationsSettings(): React.ReactElement {
               </p>
               <AutoSaveStatus
                 className="mt-1"
-                onRetry={retry}
+                onRetry={() => retry("release-notes")}
                 state={autoSave.stateFor("release-notes")}
               />
             </div>
             <SettingsSwitch
-              checked={enabled}
+              checked={preferences.releaseNotesEnabled}
               label="Notify me about new releases"
-              onCheckedChange={change}
+              onCheckedChange={(value) => setPreference("release-notes",value)}
               testId="release-notes-user-pref-toggle"
             />
           </div>
           <ReleaseNotesPreview isAdmin={false} />
         </div>
-      )}
-    </SettingsCard>
+      </SettingsCard>
+    </div>
   );
 }

--- a/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -10,6 +10,7 @@ import {
   cacheAgentCompletionPreferences,
   deliverAgentCompletionAlert,
   getBrowserNotificationCapability,
+  prepareBrowserNotificationDelivery,
   primeCompletionChime,
   requestBrowserNotificationPermission,
   type BrowserNotificationCapability,
@@ -169,6 +170,7 @@ export function NotificationsSettings(): React.ReactElement {
     const permission = await requestBrowserNotificationPermission();
     setCapability(permission);
     if (permission !== "granted") return;
+    await prepareBrowserNotificationDelivery();
     setPreference("browser-completions",true);
   };
 
@@ -199,8 +201,14 @@ export function NotificationsSettings(): React.ReactElement {
         },
       },
     );
-    if (result.notificationShown || result.chimePlayed) {
-      setTestMessage("Test alert sent.");
+    if (result.notificationShown && result.chimePlayed) {
+      setTestMessage("Browser notification accepted and chime played. If no banner appeared, check system notifications for this browser.");
+    } else if (result.notificationShown) {
+      setTestMessage("Browser notification accepted. If no banner appeared, check system notifications for this browser.");
+    } else if (result.chimePlayed && preferences.browserEnabled) {
+      setTestMessage("Chime played, but the browser notification could not be shown. Check this site's notification permission.");
+    } else if (result.chimePlayed) {
+      setTestMessage("Chime played. Browser notifications are turned off.");
     } else if (preferences.browserEnabled && currentCapability !== "granted") {
       setTestMessage(permissionDescription(currentCapability));
     } else {

--- a/ui/src/components/settings/sections/NotificationsSettings.tsx
+++ b/ui/src/components/settings/sections/NotificationsSettings.tsx
@@ -197,6 +197,7 @@ export function NotificationsSettings(): React.ReactElement {
       {
         agentName: "Example agent",
         conversationId: "example",
+        href: "/settings/notifications",
         messageId: `test-${Date.now()}`,
       },
       {

--- a/ui/src/components/settings/sections/__tests__/NotificationsSettings.test.tsx
+++ b/ui/src/components/settings/sections/__tests__/NotificationsSettings.test.tsx
@@ -19,9 +19,94 @@ function jsonResponse(body: unknown,ok = true): Response {
   } as Response;
 }
 
+class MockNotification {
+  static permission: NotificationPermission = "default";
+  static requestPermission = jest.fn<Promise<NotificationPermission>,[]>();
+
+  close = jest.fn();
+  onclick: (() => void) | null = null;
+
+  constructor() {}
+}
+
 describe("NotificationsSettings",() => {
   beforeEach(() => {
     jest.clearAllMocks();
+    MockNotification.permission = "default";
+    MockNotification.requestPermission.mockResolvedValue("granted");
+    Object.defineProperty(window,"Notification",{
+      configurable: true,
+      value: MockNotification,
+    });
+  });
+
+  it("requests permission from the browser toggle and saves completion alerts",async () => {
+    const fetchMock = jest.fn(async (_input: RequestInfo | URL,init?: RequestInit) => {
+      if (init?.method === "PATCH") return jsonResponse({ success: true,data: {} });
+      return jsonResponse({
+        success: true,
+        data: {
+          notifications: {
+            agent_completion_browser_enabled: false,
+            agent_completion_chime_enabled: false,
+          },
+        },
+      });
+    });
+    global.fetch = fetchMock;
+    render(<NotificationsSettings />);
+
+    fireEvent.click(await screen.findByRole("switch",{
+      name: "Browser notifications for agent completions",
+    }));
+
+    await waitFor(() => {
+      expect(MockNotification.requestPermission).toHaveBeenCalledTimes(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/settings/notifications",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ agent_completion_browser_enabled: true }),
+        }),
+      );
+    });
+  });
+
+  it("does not save browser alerts when permission is denied",async () => {
+    MockNotification.requestPermission.mockResolvedValue("denied");
+    global.fetch = jest.fn(async () => jsonResponse({ success: true,data: {} }));
+    render(<NotificationsSettings />);
+
+    fireEvent.click(await screen.findByRole("switch",{
+      name: "Browser notifications for agent completions",
+    }));
+
+    expect(await screen.findByText(/blocked by this browser/i)).toBeInTheDocument();
+    expect(global.fetch).not.toHaveBeenCalledWith(
+      "/api/settings/notifications",
+      expect.objectContaining({ method: "PATCH" }),
+    );
+  });
+
+  it("saves the optional completion chime independently",async () => {
+    const fetchMock = jest.fn(async (_input: RequestInfo | URL,init?: RequestInit) => {
+      if (init?.method === "PATCH") return jsonResponse({ success: true,data: {} });
+      return jsonResponse({ success: true,data: {} });
+    });
+    global.fetch = fetchMock;
+    render(<NotificationsSettings />);
+
+    fireEvent.click(await screen.findByRole("switch",{ name: "Completion chime" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/settings/notifications",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ agent_completion_chime_enabled: true }),
+        }),
+      );
+    });
   });
 
   it("loads an opted-out personal preference",async () => {

--- a/ui/src/components/settings/sections/__tests__/NotificationsSettings.test.tsx
+++ b/ui/src/components/settings/sections/__tests__/NotificationsSettings.test.tsx
@@ -123,6 +123,27 @@ describe("NotificationsSettings",() => {
     );
   });
 
+  it("expands and collapses notification sections individually or together",async () => {
+    global.fetch = jest.fn(async () => jsonResponse({ success: true,data: {} }));
+    render(<NotificationsSettings />);
+
+    await screen.findByRole("switch",{ name: "Browser notifications for agent completions" });
+    fireEvent.click(screen.getByRole("button",{ name: "Collapse Agent completions" }));
+    expect(screen.queryByRole("switch",{
+      name: "Browser notifications for agent completions",
+    })).not.toBeInTheDocument();
+    expect(screen.getByRole("switch",{ name: "Notify me about new releases" })).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button",{ name: "Collapse all" }));
+    expect(screen.queryByRole("switch",{ name: "Notify me about new releases" })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button",{ name: "Expand all" }));
+    expect(screen.getByRole("switch",{
+      name: "Browser notifications for agent completions",
+    })).toBeInTheDocument();
+    expect(screen.getByRole("switch",{ name: "Notify me about new releases" })).toBeInTheDocument();
+  });
+
   it("auto-saves the personal preference without a Save button",async () => {
     const fetchMock = jest.fn(async (input: RequestInfo | URL,init?: RequestInit) => {
       if (init?.method === "PATCH") return jsonResponse({ success: true,data: {} });

--- a/ui/src/components/settings/shared/SettingsCard.tsx
+++ b/ui/src/components/settings/shared/SettingsCard.tsx
@@ -1,26 +1,53 @@
 import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import { ChevronDown } from "lucide-react";
 
 interface SettingsCardProps {
   children: React.ReactNode;
   className?: string;
+  collapsibleLabel?: string;
   description?: React.ReactNode;
+  expanded?: boolean;
+  onExpandedChange?: (expanded: boolean) => void;
   title: React.ReactNode;
 }
 
 export function SettingsCard({
   children,
   className,
+  collapsibleLabel,
   description,
+  expanded = true,
+  onExpandedChange,
   title,
 }: SettingsCardProps): React.ReactElement {
+  const collapsible = Boolean(collapsibleLabel && onExpandedChange);
+
   return (
     <Card className={cn("overflow-hidden",className)}>
       <CardHeader>
-        <CardTitle className="text-lg">{title}</CardTitle>
-        {description ? <CardDescription>{description}</CardDescription> : null}
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <CardTitle className="text-lg">{title}</CardTitle>
+            {description ? <CardDescription className="mt-1.5">{description}</CardDescription> : null}
+          </div>
+          {collapsible ? (
+            <Button
+              aria-expanded={expanded}
+              aria-label={`${expanded ? "Collapse" : "Expand"} ${collapsibleLabel}`}
+              className="-mr-2 -mt-2 shrink-0"
+              onClick={() => onExpandedChange?.(!expanded)}
+              size="icon"
+              type="button"
+              variant="ghost"
+            >
+              <ChevronDown className={cn("h-4 w-4 transition-transform",expanded && "rotate-180")} />
+            </Button>
+          ) : null}
+        </div>
       </CardHeader>
-      <CardContent>{children}</CardContent>
+      {!collapsible || expanded ? <CardContent>{children}</CardContent> : null}
     </Card>
   );
 }

--- a/ui/src/lib/__tests__/agent-completion-notifications.test.ts
+++ b/ui/src/lib/__tests__/agent-completion-notifications.test.ts
@@ -1,0 +1,138 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import {
+  cacheAgentCompletionPreferences,
+  deliverAgentCompletionAlert,
+  loadAgentCompletionPreferences,
+  readCachedAgentCompletionPreferences,
+  resetAgentCompletionPreferenceLoad,
+  shouldAlertForCurrentPage,
+} from "../agent-completion-notifications";
+
+const notifications: MockNotification[] = [];
+
+class MockNotification {
+  static permission: NotificationPermission = "granted";
+  static requestPermission = jest.fn(async () => MockNotification.permission);
+  body?: string;
+  close = jest.fn();
+  onclick: (() => void) | null = null;
+  tag?: string;
+  title: string;
+
+  constructor(title: string,options?: NotificationOptions) {
+    this.title = title;
+    this.body = options?.body;
+    this.tag = options?.tag;
+    notifications.push(this);
+  }
+}
+
+function jsonResponse(body: unknown,ok = true): Response {
+  return {
+    ok,
+    status: ok ? 200 : 500,
+    json: async () => body,
+  } as Response;
+}
+
+describe("agent completion notifications",() => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    notifications.length = 0;
+    localStorage.clear();
+    resetAgentCompletionPreferenceLoad();
+    MockNotification.permission = "granted";
+    Object.defineProperty(window,"Notification",{
+      configurable: true,
+      value: MockNotification,
+    });
+    Object.defineProperty(document,"hidden",{ configurable: true,value: true });
+    Object.defineProperty(document,"hasFocus",{
+      configurable: true,
+      value: jest.fn(() => false),
+    });
+  });
+
+  it("caches both opt-in preferences",() => {
+    cacheAgentCompletionPreferences({ browserEnabled: true,chimeEnabled: false });
+
+    expect(readCachedAgentCompletionPreferences()).toEqual({
+      browserEnabled: true,
+      chimeEnabled: false,
+    });
+  });
+
+  it("hydrates preferences from the authenticated settings API",async () => {
+    global.fetch = jest.fn(async () => jsonResponse({
+      success: true,
+      data: {
+        notifications: {
+          agent_completion_browser_enabled: true,
+          agent_completion_chime_enabled: false,
+        },
+      },
+    }));
+
+    await expect(loadAgentCompletionPreferences()).resolves.toEqual({
+      browserEnabled: true,
+      chimeEnabled: false,
+    });
+    expect(global.fetch).toHaveBeenCalledWith("/api/settings",{ cache: "no-store" });
+  });
+
+  it("alerts only when the page is hidden or unfocused",() => {
+    expect(shouldAlertForCurrentPage()).toBe(true);
+
+    Object.defineProperty(document,"hidden",{ configurable: true,value: false });
+    Object.defineProperty(document,"hasFocus",{
+      configurable: true,
+      value: jest.fn(() => true),
+    });
+    expect(shouldAlertForCurrentPage()).toBe(false);
+  });
+
+  it("shows a content-safe browser notification for a background completion",async () => {
+    const result = await deliverAgentCompletionAlert(
+      {
+        agentName: "Example agent",
+        conversationId: "conversation-primary",
+        messageId: "message-primary",
+      },
+      {
+        preferences: { browserEnabled: true,chimeEnabled: false },
+      },
+    );
+
+    expect(result).toEqual({ chimePlayed: false,notificationShown: true });
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]).toMatchObject({
+      title: "Example agent finished",
+      body: "Your response is ready.",
+      tag: "caipe-agent-completion-conversation-primary",
+    });
+  });
+
+  it("does not interrupt a user who is already looking at CAIPE",async () => {
+    Object.defineProperty(document,"hidden",{ configurable: true,value: false });
+    Object.defineProperty(document,"hasFocus",{
+      configurable: true,
+      value: jest.fn(() => true),
+    });
+
+    const result = await deliverAgentCompletionAlert(
+      {
+        conversationId: "conversation-primary",
+        messageId: "message-primary",
+      },
+      {
+        preferences: { browserEnabled: true,chimeEnabled: false },
+      },
+    );
+
+    expect(result.notificationShown).toBe(false);
+    expect(notifications).toHaveLength(0);
+  });
+});

--- a/ui/src/lib/__tests__/agent-completion-notifications.test.ts
+++ b/ui/src/lib/__tests__/agent-completion-notifications.test.ts
@@ -115,16 +115,17 @@ describe("agent completion notifications",() => {
     expect(notifications[0]).toMatchObject({
       title: "Example agent finished",
       body: "Your response is ready.",
-      tag: "caipe-agent-completion-conversation-primary",
+      tag: "caipe-agent-completion-conversation-primary-message-primary",
     });
   });
 
   it("prefers persistent service-worker notification delivery",async () => {
     const showNotification = jest.fn(async () => undefined);
-    const register = jest.fn(async () => ({ showNotification }));
+    const registration = { active: {},showNotification };
+    const register = jest.fn(async () => registration);
     Object.defineProperty(navigator,"serviceWorker",{
       configurable: true,
-      value: { register },
+      value: { ready: Promise.resolve(registration),register },
     });
 
     const result = await deliverAgentCompletionAlert(
@@ -144,10 +145,38 @@ describe("agent completion notifications",() => {
       "Example agent finished",
       expect.objectContaining({
         body: "Your response is ready.",
-        tag: "caipe-agent-completion-conversation-primary",
+        renotify: true,
+        requireInteraction: true,
+        silent: false,
+        tag: "caipe-agent-completion-conversation-primary-message-primary",
       }),
     );
     expect(notifications).toHaveLength(0);
+  });
+
+  it("waits for a newly registered service worker to become active",async () => {
+    const showNotification = jest.fn(async () => undefined);
+    const installingRegistration = { active: null,showNotification };
+    const activeRegistration = { active: {},showNotification };
+    const register = jest.fn(async () => installingRegistration);
+    Object.defineProperty(navigator,"serviceWorker",{
+      configurable: true,
+      value: { ready: Promise.resolve(activeRegistration),register },
+    });
+
+    const result = await deliverAgentCompletionAlert(
+      {
+        agentName: "Example agent",
+        conversationId: "conversation-secondary",
+        messageId: "message-secondary",
+      },
+      {
+        preferences: { browserEnabled: true,chimeEnabled: false },
+      },
+    );
+
+    expect(result.notificationShown).toBe(true);
+    expect(showNotification).toHaveBeenCalledTimes(1);
   });
 
   it("does not interrupt a user who is already looking at CAIPE",async () => {

--- a/ui/src/lib/__tests__/agent-completion-notifications.test.ts
+++ b/ui/src/lib/__tests__/agent-completion-notifications.test.ts
@@ -49,6 +49,10 @@ describe("agent completion notifications",() => {
       configurable: true,
       value: MockNotification,
     });
+    Object.defineProperty(navigator,"serviceWorker",{
+      configurable: true,
+      value: undefined,
+    });
     Object.defineProperty(document,"hidden",{ configurable: true,value: true });
     Object.defineProperty(document,"hasFocus",{
       configurable: true,
@@ -113,6 +117,37 @@ describe("agent completion notifications",() => {
       body: "Your response is ready.",
       tag: "caipe-agent-completion-conversation-primary",
     });
+  });
+
+  it("prefers persistent service-worker notification delivery",async () => {
+    const showNotification = jest.fn(async () => undefined);
+    const register = jest.fn(async () => ({ showNotification }));
+    Object.defineProperty(navigator,"serviceWorker",{
+      configurable: true,
+      value: { register },
+    });
+
+    const result = await deliverAgentCompletionAlert(
+      {
+        agentName: "Example agent",
+        conversationId: "conversation-primary",
+        messageId: "message-primary",
+      },
+      {
+        preferences: { browserEnabled: true,chimeEnabled: false },
+      },
+    );
+
+    expect(result).toEqual({ chimePlayed: false,notificationShown: true });
+    expect(register).toHaveBeenCalledWith("/caipe-notification-sw.js",{ scope: "/" });
+    expect(showNotification).toHaveBeenCalledWith(
+      "Example agent finished",
+      expect.objectContaining({
+        body: "Your response is ready.",
+        tag: "caipe-agent-completion-conversation-primary",
+      }),
+    );
+    expect(notifications).toHaveLength(0);
   });
 
   it("does not interrupt a user who is already looking at CAIPE",async () => {

--- a/ui/src/lib/__tests__/agent-completion-notifications.test.ts
+++ b/ui/src/lib/__tests__/agent-completion-notifications.test.ts
@@ -18,6 +18,7 @@ class MockNotification {
   static requestPermission = jest.fn(async () => MockNotification.permission);
   body?: string;
   close = jest.fn();
+  data?: unknown;
   onclick: (() => void) | null = null;
   tag?: string;
   title: string;
@@ -25,6 +26,7 @@ class MockNotification {
   constructor(title: string,options?: NotificationOptions) {
     this.title = title;
     this.body = options?.body;
+    this.data = options?.data;
     this.tag = options?.tag;
     notifications.push(this);
   }
@@ -116,6 +118,24 @@ describe("agent completion notifications",() => {
       title: "Example agent finished",
       body: "Your response is ready.",
       tag: "caipe-agent-completion-conversation-primary-message-primary",
+    });
+  });
+
+  it("uses an explicit internal destination for a test notification",async () => {
+    await deliverAgentCompletionAlert(
+      {
+        agentName: "Example agent",
+        conversationId: "example",
+        href: "/settings/notifications",
+        messageId: "message-test",
+      },
+      {
+        preferences: { browserEnabled: true,chimeEnabled: false },
+      },
+    );
+
+    expect(notifications[0]).toMatchObject({
+      data: expect.objectContaining({ href: "/settings/notifications" }),
     });
   });
 

--- a/ui/src/lib/agent-completion-notifications.ts
+++ b/ui/src/lib/agent-completion-notifications.ts
@@ -6,6 +6,7 @@ export interface AgentCompletionPreferences {
 export interface AgentCompletionAlert {
   agentName?: string;
   conversationId: string;
+  href?: string;
   messageId: string;
 }
 
@@ -124,6 +125,12 @@ function getAudioContext(): AudioContext | null {
   return audioContext;
 }
 
+function notificationTargetPath(alert: AgentCompletionAlert): string {
+  const href = alert.href?.trim();
+  if (href?.startsWith("/") && !href.startsWith("//")) return href;
+  return `/chat/${encodeURIComponent(alert.conversationId)}`;
+}
+
 /**
  * Call from a click/key handler so browser autoplay policy allows a later
  * background completion chime.
@@ -181,6 +188,7 @@ async function showBrowserNotification(alert: AgentCompletionAlert): Promise<boo
     body: "Your response is ready.",
     data: {
       conversationId: alert.conversationId,
+      href: notificationTargetPath(alert),
       messageId: alert.messageId,
     },
     icon: "/icon.ico",
@@ -206,7 +214,7 @@ async function showBrowserNotification(alert: AgentCompletionAlert): Promise<boo
     const notification = new window.Notification(title,options);
     notification.onclick = () => {
       window.focus();
-      window.location.assign(`/chat/${encodeURIComponent(alert.conversationId)}`);
+      window.location.assign(notificationTargetPath(alert));
       notification.close();
     };
     return true;

--- a/ui/src/lib/agent-completion-notifications.ts
+++ b/ui/src/lib/agent-completion-notifications.ts
@@ -94,6 +94,13 @@ async function getNotificationServiceWorker(): Promise<ServiceWorkerRegistration
   if (!notificationServiceWorkerPromise) {
     notificationServiceWorkerPromise = navigator.serviceWorker
       .register("/caipe-notification-sw.js",{ scope: "/" })
+      .then(async (registration) => {
+        // register() may resolve while a newly installed worker is still
+        // activating. showNotification() requires an active worker and can
+        // otherwise fail before falling back to the less reliable page API.
+        if (registration.active) return registration;
+        return navigator.serviceWorker.ready;
+      })
       .catch(() => null);
   }
   return notificationServiceWorkerPromise;
@@ -175,7 +182,12 @@ async function showBrowserNotification(alert: AgentCompletionAlert): Promise<boo
       messageId: alert.messageId,
     },
     icon: "/icon.ico",
-    tag: `caipe-agent-completion-${alert.conversationId}`,
+    // Each completed message must have its own identity. Reusing only the
+    // conversation ID lets Chrome silently replace the prior notification.
+    tag: `caipe-agent-completion-${alert.conversationId}-${alert.messageId}`,
+    renotify: true,
+    requireInteraction: true,
+    silent: false,
   };
 
   const registration = await getNotificationServiceWorker();

--- a/ui/src/lib/agent-completion-notifications.ts
+++ b/ui/src/lib/agent-completion-notifications.ts
@@ -23,6 +23,7 @@ const DEFAULT_PREFERENCES: AgentCompletionPreferences = {
 
 let settingsLoadPromise: Promise<AgentCompletionPreferences> | null = null;
 let audioContext: AudioContext | null = null;
+let notificationServiceWorkerPromise: Promise<ServiceWorkerRegistration | null> | null = null;
 
 function readBoolean(key: string): boolean | undefined {
   if (typeof window === "undefined") return undefined;
@@ -71,6 +72,7 @@ export async function loadAgentCompletionPreferences(): Promise<AgentCompletionP
 
 export function resetAgentCompletionPreferenceLoad(): void {
   settingsLoadPromise = null;
+  notificationServiceWorkerPromise = null;
 }
 
 export function getBrowserNotificationCapability(): BrowserNotificationCapability {
@@ -81,6 +83,27 @@ export function getBrowserNotificationCapability(): BrowserNotificationCapabilit
 export async function requestBrowserNotificationPermission(): Promise<BrowserNotificationCapability> {
   if (typeof window === "undefined" || !("Notification" in window)) return "unsupported";
   return window.Notification.requestPermission();
+}
+
+async function getNotificationServiceWorker(): Promise<ServiceWorkerRegistration | null> {
+  if (
+    typeof navigator === "undefined"
+    || !("serviceWorker" in navigator)
+    || !navigator.serviceWorker
+  ) return null;
+  if (!notificationServiceWorkerPromise) {
+    notificationServiceWorkerPromise = navigator.serviceWorker
+      .register("/caipe-notification-sw.js",{ scope: "/" })
+      .catch(() => null);
+  }
+  return notificationServiceWorkerPromise;
+}
+
+/** Prepare persistent notification delivery while the page is active. */
+export async function prepareBrowserNotificationDelivery(): Promise<boolean> {
+  if (getBrowserNotificationCapability() !== "granted") return false;
+  if (await getNotificationServiceWorker()) return true;
+  return typeof window !== "undefined" && "Notification" in window;
 }
 
 function getAudioContext(): AudioContext | null {
@@ -140,20 +163,33 @@ export function shouldAlertForCurrentPage(): boolean {
   return document.hidden || !document.hasFocus();
 }
 
-function showBrowserNotification(alert: AgentCompletionAlert): boolean {
+async function showBrowserNotification(alert: AgentCompletionAlert): Promise<boolean> {
   if (getBrowserNotificationCapability() !== "granted") return false;
 
+  const agentLabel = alert.agentName?.trim() || "Agent";
+  const title = `${agentLabel} finished`;
+  const options: NotificationOptions = {
+    body: "Your response is ready.",
+    data: {
+      conversationId: alert.conversationId,
+      messageId: alert.messageId,
+    },
+    icon: "/icon.ico",
+    tag: `caipe-agent-completion-${alert.conversationId}`,
+  };
+
+  const registration = await getNotificationServiceWorker();
+  if (registration) {
+    try {
+      await registration.showNotification(title,options);
+      return true;
+    } catch {
+      // Fall back to the page Notification API below.
+    }
+  }
+
   try {
-    const agentLabel = alert.agentName?.trim() || "Agent";
-    const notification = new window.Notification(`${agentLabel} finished`,{
-      body: "Your response is ready.",
-      data: {
-        conversationId: alert.conversationId,
-        messageId: alert.messageId,
-      },
-      icon: "/icon.ico",
-      tag: `caipe-agent-completion-${alert.conversationId}`,
-    });
+    const notification = new window.Notification(title,options);
     notification.onclick = () => {
       window.focus();
       window.location.assign(`/chat/${encodeURIComponent(alert.conversationId)}`);
@@ -178,7 +214,7 @@ export async function deliverAgentCompletionAlert(
   const preferences = options.preferences ?? await loadAgentCompletionPreferences();
   const [chimePlayed,notificationShown] = await Promise.all([
     preferences.chimeEnabled ? playCompletionChime() : Promise.resolve(false),
-    Promise.resolve(preferences.browserEnabled ? showBrowserNotification(alert) : false),
+    preferences.browserEnabled ? showBrowserNotification(alert) : Promise.resolve(false),
   ]);
   return { chimePlayed,notificationShown };
 }

--- a/ui/src/lib/agent-completion-notifications.ts
+++ b/ui/src/lib/agent-completion-notifications.ts
@@ -1,0 +1,184 @@
+export interface AgentCompletionPreferences {
+  browserEnabled: boolean;
+  chimeEnabled: boolean;
+}
+
+export interface AgentCompletionAlert {
+  agentName?: string;
+  conversationId: string;
+  messageId: string;
+}
+
+export type BrowserNotificationCapability = NotificationPermission | "unsupported";
+
+const STORAGE_KEYS = {
+  browserEnabled: "caipe-agent-completion-browser-enabled",
+  chimeEnabled: "caipe-agent-completion-chime-enabled",
+} as const;
+
+const DEFAULT_PREFERENCES: AgentCompletionPreferences = {
+  browserEnabled: false,
+  chimeEnabled: false,
+};
+
+let settingsLoadPromise: Promise<AgentCompletionPreferences> | null = null;
+let audioContext: AudioContext | null = null;
+
+function readBoolean(key: string): boolean | undefined {
+  if (typeof window === "undefined") return undefined;
+  const value = window.localStorage.getItem(key);
+  if (value === "true") return true;
+  if (value === "false") return false;
+  return undefined;
+}
+
+export function readCachedAgentCompletionPreferences(): AgentCompletionPreferences {
+  return {
+    browserEnabled: readBoolean(STORAGE_KEYS.browserEnabled) ?? DEFAULT_PREFERENCES.browserEnabled,
+    chimeEnabled: readBoolean(STORAGE_KEYS.chimeEnabled) ?? DEFAULT_PREFERENCES.chimeEnabled,
+  };
+}
+
+export function cacheAgentCompletionPreferences(preferences: AgentCompletionPreferences): void {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(STORAGE_KEYS.browserEnabled,String(preferences.browserEnabled));
+  window.localStorage.setItem(STORAGE_KEYS.chimeEnabled,String(preferences.chimeEnabled));
+  settingsLoadPromise = Promise.resolve(preferences);
+}
+
+export async function loadAgentCompletionPreferences(): Promise<AgentCompletionPreferences> {
+  if (typeof window === "undefined") return DEFAULT_PREFERENCES;
+  if (settingsLoadPromise) return settingsLoadPromise;
+
+  settingsLoadPromise = fetch("/api/settings",{ cache: "no-store" })
+    .then(async (response) => {
+      const body = await response.json();
+      if (!response.ok || !body.success) {
+        throw new Error(body.error || "Could not load notification preferences");
+      }
+      const notifications = body.data?.notifications;
+      const preferences = {
+        browserEnabled: notifications?.agent_completion_browser_enabled === true,
+        chimeEnabled: notifications?.agent_completion_chime_enabled === true,
+      };
+      cacheAgentCompletionPreferences(preferences);
+      return preferences;
+    })
+    .catch(() => readCachedAgentCompletionPreferences());
+
+  return settingsLoadPromise;
+}
+
+export function resetAgentCompletionPreferenceLoad(): void {
+  settingsLoadPromise = null;
+}
+
+export function getBrowserNotificationCapability(): BrowserNotificationCapability {
+  if (typeof window === "undefined" || !("Notification" in window)) return "unsupported";
+  return window.Notification.permission;
+}
+
+export async function requestBrowserNotificationPermission(): Promise<BrowserNotificationCapability> {
+  if (typeof window === "undefined" || !("Notification" in window)) return "unsupported";
+  return window.Notification.requestPermission();
+}
+
+function getAudioContext(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  if (audioContext && audioContext.state !== "closed") return audioContext;
+
+  const AudioContextConstructor = window.AudioContext
+    ?? (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!AudioContextConstructor) return null;
+  audioContext = new AudioContextConstructor();
+  return audioContext;
+}
+
+/**
+ * Call from a click/key handler so browser autoplay policy allows a later
+ * background completion chime.
+ */
+export async function primeCompletionChime(): Promise<boolean> {
+  const context = getAudioContext();
+  if (!context) return false;
+  if (context.state !== "running") {
+    try {
+      await context.resume();
+    } catch {
+      return false;
+    }
+  }
+  return context.state === "running";
+}
+
+export async function playCompletionChime(): Promise<boolean> {
+  const context = getAudioContext();
+  if (!context || !(await primeCompletionChime())) return false;
+
+  const playTone = (frequency: number,startsAt: number,duration: number): void => {
+    const oscillator = context.createOscillator();
+    const gain = context.createGain();
+    oscillator.type = "sine";
+    oscillator.frequency.setValueAtTime(frequency,startsAt);
+    gain.gain.setValueAtTime(0.0001,startsAt);
+    gain.gain.exponentialRampToValueAtTime(0.075,startsAt + 0.02);
+    gain.gain.exponentialRampToValueAtTime(0.0001,startsAt + duration);
+    oscillator.connect(gain);
+    gain.connect(context.destination);
+    oscillator.start(startsAt);
+    oscillator.stop(startsAt + duration);
+  };
+
+  const now = context.currentTime;
+  playTone(659.25,now,0.18);
+  playTone(880,now + 0.11,0.24);
+  return true;
+}
+
+export function shouldAlertForCurrentPage(): boolean {
+  if (typeof document === "undefined" || typeof window === "undefined") return false;
+  return document.hidden || !document.hasFocus();
+}
+
+function showBrowserNotification(alert: AgentCompletionAlert): boolean {
+  if (getBrowserNotificationCapability() !== "granted") return false;
+
+  try {
+    const agentLabel = alert.agentName?.trim() || "Agent";
+    const notification = new window.Notification(`${agentLabel} finished`,{
+      body: "Your response is ready.",
+      data: {
+        conversationId: alert.conversationId,
+        messageId: alert.messageId,
+      },
+      icon: "/icon.ico",
+      tag: `caipe-agent-completion-${alert.conversationId}`,
+    });
+    notification.onclick = () => {
+      window.focus();
+      window.location.assign(`/chat/${encodeURIComponent(alert.conversationId)}`);
+      notification.close();
+    };
+    return true;
+  } catch {
+    // Desktop Notification construction is not supported by every browser,
+    // notably several mobile implementations. The in-app response still works.
+    return false;
+  }
+}
+
+export async function deliverAgentCompletionAlert(
+  alert: AgentCompletionAlert,
+  options: { force?: boolean; preferences?: AgentCompletionPreferences } = {},
+): Promise<{ chimePlayed: boolean; notificationShown: boolean }> {
+  if (!options.force && !shouldAlertForCurrentPage()) {
+    return { chimePlayed: false,notificationShown: false };
+  }
+
+  const preferences = options.preferences ?? await loadAgentCompletionPreferences();
+  const [chimePlayed,notificationShown] = await Promise.all([
+    preferences.chimeEnabled ? playCompletionChime() : Promise.resolve(false),
+    Promise.resolve(preferences.browserEnabled ? showBrowserNotification(alert) : false),
+  ]);
+  return { chimePlayed,notificationShown };
+}

--- a/ui/src/lib/agent-completion-notifications.ts
+++ b/ui/src/lib/agent-completion-notifications.ts
@@ -175,7 +175,9 @@ async function showBrowserNotification(alert: AgentCompletionAlert): Promise<boo
 
   const agentLabel = alert.agentName?.trim() || "Agent";
   const title = `${agentLabel} finished`;
-  const options: NotificationOptions = {
+  // `renotify` is supported by Chromium's Notification API but is not yet
+  // included in every TypeScript DOM library version.
+  const options: NotificationOptions & { renotify?: boolean } = {
     body: "Your response is ready.",
     data: {
       conversationId: alert.conversationId,

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -260,6 +260,10 @@ export interface UserSettings {
     in_app_enabled: boolean;
     conversation_shared: boolean;
     weekly_summary: boolean;
+    /** Show an OS-level alert when an agent turn completes in the background. */
+    agent_completion_browser_enabled: boolean;
+    /** Play the optional completion chime with a background completion alert. */
+    agent_completion_chime_enabled: boolean;
   };
   defaults: {
     default_model: string;
@@ -295,6 +299,8 @@ export const DEFAULT_USER_SETTINGS: Omit<
     in_app_enabled: true,
     conversation_shared: true,
     weekly_summary: false,
+    agent_completion_browser_enabled: false,
+    agent_completion_chime_enabled: false,
   },
   defaults: {
     default_model: "gpt-4o",

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev3"
+version = "1.0.0.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Adds opt-in agent completion alerts to the CAIPE web UI.

- Adds authenticated per-user controls for browser notifications and an optional two-note chime under **Settings → Notifications**.
- Requests browser permission only after a user turns on the setting or sends a test alert.
- Emits an alert only when a successful agent turn completes while the CAIPE page is hidden or unfocused.
- Observes the shared chat store, so the behavior is independent of the selected execution harness.
- Keeps desktop alerts content-safe: they include the agent name and a generic completion message, but no prompt or response content.
- Leaves both completion channels disabled by default and preserves the existing release-notes notification setting.

Browser alerts require HTTPS and an open CAIPE tab. A lightweight service worker provides persistent display and click-through handling; this change does not add push delivery for closed-browser notifications.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; this is a UI-only change.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in the settings UI and code comments
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing relevant tests pass

## Validation

- `npm run lint`
- `npx tsc --noEmit`
- `npm test -- --runInBand src/lib/__tests__/agent-completion-notifications.test.ts src/components/notifications/__tests__/AgentCompletionNotifier.test.tsx src/components/settings/sections/__tests__/NotificationsSettings.test.tsx src/app/api/__tests__/settings.test.ts` — 38 tests passed
- `npm run build`
