### PR TITLE
fix(ui): support legacy conversation identifiers

### DIFF
--- a/docs/docs/security/rbac/usage.md
+++ b/docs/docs/security/rbac/usage.md
@@ -14,6 +14,14 @@ COMPOSE_PROFILES='rbac,caipe-ui,caipe-mongodb' \
 docker compose -f docker-compose.dev.yaml ps keycloak
 ```
 
+## Conversation History Compatibility
+
+Chat API routes accept both UUID conversation IDs and bounded legacy opaque IDs.
+This keeps history created before server-owned UUID generation readable and
+manageable. The identifier is only used for an exact record lookup; the normal
+conversation authorization check still runs after the record is loaded for
+every read, update, archive, restore, bookmark, share, and message operation.
+
 Keycloak admin console: `http://localhost:7080/admin` (admin / admin)
 
 When the `rbac` profile is selected, `caipe-ui` has an optional `depends_on`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.3"
+version = "1.0.0-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/app/api/__tests__/chat-conversation-metadata-auth.test.ts
+++ b/ui/src/app/api/__tests__/chat-conversation-metadata-auth.test.ts
@@ -38,7 +38,7 @@ jest.mock("@/lib/api-middleware", () => {
       },
     successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
     ApiError,
-    validateUUID: () => true,
+    validateConversationId: () => true,
   };
 });
 

