### PR TITLE
test: remove tautological skills helper check

### DIFF
--- a/tests/test_caipe_skills_helper.py
+++ b/tests/test_caipe_skills_helper.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 import importlib.util
 import io
 import json
-import sys
 import urllib.error
 from contextlib import redirect_stdout
 from pathlib import Path
@@ -79,23 +78,14 @@ def test_helper_file_exists():
     )
 
 
-def test_helper_uses_only_stdlib(helper: Any):
+def test_helper_uses_only_stdlib() -> None:
     """No third-party deps — keeps `python3 ~/.config/caipe/caipe-skills.py` working anywhere."""
-    third_party = {
-        name
-        for name in sys.modules
-        if name.startswith(("requests", "httpx", "urllib3", "aiohttp"))
-    }
     # The helper itself imports nothing third-party; this is a safety net
     # against a future refactor accidentally adding a dep.
     forbidden_in_source = ("import requests", "import httpx", "import aiohttp")
     src = HELPER_PATH.read_text(encoding="utf-8")
     for needle in forbidden_in_source:
         assert needle not in src, f"helper imports forbidden dep: {needle}"
-    # Document the current third-party state so a regression is loud.
-    assert third_party == set() or all(
-        m in third_party for m in third_party
-    )  # tautology; placeholder to keep the assertion explicit
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description

Remove the explicit tautology from the chart skills helper's stdlib-only test. The meaningful source checks remain; the test no longer depends on the ambient test runner's imported modules.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (test cleanup)

## Pre-release Helm Charts (Optional)

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented (not applicable)
- [x] All code style checks pass (`git diff --check`)
- [x] New code contribution is covered by automated tests (existing focused test)
- [x] All new and existing tests pass (`uv run pytest tests/test_caipe_skills_helper.py`)
