### PR TITLE
docs: simplify versioned docs retention

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -20,8 +20,8 @@ Audit every documentation surface in `ai-platform-engineering` and fix what is o
 |---|---------|-------------|
 | 1 | **Release blog posts** | A git tag exists with no matching `docs/releases/` file |
 | 2 | **Homepage version string** | Helm `--version` in `docs/src/pages/index.tsx` doesn't match latest git tag |
-| 3 | **Docusaurus version config** | `lastVersion` in `docusaurus.config.ts` doesn't match latest git tag |
-| 4 | **Docusaurus version snapshot** | A tag exists but no `versioned_docs/version-X.Y.Z/` snapshot |
+| 3 | **Docusaurus version config** | The latest released snapshot is not at the root path, current docs are not labelled Next, or snapshots lack minor-only labels |
+| 4 | **Docusaurus version snapshots** | The final releases of the newest three minor series are not generated |
 | 5 | **Features page** | `docs/src/pages/features.tsx` tiles don't reflect new feature docs in `docs/docs/features/` |
 | 6 | **Agent docs** | A directory under `ai_platform_engineering/agents/` has no matching `docs/docs/agents/<name>.md` |
 | 7 | **Sidebar completeness** | A directory under `docs/docs/` is not referenced in `docs/sidebars.ts` |
