### PR TITLE
feat(ui): restore feature-gated feedback shortcut

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -349,6 +349,11 @@ SLACK_JIT_ALLOWED_EMAIL_DOMAINS=
 
 # UI feature flags (caipe-ui container)
 WORKFLOW_RUNNER_ENABLED=false
+WORKFLOWS_ENABLED=false
+SCHEDULER_ENABLED=false
+SCHEDULER_ADMIN_ONLY=false
+# Optional compact header shortcut that opens the existing report dialog.
+PROVIDE_FEEDBACK_ENABLED=false
 RAG_ENABLED=true
 
 # Identity sync — process IDP group claims at login and auto-create teams

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -570,6 +570,9 @@ services:
       - WORKFLOW_RUNNER_ENABLED=${WORKFLOW_RUNNER_ENABLED:-false}
       # Workflows tab - set WORKFLOWS_ENABLED=true to show the top-level Workflows UI
       - WORKFLOWS_ENABLED=${WORKFLOWS_ENABLED:-false}
+      - SCHEDULER_ENABLED=${SCHEDULER_ENABLED:-false}
+      - SCHEDULER_ADMIN_ONLY=${SCHEDULER_ADMIN_ONLY:-false}
+      - PROVIDE_FEEDBACK_ENABLED=${PROVIDE_FEEDBACK_ENABLED:-false}
       # Dynamic Agents - set DYNAMIC_AGENTS_ENABLED=true and add dynamic-agents profile to enable Custom Agents tab
       - DYNAMIC_AGENTS_ENABLED=${DYNAMIC_AGENTS_ENABLED:-false}
       # Chat runtime health endpoint URL
@@ -812,6 +815,9 @@ services:
       - PREVIEW_MODE=${PREVIEW_MODE:-}
       - WORKFLOW_RUNNER_ENABLED=${WORKFLOW_RUNNER_ENABLED:-false}
       - WORKFLOWS_ENABLED=${WORKFLOWS_ENABLED:-false}
