### PR TITLE
chore(make): remove stale compose generator targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ DOCKER_COMPOSE_BUILD_ENV := DOCKER_BUILDKIT=1 COMPOSE_PARALLEL_LIMIT=$(COMPOSE_P
 	setup-venv start-venv clean-pyc clean-venv clean-build-artifacts clean \
 	uv-prep \
 	generate-agent-commands \
-	lint lint-fix test test-compose-generator test-compose-generator-coverage \
+	lint lint-fix test \
 	test-rag-unit test-rag-coverage test-rag-memory test-rag-scale validate lock-all help \
 	beads-gh-issues-sync beads-gh-issues-sync-run beads-list beads-ready beads-sync \
 	caipe-ui caipe-ui-install caipe-ui-build caipe-ui-dev caipe-ui-tests caipe-ui-e2e-rbac \
@@ -246,16 +246,6 @@ lint-fix: setup-venv ## Automatically fix linting issues using Ruff
 	@uv run python -m ruff check . --select E,F --ignore F403 --ignore E402 --line-length 320 --fix
 
 ## ========== Test ==========
-
-test-compose-generator: setup-venv ## Run unit tests for docker-compose generator
-	@echo "Running docker-compose generator tests..."
-	@. .venv/bin/activate && uv add pytest pyyaml --dev
-	@. .venv/bin/activate && uv run python -m pytest scripts/test_generate_docker_compose.py -v --tb=short
-
-test-compose-generator-coverage: setup-venv ## Run docker-compose generator tests with coverage
-	@echo "Running docker-compose generator tests with coverage..."
-	@. .venv/bin/activate && uv add pytest pytest-cov pyyaml --dev
-	@. .venv/bin/activate && uv run python -m pytest scripts/test_generate_docker_compose.py -v --cov=generate_docker_compose --cov-report=term-missing --cov-report=html
 
 test-core: setup-venv ## Run tests for the core/shared workspace (utils, dynamic_agents, etc.)
 	@echo "Running core workspace tests..."


### PR DESCRIPTION
# Description

Remove two Make targets that invoke `scripts/test_generate_docker_compose.py`, which was deleted from the repository. Keeping them advertised as supported entrypoints gives contributors an immediate file-not-found failure and makes the root test surface harder to trust.

This changes no Compose configuration and does not touch `.env`, `.env.example`, `docker-compose.yaml`, or `docker-compose.dev.yaml`.

Related to #2423 and #2444.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other: repository maintenance

## Validation

- `make help`
- `rg` confirms no live non-historical reference to either removed target or missing test file
- `git diff main...HEAD --check`

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced
- [x] I have verified this change is not present in another open pull request
- [x] Functionality is unchanged; the invoked test file no longer exists
- [x] Relevant checks pass
- [x] No new code requires tests