@@ -53,8 +53,8 @@ git tag --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$'
 # Existing release blog posts (extract version from filename)
 ls docs/releases/*.md 2>/dev/null | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | tr '-' '.'
 
-# Current lastVersion in docusaurus config
-grep 'lastVersion' docs/docusaurus.config.ts
+# Published release snapshots
+cat docs/published-versions.json
 
 # Current Helm version string on homepage
 grep -o "'--version [0-9.]*'" docs/src/pages/index.tsx ||
@@ -111,27 +111,28 @@ grep -n "$LATEST\|--version" docs/src/pages/index.tsx | head -5
 - If the Helm `--version` value ≠ `$LATEST` → **STALE**: update `HELM_CMD` constant and any hardcoded version strings in `index.tsx`.
 - Fix: replace every occurrence of the old version string with `$LATEST`.
 
-### Check 3 — Docusaurus `lastVersion`
+### Check 3 — Docusaurus version configuration
 
 ```bash
-grep 'lastVersion' docs/docusaurus.config.ts
+cat docs/published-versions.json
 ```
 
-- If `lastVersion` ≠ `$LATEST` → **STALE**: update `lastVersion` in `docs/docusaurus.config.ts`.
+- The entries must be the final releases of the newest three minor series.
+- The generated config must label the newest release as `X.Y (Latest)` at the
+  root path, older snapshots as `X.Y`, and current development docs as `Next`
+  at `/next`.
 
-### Check 4 — Versioned snapshot exists
+### Check 4 — Version snapshots exist
 
 ```bash
 ls docs/versioned_docs/
 ```
 
-- If `versioned_docs/version-$LATEST/` does not exist → **STALE**: run:
+- If any final newest-three-minor snapshot is missing, generate it with:
 
 ```bash
-cd docs && npm run docusaurus -- docs:version $LATEST
+node docs/scripts/generate-versioned-docs.js
 ```
-
-Then update `docusaurus.config.ts` to add the new version entry and set it as `lastVersion`.
 
 ### Check 5 — Features page vs feature docs
 
@@ -189,10 +190,12 @@ done
 ### Check 8 — Navbar version label
 
 ```bash
-grep "label.*Latest" docs/docusaurus.config.ts
+cat docs/versions-config.json
 ```
 
-- If the label says `X.Y.Z (Latest)` but `$LATEST` ≠ X.Y.Z → **STALE**: update the label.
+- If the generated latest release label is not `X.Y (Latest)`, or `current` is
+  not labelled `Next` at `/next` → **STALE**: fix
+  `docs/scripts/generate-versioned-docs.js`.
 
 ---
 
@@ -201,8 +204,8 @@ grep "label.*Latest" docs/docusaurus.config.ts
 Apply fixes in this order (each is independent):
 
 1. **Homepage version** — find-replace the old version string in `docs/src/pages/index.tsx`
-2. **Docusaurus config** — update `lastVersion` and the version label
-3. **Version snapshot** — run `npm run docusaurus -- docs:version $LATEST` if missing
+2. **Docusaurus config** — verify generated labels for the latest release, prior snapshots, and Next
+3. **Version snapshots** — run `node docs/scripts/generate-versioned-docs.js` if missing
 4. **Missing agent stubs** — scaffold from template for each uncovered agent
 5. **Sidebar gaps** — append missing dir entries to `docs/sidebars.ts`
 6. **Missing release posts** — delegate to `/release-docs` for each unposted tag
@@ -222,8 +225,8 @@ After all checks and fixes, produce a summary table:
 |-------|--------|--------------|
 | Release posts | ✅ / ⚠️ | Created N posts / N missing, run /release-docs for: X.Y.Z |
 | Homepage version | ✅ / ⚠️ | Updated X.Y.Z → A.B.C |
-| lastVersion config | ✅ / ⚠️ | Updated |
-| Version snapshot | ✅ / ⚠️ | Created versioned_docs/version-A.B.C |
+| Version configuration | ✅ / ⚠️ | Latest release, snapshot, and Next labels verified |
+| Version snapshots | ✅ / ⚠️ | Created versioned_docs/version-A.B.C |
 | Features page | ✅ / ⚠️ | N tiles match / N new features need tiles: [list] |
 | Agent docs | ✅ / ⚠️ | Scaffolded stubs for: [list] |
 | Sidebar | ✅ / ⚠️ | Added entries for: [list] |

--- a/docs/docs/repo-ops/releases.md
+++ b/docs/docs/repo-ops/releases.md
@@ -90,11 +90,13 @@ This checks and fixes:
 - Navbar version label
 
 > **Versioned docs are no longer committed.** Pushing a release tag runs the
-> `[Docs] Register Published Version` workflow, which adds the version to
-> `docs/published-versions.json` (applying the retention policy) and opens a tiny
-> auto-merging PR. The versioned snapshots are then materialised from release tags
-> at build time by `docs/scripts/generate-versioned-docs.js` during the GitHub
-> Pages deploy — nothing under `versioned_docs/` is stored in git.
+> `[Docs] Register Published Version` workflow, which records the final release
+> of each of the newest three minor lines in `docs/published-versions.json`.
+> Those three snapshots are materialised from release tags at build time by
+> `docs/scripts/generate-versioned-docs.js` during the GitHub Pages deploy —
+> nothing under `versioned_docs/` is stored in git. The newest snapshot is
+> labelled Latest; development docs remain at Next. Release posts and upgrade
+> guides remain available for every release.
 
 See [Skills → Overview](./skills/) for the full checklist.
 

--- a/docs/docs/repo-ops/skills/index.md
+++ b/docs/docs/repo-ops/skills/index.md
@@ -40,7 +40,7 @@ Audit and sync all documentation surfaces after a release or feature addition.
 |---|---|---|
 | 1 | Release blog posts | A git tag has no matching `docs/releases/` file |
 | 2 | Homepage version string | Helm `--version` in `index.tsx` is behind latest tag |
-| 3 | Published versions | A released tag is missing from `docs/published-versions.json` |
+| 3 | Published versions | A final release from the newest three minor lines is missing from `docs/published-versions.json` |
 | 4 | Features page tiles | New feature docs without a tile in `features.tsx` |
 | 5 | MCP docs | Packaged MCP integration without current docs |
 | 6 | Sidebar | Doc directory not in `sidebars.ts` |

--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
-    "build": "docusaurus build",
+    "build": "npm run test:version-policy && docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",
     "clear": "docusaurus clear",
@@ -13,7 +13,8 @@
     "write-translations": "docusaurus write-translations",
     "write-heading-ids": "docusaurus write-heading-ids",
     "postinstall": "node scripts/patch-gray-matter-js-yaml.mjs && node scripts/patch-image-size-dos.mjs",
-    "typecheck": "tsc"
+    "typecheck": "tsc",
+    "test:version-policy": "node scripts/test-versioned-docs-policy.js"
   },
   "dependencies": {
     "@docusaurus/core": "3.9.2",

--- a/docs/scripts/generate-versioned-docs.js
+++ b/docs/scripts/generate-versioned-docs.js
@@ -3,12 +3,13 @@
  * Generate Docusaurus versioned docs at build time from git release tags.
  *
  * Instead of committing `versioned_docs/` snapshots into the repo, the published
- * versions are listed in `docs/published-versions.json` and materialised here, on
- * demand, by snapshotting each tag's `docs/` tree with the current Docusaurus
- * toolchain. The generated `versioned_docs/`, `versioned_sidebars/`,
+ * versions are listed in `docs/published-versions.json`. They are the final
+ * releases of the newest three minor lines and are materialised here, on demand,
+ * with the current Docusaurus toolchain. The generated `versioned_docs/`,
+ * `versioned_sidebars/`,
  * `versions.json` and `versions-config.json` are git-ignored.
  *
- * Mechanism (per published version X.Y.Z):
+ * Mechanism (per published release X.Y.Z):
  *   1. `git worktree add` a detached checkout at tag X.Y.Z.
  *   2. Reuse the current `docs/node_modules` (symlink) so the snapshot is produced
  *      with the toolchain that will actually build the site.
@@ -28,6 +29,7 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 const { execSync } = require('child_process');
+const { createVersionsConfig, normalizeVersions } = require('./versioned-docs-policy');
 
 const DOCS_DIR = path.join(__dirname, '..');
 const REPO_ROOT = path.resolve(DOCS_DIR, '..');
@@ -205,15 +207,6 @@ function sanitizeMdxBreakingPatterns(absFile) {
   return true;
 }
 
-function compareVersionsDesc(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    if ((pa[i] || 0) !== (pb[i] || 0)) return (pb[i] || 0) - (pa[i] || 0);
-  }
-  return 0;
-}
-
 // ---------------------------------------------------------------------------
 
 if (!fs.existsSync(PUBLISHED_JSON)) {
@@ -226,11 +219,11 @@ if (!fs.existsSync(NODE_MODULES)) {
   process.exit(1);
 }
 
-let versions = JSON.parse(fs.readFileSync(PUBLISHED_JSON, 'utf8'));
-versions = [...new Set(versions)].sort(compareVersionsDesc);
+const publishedVersions = normalizeVersions(JSON.parse(fs.readFileSync(PUBLISHED_JSON, 'utf8')));
+const versionsConfig = createVersionsConfig(publishedVersions);
 
-if (versions.length === 0) {
-  console.log('No published versions listed; nothing to generate. Building current docs only.');
+if (publishedVersions.length === 0) {
+  console.log('No published versions listed; building current docs only.');
 }
 
 // Start from a clean slate so stale generated versions never leak into a build.
@@ -242,7 +235,7 @@ fs.mkdirSync(VERSIONED_SIDEBARS_DIR, { recursive: true });
 const worktreeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'caipe-docs-versions-'));
 
 try {
-  for (const version of versions) {
+  for (const version of publishedVersions) {
     const tag = version;
 
     try {
@@ -294,24 +287,16 @@ try {
   fs.rmSync(worktreeRoot, { recursive: true, force: true });
 }
 
-// versions.json: newest first.
-fs.writeFileSync(VERSIONS_JSON, JSON.stringify(versions, null, 2) + '\n');
-
-// versions-config.json: latest at root path, others under their version path.
-const latest = versions[0];
-const versionsBlock = {
-  current: { label: 'main 🚧', path: 'next', badge: true },
-};
-if (latest) {
-  versionsBlock[latest] = { label: `${latest} (Latest)`, path: '', badge: false };
-  for (const v of versions.slice(1)) {
-    versionsBlock[v] = { label: v, path: v, badge: false };
-  }
-}
+// Published releases include the root-path latest snapshot and two older
+// minor-line snapshots. Current development docs remain at /next.
+fs.writeFileSync(VERSIONS_JSON, JSON.stringify(publishedVersions, null, 2) + '\n');
 
 fs.writeFileSync(
   VERSIONS_CONFIG_JSON,
-  JSON.stringify({ lastVersion: latest || 'current', versions: versionsBlock }, null, 2) + '\n'
+  JSON.stringify(versionsConfig, null, 2) + '\n'
 );
 
-console.log(`\nDone. Generated ${versions.length} version(s): ${versions.join(', ') || '(none)'}`);
+console.log(
+  `\nDone. Generated ${publishedVersions.length} version(s): ` +
+    `${publishedVersions.join(', ') || '(none)'}`
+);

--- a/docs/scripts/test-versioned-docs-policy.js
+++ b/docs/scripts/test-versioned-docs-policy.js
@@ -1,0 +1,27 @@
+'use strict';
+
+const assert = require('assert/strict');
+const { createVersionsConfig, retainVersions } = require('./versioned-docs-policy');
+
+assert.deepStrictEqual(
+  retainVersions(['0.4.18', '0.5.68', '0.6.0', '0.5.69', '0.3.2']),
+  ['0.6.0', '0.5.69', '0.4.18']
+);
+assert.deepStrictEqual(
+  retainVersions(['0.4.18', '0.5.69', '0.6.0', '0.6.1', '0.7.0']),
+  ['0.7.0', '0.6.1', '0.5.69']
+);
+assert.deepStrictEqual(
+  createVersionsConfig(['0.6.0', '0.5.69', '0.4.18']),
+  {
+    lastVersion: '0.6.0',
+    versions: {
+      current: { label: 'Next', path: 'next', badge: true },
+      '0.6.0': { label: '0.6 (Latest)', path: '', badge: false },
+      '0.5.69': { label: '0.5', path: '0.5', badge: false },
+      '0.4.18': { label: '0.4', path: '0.4', badge: false },
+    },
+  }
+);
+
+console.log('versioned docs policy: OK');

--- a/docs/scripts/update-published-versions.js
+++ b/docs/scripts/update-published-versions.js
@@ -6,13 +6,12 @@
  * generate-versioned-docs.js, never committed.
  *
  * Retention policy:
- *   - Keep the latest MAX_PATCHES patches of the current minor series.
- *   - Keep only the highest patch of each older minor series.
- *   - Keep at most MAX_MINORS minor series in total (newest first).
+ *   - Keep the final release of the newest three minor series as frozen
+ *     snapshots.
  *
- * MAX_PATCHES caps versioned-docs build size. Each additional version adds
- * ~1-2 GB to the Docusaurus static-generation heap; 5 patches is the tested
- * safe ceiling on the 8 GB CI runner.
+ * Frozen snapshots are the only generated versioned-docs trees. Keeping three
+ * limits the Docusaurus static-generation footprint while leaving historical
+ * release notes and upgrade guides in the releases blog intact.
  *
  * Usage:
  *   NEW_VERSION=0.5.3 node docs/scripts/update-published-versions.js
@@ -24,26 +23,10 @@
 
 const fs = require('fs');
 const path = require('path');
+const { retainVersions } = require('./versioned-docs-policy');
 
 const DOCS_DIR = path.join(__dirname, '..');
 const PUBLISHED_JSON = path.join(DOCS_DIR, 'published-versions.json');
-
-const MAX_MINORS = 3;
-const MAX_PATCHES = 5; // keep last 5 patches of the current minor
-
-function compareVersionsDesc(a, b) {
-  const pa = a.split('.').map(Number);
-  const pb = b.split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    if ((pa[i] || 0) !== (pb[i] || 0)) return (pb[i] || 0) - (pa[i] || 0);
-  }
-  return 0;
-}
-
-function minorKey(v) {
-  const [major, minor] = v.split('.').map(Number);
-  return `${major}.${minor}`;
-}
 
 const newVersion = (process.env.NEW_VERSION || '').replace(/^v/, '').trim();
 if (!/^\d+\.\d+\.\d+$/.test(newVersion)) {
@@ -56,36 +39,7 @@ if (fs.existsSync(PUBLISHED_JSON)) {
   versions = JSON.parse(fs.readFileSync(PUBLISHED_JSON, 'utf8'));
 }
 
-versions = [...new Set([newVersion, ...versions])].sort(compareVersionsDesc);
-
-// Group by minor series (already sorted desc, so index 0 of each group is highest).
-const byMinor = {};
-for (const v of versions) {
-  const key = minorKey(v);
-  (byMinor[key] = byMinor[key] || []).push(v);
-}
-
-const sortedMinors = Object.keys(byMinor).sort((a, b) => {
-  const [aMaj, aMin] = a.split('.').map(Number);
-  const [bMaj, bMin] = b.split('.').map(Number);
-  if (aMaj !== bMaj) return bMaj - aMaj;
-  return bMin - aMin;
-});
-
-const currentMinor = sortedMinors[0];
-const keep = new Set();
-
-for (const minor of sortedMinors.slice(0, MAX_MINORS)) {
-  if (minor === currentMinor) {
-    // Keep only the latest MAX_PATCHES patches of the current minor series.
-    byMinor[minor].slice(0, MAX_PATCHES).forEach((v) => keep.add(v));
-  } else {
-    // Keep only the highest patch of older minor series.
-    keep.add(byMinor[minor][0]);
-  }
-}
-
-const updated = versions.filter((v) => keep.has(v)).sort(compareVersionsDesc);
+const updated = retainVersions([newVersion, ...versions]);
 
 fs.writeFileSync(PUBLISHED_JSON, JSON.stringify(updated, null, 2) + '\n');
 console.log(`published-versions.json -> [${updated.join(', ')}]`);

--- a/docs/scripts/versioned-docs-policy.js
+++ b/docs/scripts/versioned-docs-policy.js
@@ -1,0 +1,64 @@
+'use strict';
+
+const RETAINED_MINORS = 3;
+
+function compareVersionsDesc(a, b) {
+  const pa = a.split('.').map(Number);
+  const pb = b.split('.').map(Number);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] || 0) !== (pb[i] || 0)) return (pb[i] || 0) - (pa[i] || 0);
+  }
+  return 0;
+}
+
+function minorKey(version) {
+  return version.split('.').slice(0, 2).join('.');
+}
+
+function normalizeVersions(versions) {
+  return [...new Set(versions)].sort(compareVersionsDesc);
+}
+
+function retainVersions(versions) {
+  const byMinor = {};
+  for (const version of normalizeVersions(versions)) {
+    const minor = minorKey(version);
+    (byMinor[minor] = byMinor[minor] || []).push(version);
+  }
+
+  const retainedMinors = Object.keys(byMinor)
+    .sort((a, b) => compareVersionsDesc(`${a}.0`, `${b}.0`))
+    .slice(0, RETAINED_MINORS);
+  const retained = retainedMinors.map((minor) => byMinor[minor][0]);
+  return normalizeVersions(retained);
+}
+
+function createVersionsConfig(versions) {
+  const publishedVersions = normalizeVersions(versions);
+  const latest = publishedVersions[0];
+  const versionsBlock = {
+    current: { label: 'Next', path: 'next', badge: true },
+  };
+
+  if (latest) {
+    versionsBlock[latest] = { label: `${minorKey(latest)} (Latest)`, path: '', badge: false };
+    for (const version of publishedVersions.slice(1)) {
+      versionsBlock[version] = {
+        label: minorKey(version),
+        path: minorKey(version),
+        badge: false,
+      };
+    }
+  }
+
+  return {
+    lastVersion: latest || 'current',
+    versions: versionsBlock,
+  };
+}
+
+module.exports = {
+  createVersionsConfig,
+  normalizeVersions,
+  retainVersions,
+};


### PR DESCRIPTION
REQUIRES DISCUSSION @sriaradhyula 

# Description

Implements the retained-docs policy using the latest released patch of the newest three minor lines: `0.6.0`, `0.5.69`, and `0.4.18`. All three are frozen release snapshots. The selector shows `0.6 (Latest)` at the root, `0.5`, `0.4`, and development docs as `Next` at `/next`.

Full docs snapshots below 0.4 are excluded from generation, the selector, the built site, and search. Historical release notes and upgrade-guide posts remain unchanged.

## Merge coordination

Merge this PR (#2455) first. Then rebase #2454 and preserve its retired-doc pruning logic alongside this PR's release allowlist and selector policy; both modify `docs/scripts/generate-versioned-docs.js`.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

Not applicable; no chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All relevant new and existing tests pass

## Validation

- `npm run test:version-policy` deterministically asserts retained-version selection and the generated Latest/Next configuration.
- `node scripts/generate-versioned-docs.js` generated only `version-0.6.0`, `version-0.5.69`, and `version-0.4.18`.
- `CI=1 npm run build` passed; it runs the policy test, compiles, generates static files, and builds Lunr search.
- Route-level search assertion verified 33,729 indexed URLs include `/docs/`, `/docs/0.5/`, `/docs/0.4/`, and `/docs/next/`, with no `/docs/0.3` route.
- Build emits existing broken-anchor warnings in current/frozen documentation but exits successfully.
- `git diff main...HEAD --check` passed; no files under `docs/releases/` or `docs/blog/` changed.

The amended commit carries the explicitly authorized DCO sign-off: `kevkantes <kkantesa@cisco.com>`.