+      - SCHEDULER_ENABLED=${SCHEDULER_ENABLED:-false}
+      - SCHEDULER_ADMIN_ONLY=${SCHEDULER_ADMIN_ONLY:-false}
+      - PROVIDE_FEEDBACK_ENABLED=${PROVIDE_FEEDBACK_ENABLED:-false}
       - DYNAMIC_AGENTS_ENABLED=${DYNAMIC_AGENTS_ENABLED:-false}
       # Chat runtime health endpoint URL
       - A2A_BASE_URL=${A2A_BASE_URL:-http://dynamic-agents:8001}

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -353,6 +353,12 @@ services:
       - KEYCLOAK_ADMIN_CLIENT_SECRET=${KEYCLOAK_ADMIN_CLIENT_SECRET:-caipe-platform-dev-secret}
       # Workflow runner - set WORKFLOW_RUNNER_ENABLED=true to show Run Workflow button and Multi-Step Workflows
       - WORKFLOW_RUNNER_ENABLED=${WORKFLOW_RUNNER_ENABLED:-false}
+      # Top-level workflows and schedules are independent, opt-in navigation surfaces.
+      - WORKFLOWS_ENABLED=${WORKFLOWS_ENABLED:-false}
+      - SCHEDULER_ENABLED=${SCHEDULER_ENABLED:-false}
+      - SCHEDULER_ADMIN_ONLY=${SCHEDULER_ADMIN_ONLY:-false}
+      # Compact header shortcut that reuses the existing feedback dialog.
+      - PROVIDE_FEEDBACK_ENABLED=${PROVIDE_FEEDBACK_ENABLED:-false}
       - DYNAMIC_AGENTS_URL=${DYNAMIC_AGENTS_URL:-http://dynamic-agents:8001}
       # Connections & Secrets. Docker Compose reads provider bootstrap values
       # from .env; Kubernetes deployments use ESO to inject the same env names.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -357,6 +357,7 @@ services:
       - WORKFLOWS_ENABLED=${WORKFLOWS_ENABLED:-false}
       - SCHEDULER_ENABLED=${SCHEDULER_ENABLED:-false}
       - SCHEDULER_ADMIN_ONLY=${SCHEDULER_ADMIN_ONLY:-false}
+      - DYNAMIC_AGENTS_ENABLED=${DYNAMIC_AGENTS_ENABLED:-false}
       # Compact header shortcut that reuses the existing feedback dialog.
       - PROVIDE_FEEDBACK_ENABLED=${PROVIDE_FEEDBACK_ENABLED:-false}
       - DYNAMIC_AGENTS_URL=${DYNAMIC_AGENTS_URL:-http://dynamic-agents:8001}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.3"
+version = "1.0.0-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/env.example
+++ b/ui/env.example
@@ -294,8 +294,12 @@ WORKFLOW_RUNNER_ENABLED=false
 #
 # Scheduler service used by the Schedules page and scheduled-run BFF path.
 # SCHEDULER_ENABLED=false
+# SCHEDULER_ADMIN_ONLY=false
 # SCHEDULER_URL=http://localhost:8080
 # SCHEDULER_SERVICE_TOKEN=dev-only-not-a-real-token
+
+# Optional compact app-header shortcut for submitting product feedback.
+# PROVIDE_FEEDBACK_ENABLED=false
 #
 # Optional model overrides for /api/skills/generate (see route.ts for defaults).
 # SKILL_AI_MODEL_ID=bedrock/global.anthropic.claude-haiku-4-5-20251001-v1:0

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -9,6 +9,7 @@ import { ReleaseUpgradeDialog } from "@/components/release/ReleaseUpgradeDialog"
 import { NotificationBell } from "@/components/notifications/NotificationBell";
 import { SettingsPanel } from "@/components/settings-panel";
 import { UnsavedChangesDialog } from "@/components/shared/UnsavedChangesDialog";
+import { ReportProblemDialog } from "@/components/ticket/ReportProblemDialog";
 import { Button } from "@/components/ui/button";
 import { useHeaderBreadcrumbSlotRef } from "@/components/layout/HeaderBreadcrumbSlot";
 import { GithubIcon as Github } from "@/components/ui/icons";
@@ -30,6 +31,7 @@ import {
 AlertTriangle,
 BookOpen,
 ChevronRight,
+MessageSquareText,
 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { usePathname,useRouter } from "next/navigation";
@@ -78,6 +80,7 @@ export function AppHeader() {
   // visibly does nothing in that race. Programmatic navigation + an
   // explicit close after navigation starts is deterministic.
   const [alertsPopoverOpen, setAlertsPopoverOpen] = React.useState(false);
+  const [feedbackDialogOpen, setFeedbackDialogOpen] = React.useState(false);
 
   // Debug logging for admin tab
   React.useEffect(() => {
@@ -360,6 +363,25 @@ export function AppHeader() {
             >
               {config.envBadge}
             </span>
+          ) : null}
+          {config.provideFeedbackEnabled ? (
+            <>
+              <Button
+                aria-label="Provide Feedback"
+                className="h-8 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+                onClick={() => setFeedbackDialogOpen(true)}
+                size="sm"
+                title="Provide Feedback"
+                variant="ghost"
+              >
+                <MessageSquareText className="h-3.5 w-3.5" />
+                <span className="hidden lg:inline">Provide Feedback</span>
+              </Button>
+              <ReportProblemDialog
+                open={feedbackDialogOpen}
+                onOpenChange={setFeedbackDialogOpen}
+              />
+            </>
           ) : null}
           <SettingsPanel />
           {config.docsUrl && (

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -368,14 +368,14 @@ export function AppHeader() {
             <>
               <Button
                 aria-label="Provide Feedback"
-                className="h-8 gap-1.5 px-2 text-xs text-muted-foreground hover:text-foreground"
+                className="h-8 w-8 text-muted-foreground hover:text-foreground"
+                data-testid="header-provide-feedback"
                 onClick={() => setFeedbackDialogOpen(true)}
-                size="sm"
+                size="icon"
                 title="Provide Feedback"
                 variant="ghost"
               >
-                <MessageSquareText className="h-3.5 w-3.5" />
-                <span className="hidden lg:inline">Provide Feedback</span>
+                <MessageSquareText aria-hidden="true" className="h-4 w-4" />
               </Button>
               <ReportProblemDialog
                 open={feedbackDialogOpen}

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -698,6 +698,10 @@ describe('AppHeader — application chrome', () => {
       fireEvent.click(screen.getByRole('button', { name: 'Provide Feedback' }))
 
       expect(screen.getByTestId('provide-feedback-dialog')).toBeInTheDocument()
+      expect(screen.getByTestId('header-provide-feedback')).toHaveAttribute(
+        'title',
+        'Provide Feedback',
+      )
     })
 
     it('renders UserMenu', () => {

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -114,6 +114,8 @@ jest.mock('@/store/chat-store', () => ({
 let mockStorageMode = 'mongodb'
 let mockRagEnabled = false
 let mockEnvBadge = ''
+const mockReportProblemEnabled = true
+let mockProvideFeedbackEnabled = false
 
 const mockReleasePrompt = {
   open: false,
@@ -187,6 +189,7 @@ jest.mock('@/lib/config', () => ({
     get storageMode() { return mockStorageMode },
     get ragEnabled() { return mockRagEnabled },
     get reportProblemEnabled() { return mockReportProblemEnabled },
+    get provideFeedbackEnabled() { return mockProvideFeedbackEnabled },
     get autonomousAgentsEnabled() { return mockAutonomousAgentsEnabled },
   },
   getConfig: jest.fn((key: string) => {
@@ -285,6 +288,11 @@ jest.mock('@/components/user-menu', () => ({
   UserMenu: () => (
     <div data-testid="user-menu" />
   ),
+}))
+
+jest.mock('@/components/ticket/ReportProblemDialog', () => ({
+  ReportProblemDialog: ({ open }: { open: boolean }) =>
+    open ? <div data-testid="provide-feedback-dialog">Provide Feedback Dialog</div> : null,
 }))
 
 jest.mock('@/components/settings-panel', () => ({
@@ -395,6 +403,7 @@ describe('AppHeader — application chrome', () => {
     mockAutonomousAgentsEnabled = true
     mockRagEnabled = false
     mockEnvBadge = ''
+    mockProvideFeedbackEnabled = false
     mockStreamingConversations = new Map()
     mockUnviewedConversations = new Set()
     mockInputRequiredConversations = new Set()
@@ -677,6 +686,20 @@ describe('AppHeader — application chrome', () => {
   })
 
   describe('right-side elements', () => {
+    it('hides the feedback shortcut when the feature flag is disabled', () => {
+      render(<AppHeader />)
+      expect(screen.queryByRole('button', { name: 'Provide Feedback' })).not.toBeInTheDocument()
+    })
+
+    it('opens the feedback dialog when the feature flag is enabled', () => {
+      mockProvideFeedbackEnabled = true
+      render(<AppHeader />)
+
+      fireEvent.click(screen.getByRole('button', { name: 'Provide Feedback' }))
+
+      expect(screen.getByTestId('provide-feedback-dialog')).toBeInTheDocument()
+    })
+
     it('renders UserMenu', () => {
       render(<AppHeader />)
       expect(screen.getByTestId('user-menu')).toBeInTheDocument()

--- a/ui/src/lib/__tests__/config.test.ts
+++ b/ui/src/lib/__tests__/config.test.ts
@@ -76,6 +76,7 @@ describe('getServerConfig', () => {
         'DEFAULT_FONT_SIZE', 'DEFAULT_FONT_FAMILY',
         'DEFAULT_THEME', 'DEFAULT_GRADIENT_THEME',
         'AUTONOMOUS_AGENTS_ENABLED', 'ENABLE_AUTONOMOUS_AGENTS',
+        'PROVIDE_FEEDBACK_ENABLED',
       );
       delete process.env.MONGODB_URI;
       delete process.env.MONGODB_DATABASE;
@@ -125,6 +126,7 @@ describe('getServerConfig', () => {
     it('should return default ticket integration values', () => {
       const cfg = getServerConfig();
       expect(cfg.reportProblemEnabled).toBe(true);
+      expect(cfg.provideFeedbackEnabled).toBe(false);
       expect(cfg.jiraTicketEnabled).toBe(false);
       expect(cfg.jiraTicketProject).toBeNull();
       expect(cfg.jiraTicketLabel).toBe('caipe-reported');
@@ -154,6 +156,7 @@ describe('getServerConfig', () => {
         'dynamicAgentsUrl',
         'autonomousAgentsEnabled',
         'reportProblemEnabled',
+        'provideFeedbackEnabled',
         'jiraTicketEnabled', 'jiraTicketProject', 'jiraTicketLabel',
         'githubTicketEnabled', 'githubTicketRepo', 'githubTicketLabel',
         'ticketEnabled', 'ticketProvider',
@@ -318,6 +321,7 @@ describe('getServerConfig', () => {
     beforeEach(() => {
       clearEnv(
         'REPORT_PROBLEM_ENABLED',
+        'PROVIDE_FEEDBACK_ENABLED',
         'JIRA_TICKET_ENABLED', 'JIRA_TICKET_PROJECT', 'JIRA_TICKET_LABEL',
         'GITHUB_TICKET_ENABLED', 'GITHUB_TICKET_REPO', 'GITHUB_TICKET_LABEL',
       );
@@ -375,6 +379,12 @@ describe('getServerConfig', () => {
     it('should enable report problem by default', () => {
       const cfg = getServerConfig();
       expect(cfg.reportProblemEnabled).toBe(true);
+    });
+
+    it('should keep the header feedback shortcut opt-in', () => {
+      expect(getServerConfig().provideFeedbackEnabled).toBe(false);
+      process.env.PROVIDE_FEEDBACK_ENABLED = 'true';
+      expect(getServerConfig().provideFeedbackEnabled).toBe(true);
     });
 
     it('should derive ticketEnabled=false when no provider is enabled', () => {
@@ -895,6 +905,7 @@ describe('getClientConfigScript (XSS safety)', () => {
       'dynamicAgentsUrl',
       'autonomousAgentsEnabled',
       'reportProblemEnabled',
+      'provideFeedbackEnabled',
       'jiraTicketEnabled', 'jiraTicketProject', 'jiraTicketLabel',
       'githubTicketEnabled', 'githubTicketRepo', 'githubTicketLabel',
       'ticketEnabled', 'ticketProvider',

--- a/ui/src/lib/config.ts
+++ b/ui/src/lib/config.ts
@@ -185,6 +185,11 @@ export interface Config {
    * When ticketEnabled is false, the dialog still opens but cannot create tickets.
    */
   reportProblemEnabled: boolean;
+  /**
+   * Whether the compact "Provide Feedback" shortcut is shown in the app header.
+   * Disabled by default. Set PROVIDE_FEEDBACK_ENABLED=true to enable it.
+   */
+  provideFeedbackEnabled: boolean;
   /** Derived: true if either Jira or GitHub ticket creation is enabled */
   ticketEnabled: boolean;
   /** Derived: which provider to use ('jira' takes precedence when both enabled) */
@@ -271,6 +276,7 @@ const DEFAULT_CONFIG: Config = {
   schedulerAdminOnly: false,
   agentProtocol: 'agui',
   reportProblemEnabled: true,
+  provideFeedbackEnabled: false,
   jiraTicketEnabled: false,
   jiraTicketProject: null,
   jiraTicketLabel: 'caipe-reported',
@@ -406,6 +412,7 @@ export function getServerConfig(): Config {
   const agentProtocol: 'custom' | 'agui' = agentProtocolEnv === 'custom' ? 'custom' : 'agui';
 
   const reportProblemEnabled = env('REPORT_PROBLEM_ENABLED') !== 'false';
+  const provideFeedbackEnabled = env('PROVIDE_FEEDBACK_ENABLED') === 'true';
   const jiraTicketEnabled = env('JIRA_TICKET_ENABLED') === 'true';
   const jiraTicketProject = env('JIRA_TICKET_PROJECT') || null;
   const jiraTicketLabel = env('JIRA_TICKET_LABEL') || 'caipe-reported';
@@ -467,6 +474,7 @@ export function getServerConfig(): Config {
     schedulerAdminOnly: env('SCHEDULER_ADMIN_ONLY') === 'true',
     agentProtocol,
     reportProblemEnabled,
+    provideFeedbackEnabled,
     jiraTicketEnabled,
     jiraTicketProject,
     jiraTicketLabel,

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev3"
+version = "1.0.0.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Restores a compact, icon-only **Provide Feedback** header shortcut behind the opt-in `PROVIDE_FEEDBACK_ENABLED` feature flag. The shortcut reuses the existing report-problem dialog and leaves the existing user-menu action controlled independently by `REPORT_PROBLEM_ENABLED`.

The Compose environment examples now also document the existing workflow and scheduler flags so operators can enable those capabilities explicitly. All new flags remain disabled by default.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [x] Documentation Update

## Validation

- `npm test -- --runInBand src/lib/__tests__/config.test.ts src/components/layout/__tests__/AppHeader.test.tsx` (208 tests passed)
- `npm run lint`
- `npm run build`
- Docker Compose first-install configuration validation with `.env.example`

## Checklist

- [x] I have read and followed the contributing guidelines.
- [x] I have added tests that prove the feature works.
- [x] Existing behavior remains unchanged when the new flag is not enabled.
- [x] Environment configuration is documented.