### PR TITLE
docs(pr): correct prebuild branch prefix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,7 +23,7 @@ Please ensure commits conform to the [Commit Guideline](https://www.conventional
 ## Pre-release Helm Charts (Optional)
 
 For chart changes, you can test pre-release versions before merging:
-- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
+- **Base repo contributors:** Create a branch starting with `prebuild/` for automatic pre-release builds
 - **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
 - Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
 - Cleanup happens automatically when the PR closes or label is removed


### PR DESCRIPTION
# Description

Correct the base-repository branch prefix in the pull request template from pre/ to prebuild/.

AGENTS.md and CONTRIBUTING.md both document prebuild/, and the relevant prebuild, cleanup, manual-dispatch, and CI workflow conditions use that same prefix. The template was the only contradictory contributor-facing instruction.

This is intentionally a one-line documentation-only change. No workflows or other documentation are modified.

Related: #2453

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Pre-release Helm Charts (Optional)

Not applicable; no chart changes.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] Code-style checks are not applicable to this one-line Markdown change
- [x] No new code requires automated test coverage
- [x] Automated tests are not applicable to this documentation-only change

## Validation

- Canonical-prefix search: AGENTS.md, CONTRIBUTING.md, and relevant workflows use prebuild/
- Contradictory template search: no remaining base-contributor pre/ instruction
- git diff --check: PASS
- Exact diff: one insertion and one deletion in .github/pull_request_template.md
