### PR TITLE
ci: fix manual MCP prebuild workflow path

### DIFF
--- a/.github/workflows/prebuild-manual.yml
+++ b/.github/workflows/prebuild-manual.yml
@@ -196,7 +196,7 @@ jobs:
       contents: write
       packages: write
       pull-requests: write
-    uses: ./.github/workflows/prebuild-mcp-agent.yml
+    uses: ./.github/workflows/prebuild-mcp-servers.yml
     with:
       pr_number: ${{ fromJSON(needs.resolve-pr.outputs.pr_number) }}
       head_ref: ${{ needs.resolve-pr.outputs.head_ref }}


### PR DESCRIPTION
# Description

Correct the manual prebuild fanout's MCP reusable-workflow reference from the nonexistent `prebuild-mcp-agent.yml` to `prebuild-mcp-servers.yml`. The existing caller inputs match the target reusable workflow's `workflow_call` contract.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (CI workflow repair)

## Pre-release Helm Charts (Optional)

Not applicable.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented (not applicable)
- [x] All code style checks pass (`git diff --check`)
- [ ] New code contribution is covered by automated tests (workflow-only)
- [x] All new and existing tests pass (YAML parsed; all local reusable-workflow targets resolved)
