### PR TITLE
chore(repo): remove obsolete Beads Make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,7 +24,6 @@ DOCKER_COMPOSE_BUILD_ENV := DOCKER_BUILDKIT=1 COMPOSE_PARALLEL_LIMIT=$(COMPOSE_P
 	generate-agent-commands \
 	lint lint-fix test test-compose-generator test-compose-generator-coverage \
 	test-rag-unit test-rag-coverage test-rag-memory test-rag-scale validate lock-all help \
-	beads-gh-issues-sync beads-gh-issues-sync-run beads-list beads-ready beads-sync \
 	caipe-ui caipe-ui-install caipe-ui-build caipe-ui-dev caipe-ui-tests caipe-ui-e2e-rbac \
 	build-caipe-ui run-caipe-ui-docker caipe-ui-docker-compose \
 	caipe-ui-hot caipe-ui-prod \
@@ -375,25 +374,6 @@ lock-all:
 			uv pip compile pyproject.toml --all-extras --prerelease; \
 		); \
 	done
-
-## ========== Beads Issue Tracking ==========
-
-beads-gh-issues-sync: ## Sync beads issues to GitHub Issues (dry-run by default)
-	@echo "Syncing beads to GitHub Issues..."
-	@./scripts/sync_beads_to_github.sh --dry-run
-
-beads-gh-issues-sync-run: ## Actually sync beads to GitHub Issues (creates issues)
-	@echo "Syncing beads to GitHub Issues (LIVE)..."
-	@./scripts/sync_beads_to_github.sh
-
-beads-list: ## List all beads issues
-	@bd list
-
-beads-ready: ## Show beads ready for work
-	@bd ready
-
-beads-sync: ## Sync beads with git
-	@bd sync
 
 ## ========== Release & Versioning ==========
 release: setup-venv  ## Bump version and create a release


### PR DESCRIPTION
# Description

Removes the five root Makefile targets that advertise or invoke the retired Beads (`bd`) tracker. Repository instructions designate GitHub Issues as the tracker and explicitly prohibit Beads, so this prevents new contributors from selecting an unsupported workflow.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (repository cleanup)

## Pre-release Helm Charts (Optional)

Not applicable: no chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable) — no open cleanup duplicate found; the only Beads result is legacy issue #600.
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented — no user-facing behavior remains to document.
- [x] All code style checks pass — `git diff --check`; `make help`.
- [ ] New code contribution is covered by automated tests — not applicable; deletion-only Makefile cleanup.
- [x] All new and existing tests pass — not applicable; `make help` completed successfully.