### PR TITLE
test(ui): remove tautological component checks

### DIFF
--- a/ui/src/components/__tests__/theme-toggle.test.tsx
+++ b/ui/src/components/__tests__/theme-toggle.test.tsx
@@ -100,11 +100,6 @@ describe("ThemeToggle", () => {
     mockResolvedTheme = "dark";
   });
 
-  it("renders without crashing", () => {
-    const { container } = render(<ThemeToggle />);
-    expect(container).toBeInTheDocument();
-  });
-
   it("shows current theme label after mount", async () => {
     render(<ThemeToggle />);
     await waitFor(() => {
@@ -219,11 +214,6 @@ describe("ThemeQuickToggle", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockResolvedTheme = "dark";
-  });
-
-  it("renders without crashing", () => {
-    const { container } = render(<ThemeQuickToggle />);
-    expect(container).toBeInTheDocument();
   });
 
   it("shows sun icon in dark mode", async () => {

--- a/ui/src/components/__tests__/token-expiry-guard.test.tsx
+++ b/ui/src/components/__tests__/token-expiry-guard.test.tsx
@@ -155,6 +155,7 @@ describe('TokenExpiryGuard', () => {
     // Should not show any warnings
     expect(screen.queryByText(/session expiring soon/i)).not.toBeInTheDocument()
     expect(screen.queryByText(/session expired/i)).not.toBeInTheDocument()
+    expect(mockSignOut).not.toHaveBeenCalled()
   })
 
   it('should not call signOut when token expires soon (warning only)', async () => {
@@ -185,39 +186,6 @@ describe('TokenExpiryGuard', () => {
     expect(mockSignOut).not.toHaveBeenCalled()
   })
 
-  it('should check token expiry periodically', async () => {
-    const futureExpiry = Math.floor(Date.now() / 1000) + 600
-
-    // Track when checkTokenExpiry is called by spying on console.warn
-    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation()
-
-    mockUseSession.mockReturnValue({
-      data: {
-        user: { name: 'Test User', email: 'test@example.com' },
-        expiresAt: futureExpiry,
-        accessToken: 'test-token',
-      } as unknown,
-      status: 'authenticated',
-      update: mockUpdateSession,
-    })
-
-    render(<TokenExpiryGuard />)
-
-    // Clear any initial logs
-    consoleSpy.mockClear()
-
-    // Advance by 30 seconds (one check cycle) - this should trigger the interval
-    await act(async () => {
-      jest.advanceTimersByTime(30000)
-    })
-
-    // Component should still be checking (no warning or errors)
-    // Just verify no errors were thrown and component is still mounted
-    expect(mockSignOut).not.toHaveBeenCalled()
-
-    consoleSpy.mockRestore()
-  })
-
   it('should cleanup interval on unmount', () => {
     const futureExpiry = Math.floor(Date.now() / 1000) + 600
 
@@ -231,15 +199,11 @@ describe('TokenExpiryGuard', () => {
     })
 
     const { unmount } = render(<TokenExpiryGuard />)
+    const mountedTimerCount = jest.getTimerCount()
+    expect(mountedTimerCount).toBeGreaterThan(0)
 
     unmount()
-
-    // Advance time - no errors should occur
-    act(() => {
-      jest.advanceTimersByTime(60000)
-    })
-
-    // No assertions needed - just ensuring no errors
+    expect(jest.getTimerCount()).toBeLessThan(mountedTimerCount)
   })
 
   // ─────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
# Description

Removes four UI unit-test cases that did not independently verify product behavior, and turns one no-assertion cleanup case into a real timer-cleanup check:

- `TokenExpiryGuard`: removes a direct constant assertion and a duplicate periodic-check case; the useful "does not sign out" assertion now lives in the existing healthy-token test.
- `TokenExpiryGuard`: the unmount case now proves the component reduces its active timer count instead of merely advancing timers and asserting nothing.
- `ThemeToggle` and `ThemeQuickToggle`: removes container-only "renders without crashing" cases; adjacent tests already render each component and assert visible behavior.

Related to #2428.

## Type of Change

- [x] Other (test-suite maintenance)

## Pre-release Helm Charts (Optional)

Not applicable.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (not applicable; test-only cleanup)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing focused tests pass

## Validation

- Focused Jest: 45 passed.
- File-level ESLint passed for the agent-authored diff; the main review changed only Jest assertions and reran the focused suite.
- Playwright discovery: 346 tests in 62 files.
- `git diff --check`: passed.