--- a/ui/src/app/api/__tests__/chat-conversations-remaining-rbac.test.ts
+++ b/ui/src/app/api/__tests__/chat-conversations-remaining-rbac.test.ts
@@ -37,8 +37,8 @@ jest.mock("@/lib/api-middleware", () => {
     requireOwnership: (...args: unknown[]) => mockRequireOwnership(...args),
     successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
     validateEmail: () => true,
+    validateConversationId: () => true,
     validateRequired: jest.fn(),
-    validateUUID: () => true,
     withAuth: async (_request: NextRequest, handler: (...args: unknown[]) => Promise<Response>) =>
       handler(_request, user, session),
     withErrorHandler:

--- a/ui/src/app/api/__tests__/chat-messages.test.ts
+++ b/ui/src/app/api/__tests__/chat-messages.test.ts
@@ -13,7 +13,7 @@
  * - Client-generated message_id tracking
  * - Turn ID metadata for message grouping
  * - Conversation access control (owner + shared users)
- * - UUID validation
+ * - UUID and legacy conversation identifier validation
  * - Pagination
  */
 
@@ -139,15 +139,37 @@ describe('GET /api/chat/conversations/[id]/messages', () => {
     expect(res.status).toBe(401);
   });
 
-  it('returns 400 for invalid UUID format', async () => {
+  it('returns 400 for an unsafe conversation identifier', async () => {
     mockGetServerSession.mockResolvedValue(authenticatedSession());
     const usersCol = createMockCollection();
     usersCol.findOne.mockResolvedValue(null);
     mockCollections['users'] = usersCol;
 
-    const req = makeRequest('/api/chat/conversations/invalid-id/messages');
-    const res = await GET(req, { params: Promise.resolve({ id: 'invalid-id' }) });
+    const req = makeRequest('/api/chat/conversations/invalid/messages');
+    const res = await GET(req, { params: Promise.resolve({ id: '../invalid' }) });
     expect(res.status).toBe(400);
+  });
+
+  it('accepts a legacy conversation identifier', async () => {
+    mockGetServerSession.mockResolvedValue(authenticatedSession());
+    const legacyId = 'legacy-demo-conversation';
+
+    const usersCol = createMockCollection();
+    usersCol.findOne.mockResolvedValue(null);
+    mockCollections['users'] = usersCol;
+
+    const convCol = createMockCollection();
+    convCol.findOne.mockResolvedValue({
+      _id: legacyId,
+      owner_id: 'user@example.com',
+    });
+    mockCollections['conversations'] = convCol;
+    mockCollections['messages'] = createMockCollection();
+
+    const req = makeRequest(`/api/chat/conversations/${legacyId}/messages`);
+    const res = await GET(req, { params: Promise.resolve({ id: legacyId }) });
+
+    expect(res.status).toBe(200);
   });
 
   it('returns paginated messages for authorized user', async () => {

--- a/ui/src/app/api/__tests__/recycle-bin.test.ts
+++ b/ui/src/app/api/__tests__/recycle-bin.test.ts
@@ -18,7 +18,7 @@
  * - Trash listing with auto-purge of 7-day-old conversations
  * - Normal listing excludes soft-deleted conversations
  * - Ownership enforcement
- * - UUID validation
+ * - UUID and legacy conversation identifier validation
  */
 
 import { NextRequest } from 'next/server';
@@ -135,6 +135,7 @@ function makeConversation(overrides: unknown = {}) {
 // ============================================================================
 
 import { DELETE } from '../chat/conversations/[id]/route';
+import { POST as TOGGLE_ARCHIVE } from '../chat/conversations/[id]/archive/route';
 import { POST as RESTORE } from '../chat/conversations/[id]/restore/route';
 import { GET as GET_TRASH } from '../chat/conversations/trash/route';
 import { GET as GET_CONVERSATIONS } from '../chat/conversations/route';
@@ -237,13 +238,57 @@ describe('Archive API', () => {
       expect(res.status).toBe(403);
     });
 
-    it('returns 400 for invalid UUID', async () => {
-      const req = makeRequest('http://localhost:3000/api/chat/conversations/not-a-uuid', {
+    it('soft-deletes a legacy conversation identifier', async () => {
+      const legacyId = 'legacy-demo-conversation';
+      const conv = makeConversation({ _id: legacyId });
+      const convCollection = createMockCollection();
+      convCollection.findOne.mockResolvedValue(conv);
+      mockCollections['conversations'] = convCollection;
+
+      const req = makeRequest(`http://localhost:3000/api/chat/conversations/${legacyId}`, {
         method: 'DELETE',
       });
 
-      const res = await DELETE(req, { params: Promise.resolve({ id: 'not-a-uuid' }) });
+      const res = await DELETE(req, { params: Promise.resolve({ id: legacyId }) });
+
+      expect(res.status).toBe(200);
+      expect(convCollection.updateOne).toHaveBeenCalledWith(
+        { _id: legacyId },
+        { $set: expect.objectContaining({ is_archived: true, deleted_at: expect.any(Date) }) },
+      );
+    });
+
+    it('returns 400 for an unsafe conversation identifier', async () => {
+      const invalidId = 'conversation?permanent=true';
+      const req = makeRequest('http://localhost:3000/api/chat/conversations/invalid', {
+        method: 'DELETE',
+      });
+
+      const res = await DELETE(req, { params: Promise.resolve({ id: invalidId }) });
       expect(res.status).toBe(400);
+    });
+  });
+
+  describe('POST /api/chat/conversations/[id]/archive', () => {
+    it('toggles archive for a legacy conversation identifier', async () => {
+      const legacyId = 'legacy-demo-conversation';
+      const conv = makeConversation({ _id: legacyId });
+      const convCollection = createMockCollection();
+      convCollection.findOne
+        .mockResolvedValueOnce(conv)
+        .mockResolvedValueOnce({ ...conv, is_archived: true });
+      mockCollections['conversations'] = convCollection;
+
+      const req = makeRequest(`http://localhost:3000/api/chat/conversations/${legacyId}/archive`, {
+        method: 'POST',
+      });
+      const res = await TOGGLE_ARCHIVE(req, { params: Promise.resolve({ id: legacyId }) });
+
+      expect(res.status).toBe(200);
+      expect(convCollection.updateOne).toHaveBeenCalledWith(
+        { _id: legacyId },
+        { $set: expect.objectContaining({ is_archived: true, updated_at: expect.any(Date) }) },
+      );
     });
   });
 

--- a/ui/src/app/api/chat/bookmarks/route.ts
+++ b/ui/src/app/api/chat/bookmarks/route.ts
@@ -7,7 +7,7 @@ getPaginationParams,
 paginatedResponse,
 successResponse,
 validateRequired,
-validateUUID,
+validateConversationId,
 withAuth,
 withErrorHandler,
 } from '@/lib/api-middleware';
@@ -43,7 +43,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
 
     validateRequired(body, ['conversation_id']);
 
-    if (!validateUUID(body.conversation_id)) {
+    if (!validateConversationId(body.conversation_id)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
     await requireResourcePermission(session, {

--- a/ui/src/app/api/chat/conversations/[id]/archive/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/archive/route.ts
@@ -3,7 +3,7 @@
 import {
 ApiError,
 successResponse,
-validateUUID,
+validateConversationId,
 withAuth,
 withErrorHandler,
 } from '@/lib/api-middleware';
@@ -21,7 +21,7 @@ export const POST = withErrorHandler(async (
     const params = await context.params;
     const conversationId = params.id;
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 

--- a/ui/src/app/api/chat/conversations/[id]/messages/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/messages/route.ts
@@ -12,7 +12,7 @@ paginatedResponse,
 requireConversationAccess,
 successResponse,
 validateRequired,
-validateUUID,
+validateConversationId,
 withErrorHandler,
 } from '@/lib/api-middleware';
 import type { ConversationAccessLevel } from '@/lib/api-middleware';
@@ -35,7 +35,7 @@ export const GET = withErrorHandler(async (
   const params = await context.params;
   const conversationId = params.id;
 
-  if (!validateUUID(conversationId)) {
+  if (!validateConversationId(conversationId)) {
     throw new ApiError('Invalid conversation ID format', 400);
   }
 
@@ -80,7 +80,7 @@ export const POST = withErrorHandler(async (
   const conversationId = params.id;
   const body: AddMessageRequest = await request.json();
 
-  if (!validateUUID(conversationId)) {
+  if (!validateConversationId(conversationId)) {
     throw new ApiError('Invalid conversation ID format', 400);
   }
 

--- a/ui/src/app/api/chat/conversations/[id]/metadata/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/metadata/route.ts
@@ -11,7 +11,7 @@ import {
 ApiError,
 getAuthFromBearerOrSession,
 successResponse,
-validateUUID,
+validateConversationId,
 withErrorHandler,
 } from '@/lib/api-middleware';
 import { getCollection,isMongoDBConfigured } from '@/lib/mongodb';
@@ -35,7 +35,7 @@ export const PATCH = withErrorHandler(async (
   const params = await context.params;
   const conversationId = params.id;
 
-  if (!validateUUID(conversationId)) {
+  if (!validateConversationId(conversationId)) {
     throw new ApiError('Invalid conversation ID format', 400);
   }
 

--- a/ui/src/app/api/chat/conversations/[id]/pin/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/pin/route.ts
@@ -3,7 +3,7 @@
 import {
 ApiError,
 successResponse,
-validateUUID,
+validateConversationId,
 withAuth,
 withErrorHandler,
 } from '@/lib/api-middleware';
@@ -21,7 +21,7 @@ export const POST = withErrorHandler(async (
     const params = await context.params;
     const conversationId = params.id;
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 

--- a/ui/src/app/api/chat/conversations/[id]/restore/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/restore/route.ts
@@ -3,7 +3,7 @@
 import {
 ApiError,
 successResponse,
-validateUUID,
+validateConversationId,
 withAuth,
 withErrorHandler,
 } from '@/lib/api-middleware';
@@ -21,7 +21,7 @@ export const POST = withErrorHandler(async (
     const params = await context.params;
     const conversationId = params.id;
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 

--- a/ui/src/app/api/chat/conversations/[id]/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/route.ts
@@ -6,7 +6,7 @@ import {
 ApiError,
 requireConversationAccess,
 successResponse,
-validateUUID,
+validateConversationId,
 withAuth,
 withErrorHandler,
 } from '@/lib/api-middleware';
@@ -37,7 +37,7 @@ export const GET = withErrorHandler(async (
     const params = await context.params;
     const conversationId = params.id;
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 
@@ -75,7 +75,7 @@ export const PUT = withErrorHandler(async (
     const conversationId = params.id;
     const body: UpdateConversationRequest = await request.json();
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 
@@ -137,7 +137,7 @@ export const DELETE = withErrorHandler(async (
     const url = new URL(request.url);
     const permanent = url.searchParams.get('permanent') === 'true';
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 

--- a/ui/src/app/api/chat/conversations/[id]/share/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/share/route.ts
@@ -7,7 +7,7 @@ ApiError,
 requireConversationAccess,
 successResponse,
 validateEmail,
-validateUUID,
+validateConversationId,
 withAuth,
 withErrorHandler
 } from '@/lib/api-middleware';
@@ -211,7 +211,7 @@ export const GET = withErrorHandler(async (
     const params = await context.params;
     const conversationId = params.id;
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 
@@ -247,7 +247,7 @@ export const POST = withErrorHandler(async (
     const conversationId = params.id;
     const body: ShareConversationRequest = await request.json();
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 
@@ -388,7 +388,7 @@ export const PATCH = withErrorHandler(async (
     const conversationId = params.id;
     const body = await request.json();
 
-    if (!validateUUID(conversationId)) {
+    if (!validateConversationId(conversationId)) {
       throw new ApiError('Invalid conversation ID format', 400);
     }
 

--- a/ui/src/app/api/chat/conversations/[id]/turns/route.ts
+++ b/ui/src/app/api/chat/conversations/[id]/turns/route.ts
@@ -20,7 +20,7 @@ paginatedResponse,
 requireConversationAccess,
 successResponse,
 validateRequired,
-validateUUID,
+validateConversationId,
 withAuth,
 withErrorHandler,
 } from "@/lib/api-middleware";
@@ -39,7 +39,7 @@ export const GET = withErrorHandler(
     return withAuth(request, async (req, user, session) => {
       const { id: conversationId } = await context.params;
 
-      if (!validateUUID(conversationId)) {
+      if (!validateConversationId(conversationId)) {
         throw new ApiError("Invalid conversation ID format", 400);
       }
 
@@ -88,7 +88,7 @@ export const POST = withErrorHandler(
       const { id: conversationId } = await context.params;
       const body: UpsertTurnRequest = await request.json();
 
-      if (!validateUUID(conversationId)) {
+      if (!validateConversationId(conversationId)) {
         throw new ApiError("Invalid conversation ID format", 400);
       }
 

--- a/ui/src/lib/__tests__/api-middleware.test.ts
+++ b/ui/src/lib/__tests__/api-middleware.test.ts
@@ -195,6 +195,7 @@ import {
   validateRequired,
   validateEmail,
   validateUUID,
+  validateConversationId,
   getPaginationParams,
   successResponse,
   paginatedResponse,
@@ -702,6 +703,23 @@ describe('validateUUID', () => {
 
   it('invalid UUID returns false - invalid chars', () => {
     expect(validateUUID('550e8400-e29b-41d4-a716-44665544000g')).toBe(false);
+  });
+});
+
+describe('validateConversationId', () => {
+  it('accepts UUIDs and legacy URL-safe identifiers', () => {
+    expect(validateConversationId('550e8400-e29b-41d4-a716-446655440000')).toBe(true);
+    expect(validateConversationId('legacy-demo-conversation')).toBe(true);
+    expect(validateConversationId('legacy.chat:thread_42')).toBe(true);
+  });
+
+  it('rejects unsafe, ambiguous, and overlong identifiers', () => {
+    expect(validateConversationId('')).toBe(false);
+    expect(validateConversationId('../conversation')).toBe(false);
+    expect(validateConversationId('conversation?archived=true')).toBe(false);
+    expect(validateConversationId('$conversation')).toBe(false);
+    expect(validateConversationId('conversation with spaces')).toBe(false);
+    expect(validateConversationId('a'.repeat(129))).toBe(false);
   });
 });
 

--- a/ui/src/lib/api-middleware.ts
+++ b/ui/src/lib/api-middleware.ts
@@ -1338,6 +1338,25 @@ export function validateUUID(uuid: string): boolean {
 }
 
 /**
+ * Validate a conversation identifier accepted by the chat API.
+ *
+ * New conversations use UUIDs, but releases before server-owned ID generation
+ * also persisted opaque, URL-safe identifiers. Keep those records operable so
+ * users can read, rename, archive, or delete their existing history. The
+ * identifier is still used only as an exact MongoDB string match; authorization
+ * is enforced after the record is loaded.
+ */
+export function validateConversationId(id: string): boolean {
+  if (validateUUID(id)) return true;
+
+  // Legacy IDs are bounded URL-safe slugs. Excluding path separators, query
+  // delimiters, whitespace, and MongoDB operator characters keeps route
+  // handling unambiguous while accepting historical IDs such as
+  // "legacy-demo-conversation".
+  return /^[A-Za-z0-9](?:[A-Za-z0-9._:-]{0,126}[A-Za-z0-9])?$/.test(id);
+}
+
+/**
  * Parse and validate pagination parameters
  */
 export function getPaginationParams(request: NextRequest) {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev3"
+version = "1.0.0.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Restores backward compatibility for conversations created before server-owned UUID generation. Legacy URL-safe conversation IDs remain fully operable across read, rename, archive, restore, pin, sharing, messages, turns, metadata, and bookmarks while authorization continues to run after the exact record lookup.

New conversations continue to use server-generated UUIDs. Unsafe, ambiguous, and overlong identifiers remain rejected.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- `npm test -- --runInBand src/lib/__tests__/api-middleware.test.ts src/app/api/__tests__/recycle-bin.test.ts src/app/api/__tests__/chat-messages.test.ts src/app/api/__tests__/chat-conversation-metadata-auth.test.ts src/app/api/__tests__/chat-conversations-remaining-rbac.test.ts` — 208 passed
- `npm run lint`
- `npm run build`
- Live preview verified on `caipe-oss.outshift.io` with an existing legacy conversation

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in code
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing targeted tests pass
