### PR TITLE
fix(ui): align new chat agent resolution

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.3"
+version = "1.0.0-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/components/chat/NewChatButton.tsx
+++ b/ui/src/components/chat/NewChatButton.tsx
@@ -2,7 +2,7 @@
 
 import { AgentAvatar } from "@/components/dynamic-agents/AgentAvatar";
 import { Button } from "@/components/ui/button";
-import { fetchChatDefaultAgentIds } from "@/lib/chat-agent-selection";
+import { resolveUsableChatAgent } from "@/lib/chat-agent-selection";
 import { cn } from "@/lib/utils";
 import type { DynamicAgentConfig } from "@/types/dynamic-agent";
 import { ChevronDown,Loader2,Plus,Search } from "lucide-react";
@@ -25,33 +25,19 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
   const [defaultAgentName, setDefaultAgentName] = useState<string>("New Chat");
   const [defaultAgentResolved, setDefaultAgentResolved] = useState(false);
 
-  // Fetch configured default agent on mount
+  // Resolve the same usable agent as the Home composer: personal Web default,
+  // platform default, then the first accessible agent. Keeping this selection
+  // in one shared resolver prevents entry points from creating different chats.
   useEffect(() => {
     let cancelled = false;
 
     async function fetchDefaultAgent() {
       try {
-        const { userDefaultAgentId, platformDefaultAgentId } =
-          await fetchChatDefaultAgentIds();
-        const agentId = userDefaultAgentId ?? platformDefaultAgentId;
+        const agent = await resolveUsableChatAgent();
 
         if (cancelled) return;
-
-        setDefaultAgentId(agentId);
-
-        if (agentId) {
-          try {
-            const agentResponse = await fetch(`/api/dynamic-agents/agents/${encodeURIComponent(agentId)}`);
-            if (agentResponse.ok) {
-              const agentData = await agentResponse.json();
-              if (!cancelled && agentData.success && agentData.data?.name) {
-                setDefaultAgentName(agentData.data.name);
-              }
-            }
-          } catch {
-            // Keep the generic label; the agent id still routes the chat correctly.
-          }
-        }
+        setDefaultAgentId(agent.id);
+        setDefaultAgentName(agent.name);
       } catch {
         if (!cancelled) {
           setDefaultAgentId(null);

--- a/ui/src/components/chat/__tests__/NewChatButton.test.tsx
+++ b/ui/src/components/chat/__tests__/NewChatButton.test.tsx
@@ -21,6 +21,11 @@ jest.mock("lucide-react", () => ({
 }));
 
 const mockFetch = jest.fn();
+const mockResolveUsableChatAgent = jest.fn();
+
+jest.mock("@/lib/chat-agent-selection", () => ({
+  resolveUsableChatAgent: () => mockResolveUsableChatAgent(),
+}));
 
 import { NewChatButton } from "../NewChatButton";
 
@@ -29,54 +34,12 @@ beforeEach(() => {
   global.fetch = mockFetch;
 });
 
-/**
- * Route fetch by URL. `prefsAgentId` is the user's personal Web default
- * (null → none); `platformAgentId` is the resolved platform default returned
- * by the same preferences endpoint.
- * `agentNames` maps agent id → display name for the detail lookup.
- */
-function mockFetchByUrl(opts: {
-  prefsAgentId?: string | null;
-  platformAgentId?: string | null;
-  agentNames?: Record<string, string>;
-  prefsPromise?: Promise<Response>;
-}) {
-  const { prefsAgentId = null, platformAgentId = null, agentNames = {} } = opts;
-  mockFetch.mockImplementation((url: string) => {
-    if (url === "/api/user/preferences") {
-      if (opts.prefsPromise) return opts.prefsPromise;
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({
-          success: true,
-          data: {
-            web_default_agent_id: prefsAgentId,
-            platform_default_agent_id: platformAgentId,
-          },
-        }),
-      } as Response);
-    }
-    const match = url.match(/^\/api\/dynamic-agents\/agents\/(.+)$/);
-    if (match) {
-      const id = decodeURIComponent(match[1]);
-      return Promise.resolve({
-        ok: true,
-        json: async () => ({ success: true, data: { _id: id, name: agentNames[id] ?? id } }),
-      } as Response);
-    }
-    return Promise.resolve({ ok: false, json: async () => ({ success: false }) } as Response);
-  });
-}
-
 describe("NewChatButton", () => {
   it("waits for default-agent resolution before creating a new chat", async () => {
-    let resolvePrefs: (value: Response) => void = () => {};
-    mockFetchByUrl({
-      platformAgentId: "agent-default",
-      prefsPromise: new Promise<Response>((resolve) => {
-        resolvePrefs = resolve;
-      }),
-    });
+    let resolveAgent: (value: { id: string; name: string; source: "platform-default" }) => void = () => {};
+    mockResolveUsableChatAgent.mockReturnValue(new Promise((resolve) => {
+      resolveAgent = resolve;
+    }));
     const onNewChat = jest.fn();
 
     render(<NewChatButton collapsed={false} onNewChat={onNewChat} />);
@@ -86,16 +49,7 @@ describe("NewChatButton", () => {
     fireEvent.click(mainButton);
     expect(onNewChat).not.toHaveBeenCalled();
 
-    resolvePrefs({
-      ok: true,
-      json: async () => ({
-        success: true,
-        data: {
-          web_default_agent_id: null,
-          platform_default_agent_id: "agent-default",
-        },
-      }),
-    } as Response);
+    resolveAgent({ id: "agent-default", name: "Platform Helper", source: "platform-default" });
 
     await waitFor(() => expect(mainButton).not.toBeDisabled());
     fireEvent.click(mainButton);
@@ -104,22 +58,22 @@ describe("NewChatButton", () => {
   });
 
   it("shows the configured default agent name once it can resolve the agent", async () => {
-    mockFetchByUrl({
-      platformAgentId: "agent-default",
-      agentNames: { "agent-default": "Platform Helper" },
+    mockResolveUsableChatAgent.mockResolvedValue({
+      id: "agent-default",
+      name: "Platform Helper",
+      source: "platform-default",
     });
 
     render(<NewChatButton collapsed={false} onNewChat={jest.fn()} />);
 
     expect(await screen.findByText("Platform Helper")).toBeInTheDocument();
-    expect(mockFetch).toHaveBeenCalledWith("/api/dynamic-agents/agents/agent-default");
   });
 
   it("prefers the user's web default over the platform default", async () => {
-    mockFetchByUrl({
-      prefsAgentId: "agent-user",
-      platformAgentId: "agent-default",
-      agentNames: { "agent-user": "My Agent", "agent-default": "Platform Helper" },
+    mockResolveUsableChatAgent.mockResolvedValue({
+      id: "agent-user",
+      name: "My Agent",
+      source: "user-default",
     });
     const onNewChat = jest.fn();
 
@@ -131,16 +85,20 @@ describe("NewChatButton", () => {
     expect(onNewChat).toHaveBeenCalledWith("agent-user");
   });
 
-  it("calls onNewChat with undefined when no default agent is configured", async () => {
-    mockFetchByUrl({ prefsAgentId: null, platformAgentId: null });
+  it("uses the first accessible agent when no personal or platform default is configured", async () => {
+    mockResolveUsableChatAgent.mockResolvedValue({
+      id: "agent-first",
+      name: "First Accessible Agent",
+      source: "first-available",
+    });
     const onNewChat = jest.fn();
 
     render(<NewChatButton collapsed={false} onNewChat={onNewChat} />);
 
-    const mainButton = screen.getByRole("button", { name: /new chat/i });
+    const mainButton = await screen.findByRole("button", { name: /first accessible agent/i });
     await waitFor(() => expect(mainButton).not.toBeDisabled());
     fireEvent.click(mainButton);
 
-    expect(onNewChat).toHaveBeenCalledWith(undefined);
+    expect(onNewChat).toHaveBeenCalledWith("agent-first");
   });
 });

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev3"
+version = "1.0.0.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Use the shared chat-agent resolver in the sidebar New Chat action, matching the Home composer. Resolution order remains:

1. Personal Web default
2. Platform default
3. First accessible agent

This removes the inconsistent generic `New Chat` fallback when no explicit defaults are configured and ensures the displayed agent is the agent passed to conversation creation. This is independent of Harness Engine.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- Targeted NewChatButton tests: 4/4 passed
- ESLint: passed for changed files
- TypeScript (`tsc --noEmit`): passed
- Added regression coverage for first-accessible-agent fallback

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in code
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] Relevant existing tests pass