### PR TITLE
chore(ci): finish caipe package tree migration

### DIFF
--- a/.claude/skills/release-docs/SKILL.md
+++ b/.claude/skills/release-docs/SKILL.md
@@ -74,7 +74,7 @@ gh pr view <number> --json title,body,labels
 ### 2b — Helm values diff
 
 ```bash
-CHART=oci://ghcr.io/cnoe-io/charts/ai-platform-engineering
+CHART=oci://ghcr.io/caipe-io/charts/ai-platform-engineering
 helm show values "$CHART" --version <from> > /tmp/values-from.yaml
 helm show values "$CHART" --version <to>   > /tmp/values-to.yaml
 diff -u /tmp/values-from.yaml /tmp/values-to.yaml
@@ -217,7 +217,7 @@ global:
 
 ```bash
 helm upgrade ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <to> \
   -f your-values.yaml
 ```

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Please ensure commits conform to the [Commit Guideline](https://www.conventional
 For chart changes, you can test temporary versions before merging:
 - **Base repo contributors:** Create a branch starting with `prebuild/` for automatic prebuilds
 - **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
-- Temporary charts are published to `ghcr.io/cnoe-io/charts` with PR-specific versions
+- Temporary charts are published to `ghcr.io/caipe-io/charts` with PR-specific versions
 - Cleanup happens automatically when the PR closes or label is removed
 
 ## Checklist

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -129,7 +129,7 @@ jobs:
             echo ""
             echo '```bash'
             echo "helm upgrade ai-platform-engineering \\"
-            echo "  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\"
+            echo "  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \\"
             echo "  --version ${NEW_VERSION} \\"
             echo "  -f your-values.yaml"
             echo '```'

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -186,7 +186,7 @@ jobs:
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: scan
         with:
-          image: "ghcr.io/cnoe-io/${{ matrix.image }}:${{ steps.tag.outputs.tag }}"
+          image: "ghcr.io/caipe-io/${{ matrix.image }}:${{ steps.tag.outputs.tag }}"
           fail-build: false
           severity-cutoff: high
           output-format: sarif

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,8 +82,10 @@ docs(charts): document the OpenFGA values
 
 Prefix a branch with `prebuild/` when you want CI to build and publish
 prebuild container images for the PR — for example
-`prebuild/feat/rag-batch-job-status`. The images are pushed to
-`ghcr.io/<org>/prebuild/<component>` and cleaned up when the PR closes.
+`prebuild/feat/rag-batch-job-status`. Images are pushed to their canonical
+`ghcr.io/caipe-io/<component>` packages with temporary PR tags. Helm charts use
+their canonical `oci://ghcr.io/caipe-io/charts/<chart>` packages with the same
+temporary lifecycle. Prebuild artifacts are cleaned up when the PR closes.
 
 Without the prefix the standard CI build runs instead, and no prebuild image is
 published.

--- a/Makefile
+++ b/Makefile
@@ -462,7 +462,7 @@ scan-images: ## Scan all locally built images with grype (make scan-images GRYPE
 		echo "✓ All images passed grype scan"; \
 	fi
 
-scan-image: ## Scan a single image with grype (make scan-image IMG=ghcr.io/cnoe-io/mcp-splunk:localtag)
+scan-image: ## Scan a single image with grype (make scan-image IMG=ghcr.io/caipe-io/mcp-splunk:localtag)
 	@command -v grype >/dev/null 2>&1 || { echo "grype not found. Install: brew install grype"; exit 1; }
 	@[ -n "$(IMG)" ] || { echo "Usage: make scan-image IMG=<image:tag>"; exit 1; }
 	@grype "$(IMG)" --fail-on "$(GRYPE_SEVERITY)"

--- a/ai_platform_engineering/knowledge_bases/rag/server/Makefile
+++ b/ai_platform_engineering/knowledge_bases/rag/server/Makefile
@@ -99,17 +99,17 @@ build-docker-a2a:            ## Build A2A Docker image
 	docker build -t $(AGENT_DIR_NAME):a2a-latest -f docker/Dockerfile.a2a .
 
 build-docker-a2a-tag:        ## Tag A2A Docker image
-	docker tag $(AGENT_DIR_NAME):a2a-latest ghcr.io/cnoe-io/$(AGENT_DIR_NAME):a2a-latest
+	docker tag $(AGENT_DIR_NAME):a2a-latest ghcr.io/caipe-io/$(AGENT_DIR_NAME):a2a-latest
 
 build-docker-a2a-push:       ## Push A2A Docker image
-	docker push ghcr.io/cnoe-io/$(AGENT_DIR_NAME):a2a-latest
+	docker push ghcr.io/caipe-io/$(AGENT_DIR_NAME):a2a-latest
 
 build-docker-a2a-tag-and-push: ## Tag and push A2A Docker image
 	@$(MAKE) build-docker-a2a build-docker-a2a-tag build-docker-a2a-push
 
 run-docker-a2a: ## Run the A2A agent in Docker
 	@A2A_AGENT_PORT=$$(grep A2A_AGENT_PORT .env | cut -d '=' -f2); \
-	LOCAL_A2A_AGENT_IMAGE=$${A2A_AGENT_IMAGE:-ghcr.io/cnoe-io/$(AGENT_DIR_NAME):a2a-latest}; \
+	LOCAL_A2A_AGENT_IMAGE=$${A2A_AGENT_IMAGE:-ghcr.io/caipe-io/$(AGENT_DIR_NAME):a2a-latest}; \
 	LOCAL_A2A_AGENT_PORT=$${A2A_AGENT_PORT:-8000}; \
 	echo "==================================================================="; \
 	echo "                      A2A AGENT DOCKER RUN                         "; \

--- a/ai_platform_engineering/knowledge_bases/rag/server/README.md
+++ b/ai_platform_engineering/knowledge_bases/rag/server/README.md
@@ -301,12 +301,12 @@ The server is available in two image variants:
 
 **Pull the default image:**
 ```bash
-docker pull ghcr.io/cnoe-io/caipe-rag-server:latest
+docker pull ghcr.io/caipe-io/caipe-rag-server:latest
 ```
 
 **Pull the HuggingFace variant (if using local embeddings):**
 ```bash
-docker pull ghcr.io/cnoe-io/caipe-rag-server:latest-hf
+docker pull ghcr.io/caipe-io/caipe-rag-server:latest-hf
 ```
 
 Build the server image locally:
@@ -456,4 +456,3 @@ uv run pytest
 - [ARCHITECTURE.md](./ARCHITECTURE.md) - Detailed architecture documentation
 - [Common Models](../common/README.md) - Shared data models
 - [Ingestors](../ingestors/README.md) - Building custom ingestors
-

--- a/ai_platform_engineering/mcp/litellm/README.md
+++ b/ai_platform_engineering/mcp/litellm/README.md
@@ -56,14 +56,15 @@ The parent `ai-platform-engineering` chart can deploy this MCP server as a
 standalone Kubernetes service. Enable it with Helm values, then point CAIPE UI
 at the in-cluster service.
 
-Dev or prebuild values:
+Use the canonical image repositories for every lifecycle. Select a temporary
+prebuild or released artifact with the tag only:
 
 ```yaml
 litellmMcp:
   enabled: true
   image:
-    repository: ghcr.io/cnoe-io/prebuild/mcp-litellm
-    tag: "<prebuild-tag>"
+    repository: ghcr.io/caipe-io/mcp-litellm
+    tag: "<prebuild-or-release-tag>"
   config:
     LITELLM_API_URL: "https://litellm.prod.outshift.ai"
     LITELLM_API_TIMEOUT: "120"
@@ -72,41 +73,8 @@ litellmMcp:
 
 dynamic-agents:
   image:
-    repository: ghcr.io/cnoe-io/prebuild/caipe-dynamic-agents
-    tag: "<prebuild-tag>"
-
-caipe-ui:
-  appConfig:
-    mcp_servers:
-      - id: litellm
-        name: LiteLLM
-        description: LiteLLM FinOps reporting tools
-        transport: http
-        endpoint: http://ai-platform-engineering-litellm-mcp:8000/mcp/
-        enabled: true
-```
-
-If the Helm release name is not `ai-platform-engineering`, update the endpoint
-host to match the rendered LiteLLM MCP Service name.
-
-Prod values use released images instead of prebuild images:
-
-```yaml
-litellmMcp:
-  enabled: true
-  image:
-    repository: ghcr.io/cnoe-io/mcp-litellm
-    tag: "<release-version>"
-  config:
-    LITELLM_API_URL: "https://litellm.prod.outshift.ai"
-    LITELLM_API_TIMEOUT: "120"
-    LITELLM_VERIFY_SSL: "true"
-  existingSecret: "litellm-mcp-secret"
-
-dynamic-agents:
-  image:
-    repository: ghcr.io/cnoe-io/caipe-dynamic-agents
-    tag: "<release-version>"
+    repository: ghcr.io/caipe-io/caipe-dynamic-agents
+    tag: "<prebuild-or-release-tag>"
 
 caipe-ui:
   appConfig:

--- a/ai_platform_engineering/scheduler/caipe_scheduler/config.py
+++ b/ai_platform_engineering/scheduler/caipe_scheduler/config.py
@@ -43,7 +43,7 @@ class Settings(BaseModel):
 
   # Kubernetes
   namespace: str = Field(default_factory=lambda: os.environ.get("SCHEDULER_NAMESPACE", "caipe"))
-  cron_runner_image: str = Field(default_factory=lambda: os.environ.get("CRON_RUNNER_IMAGE", "ghcr.io/cnoe-io/caipe-cron-runner:latest"))
+  cron_runner_image: str = Field(default_factory=lambda: os.environ.get("CRON_RUNNER_IMAGE", "ghcr.io/caipe-io/caipe-cron-runner:latest"))
   cron_runner_image_pull_policy: str = Field(default_factory=lambda: os.environ.get("CRON_RUNNER_IMAGE_PULL_POLICY", "IfNotPresent"))
   # ServiceAccount for the per-schedule CronJob runner pods. No perms.
   cron_runner_service_account: str = Field(default_factory=lambda: os.environ.get("CRON_RUNNER_SERVICE_ACCOUNT", "caipe-cron-runner"))

--- a/charts/ai-platform-engineering/README.md
+++ b/charts/ai-platform-engineering/README.md
@@ -114,7 +114,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | caipe-ui.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | caipe-ui.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | caipe-ui.image.pullPolicy | string | `"IfNotPresent"` |  |
-| caipe-ui.image.repository | string | `"ghcr.io/cnoe-io/caipe-ui"` |  |
+| caipe-ui.image.repository | string | `"ghcr.io/caipe-io/caipe-ui"` |  |
 | caipe-ui.image.tag | string | `""` |  |
 | caipe-ui.ingress.annotations | object | `{}` |  |
 | caipe-ui.ingress.className | string | `"nginx"` |  |
@@ -185,7 +185,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | dynamic-agents.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | dynamic-agents.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | dynamic-agents.image.pullPolicy | string | `"IfNotPresent"` |  |
-| dynamic-agents.image.repository | string | `"ghcr.io/cnoe-io/caipe-dynamic-agents"` |  |
+| dynamic-agents.image.repository | string | `"ghcr.io/caipe-io/caipe-dynamic-agents"` |  |
 | dynamic-agents.image.tag | string | `""` |  |
 | dynamic-agents.nameOverride | string | `"dynamic-agents"` |  |
 | dynamic-agents.service.metricsPort | int | `0` |  |
@@ -219,7 +219,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | global.agentgateway.static.configBridge.enabled | bool | `true` |  |
 | global.agentgateway.static.configBridge.extraEnv | list | `[]` |  |
 | global.agentgateway.static.configBridge.image.pullPolicy | string | `"IfNotPresent"` |  |
-| global.agentgateway.static.configBridge.image.repository | string | `"ghcr.io/cnoe-io/agentgateway-config-bridge"` |  |
+| global.agentgateway.static.configBridge.image.repository | string | `"ghcr.io/caipe-io/agentgateway-config-bridge"` |  |
 | global.agentgateway.static.configBridge.image.tag | string | `""` |  |
 | global.agentgateway.static.configBridge.pollSeconds | int | `5` |  |
 | global.agentgateway.static.configBridge.ui.existingSecret.key | string | `"AGENTGATEWAY_TARGETS_TOKEN"` |  |
@@ -321,7 +321,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | litellmMcp.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | litellmMcp.fullnameOverride | string | `""` |  |
 | litellmMcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| litellmMcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-litellm"` |  |
+| litellmMcp.image.repository | string | `"ghcr.io/caipe-io/mcp-litellm"` |  |
 | litellmMcp.image.tag | string | `""` |  |
 | litellmMcp.imagePullSecrets | list | `[]` |  |
 | litellmMcp.livenessProbe.failureThreshold | int | `3` |  |
@@ -350,11 +350,11 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | litellmMcp.service.type | string | `"ClusterIP"` |  |
 | litellmMcp.tolerations | list | `[]` |  |
 | mcp-argocd.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-argocd.image.repository | string | `"ghcr.io/cnoe-io/mcp-argocd"` |  |
+| mcp-argocd.image.repository | string | `"ghcr.io/caipe-io/mcp-argocd"` |  |
 | mcp-argocd.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-argocd.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-argocd.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-argocd.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-argocd"` |  |
+| mcp-argocd.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-argocd"` |  |
 | mcp-argocd.mcp.image.tag | string | `""` |  |
 | mcp-argocd.mcp.mode | string | `"http"` |  |
 | mcp-argocd.mcp.port | int | `8000` |  |
@@ -370,7 +370,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-aws.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-aws.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-aws.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-aws.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-aws"` |  |
+| mcp-aws.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-aws"` |  |
 | mcp-aws.mcp.image.tag | string | `""` |  |
 | mcp-aws.mcp.mode | string | `"http"` |  |
 | mcp-aws.mcp.port | int | `8000` |  |
@@ -380,7 +380,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-backstage.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-backstage.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-backstage.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-backstage.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-backstage"` |  |
+| mcp-backstage.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-backstage"` |  |
 | mcp-backstage.mcp.image.tag | string | `""` |  |
 | mcp-backstage.mcp.mode | string | `"http"` |  |
 | mcp-backstage.mcp.port | int | `8000` |  |
@@ -397,7 +397,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-confluence.mcp.port | int | `8000` |  |
 | mcp-confluence.nameOverride | string | `"mcp-confluence"` |  |
 | mcp-github.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-github.image.repository | string | `"ghcr.io/cnoe-io/mcp-github"` |  |
+| mcp-github.image.repository | string | `"ghcr.io/caipe-io/mcp-github"` |  |
 | mcp-github.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-github.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-github.mcp.agentgateway.providerTokenAuth | bool | `true` |  |
@@ -431,7 +431,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-jira.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-jira.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-jira.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-jira.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-jira"` |  |
+| mcp-jira.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-jira"` |  |
 | mcp-jira.mcp.image.tag | string | `""` |  |
 | mcp-jira.mcp.mode | string | `"http"` |  |
 | mcp-jira.mcp.port | int | `8000` |  |
@@ -441,7 +441,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-komodor.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-komodor.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-komodor.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-komodor.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-komodor"` |  |
+| mcp-komodor.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-komodor"` |  |
 | mcp-komodor.mcp.image.tag | string | `""` |  |
 | mcp-komodor.mcp.mode | string | `"http"` |  |
 | mcp-komodor.mcp.port | int | `8000` |  |
@@ -452,7 +452,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-netutils.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-netutils.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-netutils.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-netutils.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-netutils"` |  |
+| mcp-netutils.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-netutils"` |  |
 | mcp-netutils.mcp.image.tag | string | `""` |  |
 | mcp-netutils.mcp.mode | string | `"http"` |  |
 | mcp-netutils.mcp.port | int | `8000` |  |
@@ -462,7 +462,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-pagerduty.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-pagerduty.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-pagerduty.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-pagerduty.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-pagerduty"` |  |
+| mcp-pagerduty.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-pagerduty"` |  |
 | mcp-pagerduty.mcp.image.tag | string | `""` |  |
 | mcp-pagerduty.mcp.mode | string | `"http"` |  |
 | mcp-pagerduty.mcp.port | int | `8000` |  |
@@ -486,7 +486,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-splunk.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-splunk.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-splunk.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-splunk.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-splunk"` |  |
+| mcp-splunk.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-splunk"` |  |
 | mcp-splunk.mcp.image.tag | string | `""` |  |
 | mcp-splunk.mcp.mode | string | `"http"` |  |
 | mcp-splunk.mcp.port | int | `8000` |  |
@@ -496,7 +496,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-victorops.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-victorops.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-victorops.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-victorops.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-victorops"` |  |
+| mcp-victorops.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-victorops"` |  |
 | mcp-victorops.mcp.image.tag | string | `""` |  |
 | mcp-victorops.mcp.mode | string | `"http"` |  |
 | mcp-victorops.mcp.port | int | `8000` |  |
@@ -510,7 +510,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-webex-meetings.mcp.agentgateway.pathPrefix | string | `"/mcp/webex_meetings"` |  |
 | mcp-webex-meetings.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-webex-meetings.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex-meetings.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-webex-meetings"` |  |
+| mcp-webex-meetings.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-webex-meetings"` |  |
 | mcp-webex-meetings.mcp.image.tag | string | `""` |  |
 | mcp-webex-meetings.mcp.mode | string | `"http"` |  |
 | mcp-webex-meetings.mcp.port | int | `8000` |  |
@@ -521,7 +521,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-webex.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-webex.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-webex.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-webex"` |  |
+| mcp-webex.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-webex"` |  |
 | mcp-webex.mcp.image.tag | string | `""` |  |
 | mcp-webex.mcp.mode | string | `"http"` |  |
 | mcp-webex.mcp.port | int | `8000` |  |
@@ -543,7 +543,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | openfga-authz-bridge.audit.subjectSalt | string | `"caipe-098-audit"` |  |
 | openfga-authz-bridge.audit.tenantId | string | `"default"` |  |
 | openfga-authz-bridge.image.pullPolicy | string | `"IfNotPresent"` |  |
-| openfga-authz-bridge.image.repository | string | `"ghcr.io/cnoe-io/openfga-authz-bridge"` |  |
+| openfga-authz-bridge.image.repository | string | `"ghcr.io/caipe-io/openfga-authz-bridge"` |  |
 | openfga-authz-bridge.image.tag | string | `""` |  |
 | openfga-authz-bridge.openfga.httpUrl | string | `""` |  |
 | openfga-authz-bridge.openfga.object | string | `"mcp_gateway:list"` |  |
@@ -571,7 +571,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | rag-stack.agent-ontology.enabled | bool | `true` |  |
 | rag-stack.agent-rag.enabled | bool | `true` |  |
 | rag-stack.agent-rag.image.pullPolicy | string | `"IfNotPresent"` |  |
-| rag-stack.agent-rag.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-rag"` |  |
+| rag-stack.agent-rag.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-rag"` |  |
 | rag-stack.agent-rag.image.tag | string | `""` |  |
 | rag-stack.milvus.enabled | bool | `true` |  |
 | rag-stack.neo4j.enabled | bool | `true` |  |
@@ -584,18 +584,18 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | rag-stack.rag-server.env.CAIPE_UNSAFE_RBAC_BYPASS | string | `"false"` |  |
 | rag-stack.rag-server.env.OPENFGA_STORE_NAME | string | `"caipe-openfga"` |  |
 | rag-stack.rag-server.image.pullPolicy | string | `"IfNotPresent"` |  |
-| rag-stack.rag-server.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| rag-stack.rag-server.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | rag-stack.rag-server.image.tag | string | `""` |  |
 | scheduler.args | list | `[]` |  |
 | scheduler.caipe.apiUrl | string | `"http://{{ .Release.Name }}-caipe-ui:3000"` |  |
 | scheduler.caipe.chatPath | string | `"/api/v1/chat/invoke"` |  |
 | scheduler.command | list | `[]` |  |
 | scheduler.cronRunner.image.pullPolicy | string | `"IfNotPresent"` |  |
-| scheduler.cronRunner.image.repository | string | `"ghcr.io/cnoe-io/caipe-cron-runner"` |  |
+| scheduler.cronRunner.image.repository | string | `"ghcr.io/caipe-io/caipe-cron-runner"` |  |
 | scheduler.cronRunner.image.tag | string | `""` |  |
 | scheduler.fullnameOverride | string | `"caipe-scheduler"` |  |
 | scheduler.image.pullPolicy | string | `"IfNotPresent"` |  |
-| scheduler.image.repository | string | `"ghcr.io/cnoe-io/caipe-scheduler"` |  |
+| scheduler.image.repository | string | `"ghcr.io/caipe-io/caipe-scheduler"` |  |
 | scheduler.image.tag | string | `""` |  |
 | scheduler.mongo.database | string | `"caipe"` |  |
 | scheduler.mongo.existingSecret | string | `""` |  |
@@ -615,7 +615,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | schedulerMcp.env.MCP_PORT | string | `"8000"` |  |
 | schedulerMcp.env.SCHEDULER_URL | string | `"http://caipe-scheduler:8080"` |  |
 | schedulerMcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| schedulerMcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-scheduler"` |  |
+| schedulerMcp.image.repository | string | `"ghcr.io/caipe-io/mcp-scheduler"` |  |
 | schedulerMcp.image.tag | string | `""` |  |
 | schedulerMcp.nameOverride | string | `"mcp-scheduler"` |  |
 | schedulerMcp.resources | object | `{}` |  |
@@ -627,7 +627,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | slack-bot.existingSecret | string | `"slack-bot-secrets"` | Reference to a pre-existing Kubernetes Secret. Should contain: SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_SIGNING_SECRET, and optionally OAUTH2_CLIENT_SECRET. |
 | slack-bot.externalSecrets | object | `{"apiVersion":"v1beta1","data":[],"enabled":false,"secretStoreRef":{"kind":"ClusterSecretStore","name":"vault"}}` | External Secrets configuration for sensitive data |
 | slack-bot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| slack-bot.image.repository | string | `"ghcr.io/cnoe-io/caipe-slack-bot"` |  |
+| slack-bot.image.repository | string | `"ghcr.io/caipe-io/caipe-slack-bot"` |  |
 | slack-bot.image.tag | string | `""` |  |
 | slack-bot.resources.limits.cpu | string | `"500m"` |  |
 | slack-bot.resources.limits.memory | string | `"512Mi"` |  |
@@ -683,7 +683,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | webex-bot.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | webex-bot.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | webex-bot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| webex-bot.image.repository | string | `"ghcr.io/cnoe-io/caipe-webex-bot"` |  |
+| webex-bot.image.repository | string | `"ghcr.io/caipe-io/caipe-webex-bot"` |  |
 | webex-bot.image.tag | string | `""` |  |
 | webex-bot.keycloakBot.clientSecretFromSecret.key | string | `"KC_WEBEX_BOT_CLIENT_SECRET"` |  |
 | webex-bot.keycloakBot.clientSecretFromSecret.name | string | `""` |  |

--- a/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       */ -}}
       {{- $cbEnabled := and $agwGlobal.enabled (eq ($agwGlobal.routingMode | default "static") "static") $cb.enabled }}
       {{- $cbImage := $cb.image | default dict }}
-      {{- $cbImageRepo := $cbImage.repository | default "ghcr.io/cnoe-io/agentgateway-config-bridge" }}
+      {{- $cbImageRepo := $cbImage.repository | default "ghcr.io/caipe-io/agentgateway-config-bridge" }}
       {{- $cbImageTag := $cbImage.tag | default .Chart.AppVersion }}
       {{- $cbImagePull := $cbImage.pullPolicy | default "IfNotPresent" }}
       serviceAccountName: {{ include "agentgateway.serviceAccountName" . }}

--- a/charts/ai-platform-engineering/charts/audit-service/README.md
+++ b/charts/ai-platform-engineering/charts/audit-service/README.md
@@ -57,7 +57,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
 | extraEnvFrom | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-audit-service"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-audit-service"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | livenessProbe.failureThreshold | int | `3` |  |

--- a/charts/ai-platform-engineering/charts/audit-service/values.yaml
+++ b/charts/ai-platform-engineering/charts/audit-service/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 revisionHistoryLimit: 3
 
 image:
-  repository: ghcr.io/cnoe-io/caipe-audit-service
+  repository: ghcr.io/caipe-io/caipe-audit-service
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/charts/ai-platform-engineering/charts/autonomous-agents/README.md
+++ b/charts/ai-platform-engineering/charts/autonomous-agents/README.md
@@ -72,7 +72,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-autonomous-agents"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-autonomous-agents"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/autonomous-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/autonomous-agents/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 # Container image configuration
 image:
-  repository: "ghcr.io/cnoe-io/caipe-autonomous-agents"
+  repository: "ghcr.io/caipe-io/caipe-autonomous-agents"
   pullPolicy: "Always"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""

--- a/charts/ai-platform-engineering/charts/caipe-ui/README.md
+++ b/charts/ai-platform-engineering/charts/caipe-ui/README.md
@@ -126,7 +126,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-ui"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-ui"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: ""
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: "ghcr.io/cnoe-io/caipe-ui"
+  repository: "ghcr.io/caipe-io/caipe-ui"
   pullPolicy: "Always"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""

--- a/charts/ai-platform-engineering/charts/dynamic-agents/README.md
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/README.md
@@ -85,7 +85,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-dynamic-agents"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-dynamic-agents"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 # Container image configuration
 image:
-  repository: "ghcr.io/cnoe-io/caipe-dynamic-agents"
+  repository: "ghcr.io/caipe-io/caipe-dynamic-agents"
   pullPolicy: "Always"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""

--- a/charts/ai-platform-engineering/charts/keycloak/README.md
+++ b/charts/ai-platform-engineering/charts/keycloak/README.md
@@ -140,7 +140,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
 | ingress.hosts[0].paths[1].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | initImage.pullPolicy | string | `"IfNotPresent"` |  |
-| initImage.repository | string | `"ghcr.io/cnoe-io/keycloak-init"` |  |
+| initImage.repository | string | `"ghcr.io/caipe-io/keycloak-init"` |  |
 | initImage.tag | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -14,7 +14,7 @@ image:
 #
 # Override with --set initImage.repository=… for air-gapped registries.
 initImage:
-  repository: ghcr.io/cnoe-io/keycloak-init
+  repository: ghcr.io/caipe-io/keycloak-init
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/README.md
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/README.md
@@ -61,7 +61,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5
 | callerToolCheck.enabled | bool | `false` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/openfga-authz-bridge"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/openfga-authz-bridge"` |  |
 | image.tag | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/values.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cnoe-io/openfga-authz-bridge
+  repository: ghcr.io/caipe-io/openfga-authz-bridge
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/charts/ai-platform-engineering/charts/scheduler/README.md
+++ b/charts/ai-platform-engineering/charts/scheduler/README.md
@@ -64,7 +64,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
 | caipe.apiUrl | string | `"http://caipe-ui:3000"` |  |
 | caipe.chatPath | string | `"/api/v1/chat/invoke"` |  |
 | cronRunner.image.pullPolicy | string | `"IfNotPresent"` |  |
-| cronRunner.image.repository | string | `"ghcr.io/cnoe-io/caipe-cron-runner"` |  |
+| cronRunner.image.repository | string | `"ghcr.io/caipe-io/caipe-cron-runner"` |  |
 | cronRunner.image.tag | string | `""` |  |
 | cronRunner.resources.limits.cpu | string | `"100m"` |  |
 | cronRunner.resources.limits.memory | string | `"128Mi"` |  |
@@ -74,7 +74,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
 | cronRunnerServiceAccount.name | string | `"caipe-cron-runner"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-scheduler"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-scheduler"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | limits.maxMessageChars | int | `2000` |  |

--- a/charts/ai-platform-engineering/charts/scheduler/values.yaml
+++ b/charts/ai-platform-engineering/charts/scheduler/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: "ghcr.io/cnoe-io/caipe-scheduler"
+  repository: "ghcr.io/caipe-io/caipe-scheduler"
   pullPolicy: "Always"
   tag: ""
 
@@ -13,7 +13,7 @@ image:
 # time; user-controlled fields are limited to schedule, timezone, and SCHEDULE_ID.
 cronRunner:
   image:
-    repository: "ghcr.io/cnoe-io/caipe-cron-runner"
+    repository: "ghcr.io/caipe-io/caipe-cron-runner"
     pullPolicy: "IfNotPresent"
     tag: ""
   # Resource limits per cron-runner pod. Kept tight - the runner makes 2-3 HTTP calls and exits.

--- a/charts/ai-platform-engineering/charts/skill-scanner/README.md
+++ b/charts/ai-platform-engineering/charts/skill-scanner/README.md
@@ -57,7 +57,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
 | affinity | object | `{}` | Pod affinity rules |
 | fullnameOverride | string | `""` | Override the full release name |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ghcr.io/cnoe-io/skill-scanner"` | Container image repository. Build via build/Dockerfile.skill-scanner and push to your registry; override in the parent values.yaml. |
+| image.repository | string | `"ghcr.io/caipe-io/skill-scanner"` | Container image repository. Build via build/Dockerfile.skill-scanner and push to your registry; override in the parent values.yaml. |
 | image.tag | string | `""` | Image tag. Defaults to the parent chart's appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":0,"periodSeconds":20,"timeoutSeconds":3}` | Liveness probe — hits the FastAPI /health endpoint. |

--- a/charts/ai-platform-engineering/charts/skill-scanner/values.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/values.yaml
@@ -13,7 +13,7 @@ revisionHistoryLimit: 3
 image:
   # -- Container image repository. Build via build/Dockerfile.skill-scanner
   # and push to your registry; override in the parent values.yaml.
-  repository: ghcr.io/cnoe-io/skill-scanner
+  repository: ghcr.io/caipe-io/skill-scanner
   # -- Image tag. Defaults to the parent chart's appVersion.
   tag: ""
   # -- Image pull policy

--- a/charts/ai-platform-engineering/charts/slack-bot/README.md
+++ b/charts/ai-platform-engineering/charts/slack-bot/README.md
@@ -58,7 +58,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
 | externalSecrets | object | `{"apiVersion":"v1beta1","data":[],"enabled":false,"secretStoreRef":{"kind":"ClusterSecretStore","name":"vault"}}` | External Secrets configuration for sensitive data (Slack tokens, OAuth2 client secret, etc.) |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-slack-bot"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-slack-bot"` |  |
 | image.tag | string | `""` |  |
 | keycloakBot | object | `{"clientSecretFromSecret":{"key":"KC_BOT_CLIENT_SECRET","name":""}}` | Cross-chart binding to the Keycloak bot client_secret used by the Slack bot's RFC 8693 OBO exchange helper. In umbrella installs this usually points at the same Secret/key as oauth2.clientSecretFromSecret. |
 | nameOverride | string | `""` |  |

--- a/charts/ai-platform-engineering/charts/slack-bot/values.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cnoe-io/caipe-slack-bot
+  repository: ghcr.io/caipe-io/caipe-slack-bot
   tag: ""
   pullPolicy: Always
 

--- a/charts/ai-platform-engineering/charts/webex-bot/README.md
+++ b/charts/ai-platform-engineering/charts/webex-bot/README.md
@@ -63,7 +63,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-webex-bot"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-webex-bot"` |  |
 | image.tag | string | `""` |  |
 | keycloakAdmin | object | `{"clientId":"","clientSecretFromSecret":{"key":"KC_PLATFORM_CLIENT_SECRET","name":""}}` | Keycloak Admin API credentials for webex_user_id lookups (typically caipe-platform). |
 | keycloakBot | object | `{"clientSecretFromSecret":{"key":"KC_WEBEX_BOT_CLIENT_SECRET","name":""}}` | Single source of truth: Keycloak chart Secret {{release}}-keycloak-webex-bot (KC_WEBEX_BOT_CLIENT_SECRET). |

--- a/charts/ai-platform-engineering/charts/webex-bot/values.yaml
+++ b/charts/ai-platform-engineering/charts/webex-bot/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cnoe-io/caipe-webex-bot
+  repository: ghcr.io/caipe-io/caipe-webex-bot
   tag: ""
   pullPolicy: Always
 

--- a/charts/ai-platform-engineering/values-mongodb.yaml.example
+++ b/charts/ai-platform-engineering/values-mongodb.yaml.example
@@ -76,7 +76,7 @@ caipe-ui:
 
   # CAIPE UI application configuration
   image:
-    repository: "ghcr.io/cnoe-io/caipe-ui"
+    repository: "ghcr.io/caipe-io/caipe-ui"
     pullPolicy: "Always"
 
   service:

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -190,7 +190,7 @@ global:
       configBridge:
         enabled: true
         image:
-          repository: ghcr.io/cnoe-io/agentgateway-config-bridge
+          repository: ghcr.io/caipe-io/agentgateway-config-bridge
           tag: ""              # defaults to agentgateway subchart appVersion
           pullPolicy: IfNotPresent
         pollSeconds: 5
@@ -400,11 +400,11 @@ skillsLiveSkills: ""           # Inline custom live-skills skill (overrides ever
 mcp-argocd:
   nameOverride: "mcp-argocd"
   image:
-    repository: "ghcr.io/cnoe-io/mcp-argocd"
+    repository: "ghcr.io/caipe-io/mcp-argocd"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-argocd"
+      repository: "ghcr.io/caipe-io/mcp-argocd"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -424,7 +424,7 @@ mcp-backstage:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-backstage"
+      repository: "ghcr.io/caipe-io/mcp-backstage"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -455,7 +455,7 @@ mcp-confluence:
 mcp-github:
   nameOverride: "mcp-github"
   image:
-    repository: "ghcr.io/cnoe-io/mcp-github"
+    repository: "ghcr.io/caipe-io/mcp-github"
     pullPolicy: "IfNotPresent"
   mcp:
     mode: "stdio"
@@ -528,7 +528,7 @@ mcp-jira:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-jira"
+      repository: "ghcr.io/caipe-io/mcp-jira"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -545,7 +545,7 @@ mcp-pagerduty:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-pagerduty"
+      repository: "ghcr.io/caipe-io/mcp-pagerduty"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -585,7 +585,7 @@ mcp-aws:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-aws"
+      repository: "ghcr.io/caipe-io/mcp-aws"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -615,7 +615,7 @@ mcp-splunk:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-splunk"
+      repository: "ghcr.io/caipe-io/mcp-splunk"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -632,7 +632,7 @@ mcp-victorops:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-victorops"
+      repository: "ghcr.io/caipe-io/mcp-victorops"
       tag: ""
       pullPolicy: "IfNotPresent"
     mode: "http" # Options: stdio, http
@@ -648,7 +648,7 @@ mcp-webex:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-webex"
+      repository: "ghcr.io/caipe-io/mcp-webex"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -664,7 +664,7 @@ mcp-webex-meetings:
     requiresSecret: false
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-webex-meetings"
+      repository: "ghcr.io/caipe-io/mcp-webex-meetings"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -688,7 +688,7 @@ mcp-komodor:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-komodor"
+      repository: "ghcr.io/caipe-io/mcp-komodor"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -707,7 +707,7 @@ mcp-netutils:
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-netutils"
+      repository: "ghcr.io/caipe-io/mcp-netutils"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -743,7 +743,7 @@ caipe-ui:
     secretKey: "KC_SCHEDULER_CLIENT_SECRET"
     clientId: "caipe-scheduler-runner"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-ui"
+    repository: "ghcr.io/caipe-io/caipe-ui"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1017,7 +1017,7 @@ litellmMcp:
   replicaCount: 1
   revisionHistoryLimit: 3
   image:
-    repository: "ghcr.io/cnoe-io/mcp-litellm"
+    repository: "ghcr.io/caipe-io/mcp-litellm"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1088,7 +1088,7 @@ litellmMcp:
 dynamic-agents:
   nameOverride: "dynamic-agents"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-dynamic-agents"
+    repository: "ghcr.io/caipe-io/caipe-dynamic-agents"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1171,7 +1171,7 @@ dynamic-agents:
 autonomous-agents:
   nameOverride: "autonomous-agents"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-autonomous-agents"
+    repository: "ghcr.io/caipe-io/caipe-autonomous-agents"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1223,14 +1223,14 @@ autonomous-agents:
 scheduler:
   fullnameOverride: "caipe-scheduler"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-scheduler"
+    repository: "ghcr.io/caipe-io/caipe-scheduler"
     tag: ""
     pullPolicy: "IfNotPresent"
   command: []
   args: []
   cronRunner:
     image:
-      repository: "ghcr.io/cnoe-io/caipe-cron-runner"
+      repository: "ghcr.io/caipe-io/caipe-cron-runner"
       tag: ""
       pullPolicy: "IfNotPresent"
   caipe:
@@ -1254,7 +1254,7 @@ schedulerMcp:
   enabled: true
   nameOverride: "mcp-scheduler"
   image:
-    repository: "ghcr.io/cnoe-io/mcp-scheduler"
+    repository: "ghcr.io/caipe-io/mcp-scheduler"
     tag: ""
     pullPolicy: "IfNotPresent"
   command: ["mcp-server-scheduler"]
@@ -1280,7 +1280,7 @@ schedulerMcp:
 # Enable with: global.integrations.slackBot.enabled=true
 slack-bot:
   image:
-    repository: "ghcr.io/cnoe-io/caipe-slack-bot"
+    repository: "ghcr.io/caipe-io/caipe-slack-bot"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1383,7 +1383,7 @@ slack-bot:
 # Enable with Helm tag: webex-bot=true
 webex-bot:
   image:
-    repository: "ghcr.io/cnoe-io/caipe-webex-bot"
+    repository: "ghcr.io/caipe-io/caipe-webex-bot"
     tag: ""
     pullPolicy: "IfNotPresent"
 
@@ -1568,7 +1568,7 @@ openfgaAuthzBridge:
 # above is kept as the dependency condition flag.
 openfga-authz-bridge:
   image:
-    repository: ghcr.io/cnoe-io/openfga-authz-bridge
+    repository: ghcr.io/caipe-io/openfga-authz-bridge
     tag: ""
     pullPolicy: IfNotPresent
   # Must match caipe-ui.config.CAIPE_ORG_KEY.
@@ -1611,7 +1611,7 @@ rag-stack:
   rag-server:
     enabled: true
     image:
-      repository: "ghcr.io/cnoe-io/caipe-rag-server"
+      repository: "ghcr.io/caipe-io/caipe-rag-server"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -1622,7 +1622,7 @@ rag-stack:
   agent-rag:
     enabled: true
     image:
-      repository: "ghcr.io/cnoe-io/caipe-rag-agent-rag"
+      repository: "ghcr.io/caipe-io/caipe-rag-agent-rag"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"

--- a/charts/rag-stack/README.md
+++ b/charts/rag-stack/README.md
@@ -57,7 +57,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
 | agent-ontology.enabled | bool | `true` |  |
 | agent-ontology.fullnameOverride | string | `"agent-ontology"` |  |
 | agent-ontology.image.pullPolicy | string | `"Always"` |  |
-| agent-ontology.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-ontology"` |  |
+| agent-ontology.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-ontology"` |  |
 | agent-ontology.image.tag | string | `""` |  |
 | agent-ontology.livenessProbe.failureThreshold | int | `3` |  |
 | agent-ontology.livenessProbe.httpGet.path | string | `"/v1/graph/ontology/agent/status"` |  |
@@ -205,7 +205,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
 | rag-server.envFrom | list | `[]` |  |
 | rag-server.fullnameOverride | string | `"rag-server"` |  |
 | rag-server.image.pullPolicy | string | `"Always"` |  |
-| rag-server.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| rag-server.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | rag-server.image.tag | string | `""` |  |
 | rag-server.podAnnotations | object | `{}` |  |
 | rag-server.resources.limits.cpu | string | `"500m"` |  |

--- a/charts/rag-stack/charts/agent-ontology/README.md
+++ b/charts/rag-stack/charts/agent-ontology/README.md
@@ -62,7 +62,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
 | env | object | `{}` |  |
 | fullnameOverride | string | `"agent-ontology"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-ontology"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-ontology"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/rag-stack/charts/agent-ontology/values.yaml
+++ b/charts/rag-stack/charts/agent-ontology/values.yaml
@@ -27,7 +27,7 @@ revisionHistoryLimit: 3
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   # This sets the image repository for the corresponding agent.
-  repository: "ghcr.io/cnoe-io/caipe-rag-agent-ontology"
+  repository: "ghcr.io/caipe-io/caipe-rag-agent-ontology"
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # tag defaults to .Chart.AppVersion when not specified

--- a/charts/rag-stack/charts/rag-ingestors/README.md
+++ b/charts/rag-stack/charts/rag-ingestors/README.md
@@ -59,7 +59,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
 | defaultResources.requests.ephemeral-storage | string | `"256Mi"` |  |
 | defaultResources.requests.memory | string | `"256Mi"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-ingestors"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-ingestors"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingestors | list | `[]` |  |

--- a/charts/rag-stack/charts/rag-ingestors/values.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/values.yaml
@@ -4,7 +4,7 @@
 
 # Global image configuration
 image:
-  repository: "ghcr.io/cnoe-io/caipe-rag-ingestors"
+  repository: "ghcr.io/caipe-io/caipe-rag-ingestors"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""
   pullPolicy: IfNotPresent

--- a/charts/rag-stack/charts/rag-server/README.md
+++ b/charts/rag-stack/charts/rag-server/README.md
@@ -58,7 +58,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `"rag-server"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |

--- a/charts/rag-stack/charts/rag-server/values.yaml
+++ b/charts/rag-stack/charts/rag-server/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: "rag-server"
 enableGraphRag: true
 
 image:
-  repository: "ghcr.io/cnoe-io/caipe-rag-server"
+  repository: "ghcr.io/caipe-io/caipe-rag-server"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""
   pullPolicy: IfNotPresent
@@ -91,7 +91,7 @@ affinity: {}
 # Init containers to run before the main containers (e.g. install Playwright browsers)
 initContainers: []
 # - name: playwright-install
-#   image: "ghcr.io/cnoe-io/caipe-rag-ingestors:0.4.4"
+#   image: "ghcr.io/caipe-io/caipe-rag-ingestors:0.4.4"
 #   command: ["sh", "-c", "playwright install chromium"]
 #   volumeMounts:
 #     - name: playwright-browsers

--- a/charts/rag-stack/values.yaml
+++ b/charts/rag-stack/values.yaml
@@ -72,7 +72,7 @@ rag-server:
   enabled: true
   fullnameOverride: "rag-server"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-rag-server"
+    repository: "ghcr.io/caipe-io/caipe-rag-server"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: Always
@@ -128,7 +128,7 @@ agent-ontology:
   enabled: true
   fullnameOverride: "agent-ontology"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-rag-agent-ontology"
+    repository: "ghcr.io/caipe-io/caipe-rag-agent-ontology"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "Always"

--- a/deploy/eks/argocd-application.yaml.example
+++ b/deploy/eks/argocd-application.yaml.example
@@ -10,7 +10,7 @@ spec:
   sources:
     # Main chart from GHCR
     - chart: ai-platform-engineering
-      repoURL: ghcr.io/cnoe-io/charts
+      repoURL: ghcr.io/caipe-io/charts
       targetRevision: <CHART VERSION>
       helm:
         valueFiles:

--- a/deploy/openfga/bridge/tests/test_helm_values.py
+++ b/deploy/openfga/bridge/tests/test_helm_values.py
@@ -140,7 +140,7 @@ def test_umbrella_values_define_webex_bot_section() -> None:
     assert webex["config"]["WEBEX_ADMIN_JWT_AUDIENCE"] == "caipe-webex-bot-admin"
     assert webex["config"]["WEBEX_ADMIN_API_ENABLED"] == "true"
     assert webex["config"]["WEBEX_ADMIN_API_PORT"] == "3002"
-    assert "ghcr.io/cnoe-io/caipe-webex-bot" in webex["image"]["repository"]
+    assert "ghcr.io/caipe-io/caipe-webex-bot" in webex["image"]["repository"]
 
 
 def test_caipe_ui_values_wire_webex_bot_admin_env() -> None:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -118,7 +118,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=backstage
-    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-backstage:${IMAGE_TAG:-localtag}
     container_name: mcp-backstage
     env_file: [.env]
     ports: ["18001:8000"]
@@ -145,7 +145,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=argocd
-    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-argocd:${IMAGE_TAG:-localtag}
     container_name: mcp-argocd
     env_file: [.env]
     ports: ["18002:8000"]
@@ -186,7 +186,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=jira
-    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-jira:${IMAGE_TAG:-localtag}
     container_name: mcp-jira
     env_file: [.env]
     ports: ["18004:8000"]
@@ -229,7 +229,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=komodor
-    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-komodor:${IMAGE_TAG:-localtag}
     container_name: mcp-komodor
     env_file: [.env]
     ports: ["18005:8000"]
@@ -255,7 +255,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=pagerduty
-    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-pagerduty:${IMAGE_TAG:-localtag}
     container_name: mcp-pagerduty
     env_file: [.env]
     ports: ["18006:8000"]
@@ -309,7 +309,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=splunk
-    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-splunk:${IMAGE_TAG:-localtag}
     container_name: mcp-splunk
     env_file: [.env]
     ports: ["18008:8000"]
@@ -336,7 +336,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=webex
-    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-webex:${IMAGE_TAG:-localtag}
     container_name: mcp-webex
     env_file: [.env]
     ports: ["18009:8000"]
@@ -363,7 +363,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=webex-meetings
-    image: ghcr.io/cnoe-io/mcp-webex-meetings:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-webex-meetings:${IMAGE_TAG:-localtag}
     container_name: mcp-webex-meetings
     env_file: [.env]
     ports: ["18013:8000"]
@@ -390,7 +390,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=victorops
-    image: ghcr.io/cnoe-io/mcp-victorops:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-victorops:${IMAGE_TAG:-localtag}
     container_name: mcp-victorops
     env_file: [.env]
     ports: ["18012:8000"]
@@ -417,7 +417,7 @@ services:
       args:
         - AGENT_NAME=netutils
         - INSTALL_NETUTILS=true
-    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-netutils:${IMAGE_TAG:-localtag}
     container_name: mcp-netutils
     env_file: [.env]
     ports: ["18011:8000"]
@@ -478,7 +478,7 @@ services:
         # Local prod-parity rebuilds skip Next's duplicate typecheck; run
         # `npm run lint` / targeted tests separately when validating changes.
         - CAIPE_UI_FAST_BUILD=${CAIPE_UI_FAST_BUILD:-true}
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-localtag}-dev
+    image: ghcr.io/caipe-io/caipe-ui:${IMAGE_TAG:-localtag}-dev
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -739,7 +739,7 @@ services:
         # Local prod-parity rebuilds skip Next's duplicate typecheck; run
         # `npm run lint` / targeted tests separately when validating changes.
         - CAIPE_UI_FAST_BUILD=${CAIPE_UI_FAST_BUILD:-true}
-    image: ghcr.io/cnoe-io/caipe-ui-prod:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-ui:${IMAGE_TAG:-localtag}-prod
     container_name: caipe-ui-prod
     # Same host port as caipe-ui — these two services are mutually exclusive.
     # Keycloak's caipe-ui client only allow-lists http://localhost:3000/*.
@@ -905,7 +905,7 @@ services:
     build:
       context: .
       dockerfile: build/Dockerfile.audit-service
-    image: ghcr.io/cnoe-io/caipe-audit-service:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-audit-service:${IMAGE_TAG:-localtag}
     container_name: audit-service
     ports:
       - "127.0.0.1:${AUDIT_SERVICE_PORT:-8010}:8010"
@@ -966,7 +966,7 @@ services:
     build:
       context: ./ai_platform_engineering/dynamic_agents
       dockerfile: build/Dockerfile
-    image: ghcr.io/cnoe-io/caipe-dynamic-agents:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-dynamic-agents:${IMAGE_TAG:-localtag}
     container_name: dynamic-agents
     ports: ["8100:8001"]
     volumes:
@@ -1120,7 +1120,7 @@ services:
       # Dockerfile itself lives at the repo root under build/
       context: ./ai_platform_engineering/autonomous_agents
       dockerfile: ../../build/Dockerfile.autonomous-agents
-    image: ghcr.io/cnoe-io/caipe-autonomous-agents:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-autonomous-agents:${IMAGE_TAG:-localtag}
     container_name: autonomous-agents
     ports: ["8002:8002"]
     env_file: [.env]
@@ -1176,7 +1176,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.server
-    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-server:${IMAGE_TAG:-localtag}
     container_name: rag-server
     # Network alias preserves the legacy `rag_server` hostname for any client
     # that still has it hardcoded. AGW's hickory-dns resolver rejects DNS
@@ -1256,7 +1256,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.agent-ontology
-    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-localtag}
     container_name: agent_ontology
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/agent_ontology/src/agent_ontology:/app/agent_ontology/src/agent_ontology
@@ -1290,7 +1290,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: web-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1322,7 +1322,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: backstage-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1349,7 +1349,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: aws-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1383,7 +1383,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: k8s-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1417,7 +1417,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: slack-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1446,7 +1446,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: webex-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1474,7 +1474,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: argocd-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1501,7 +1501,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: github-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1563,7 +1563,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: confluence-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1890,7 +1890,7 @@ services:
     build:
       context: .
       dockerfile: build/Dockerfile.slack-bot
-    image: ghcr.io/cnoe-io/caipe-slack-bot:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-slack-bot:${IMAGE_TAG:-localtag}
     container_name: slack-bot
     volumes:
       - ./ai_platform_engineering/integrations/slack_bot:/app
@@ -1994,7 +1994,7 @@ services:
     build:
       context: .
       dockerfile: build/Dockerfile.webex-bot
-    image: ghcr.io/cnoe-io/caipe-webex-bot:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-webex-bot:${IMAGE_TAG:-localtag}
     container_name: webex-bot
     volumes:
       - ./ai_platform_engineering/integrations/webex_bot:/app/ai_platform_engineering/integrations/webex_bot
@@ -2406,7 +2406,7 @@ services:
     build:
       context: ./deploy/agentgateway
       dockerfile: Dockerfile.config-bridge
-    image: ghcr.io/cnoe-io/agentgateway-config-bridge:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/agentgateway-config-bridge:${IMAGE_TAG:-localtag}
     container_name: agentgateway-config-bridge
     restart: unless-stopped
     read_only: true
@@ -2519,7 +2519,7 @@ services:
         # Bumping requires verifying /scan-upload response shape vs
         # ui/src/lib/skill-scan.ts.
         - SKILL_SCANNER_VERSION=${SKILL_SCANNER_VERSION:-2.0.11}
-    image: ghcr.io/cnoe-io/skill-scanner:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/skill-scanner:${IMAGE_TAG:-localtag}
     container_name: skill-scanner
     # Bind to 127.0.0.1 only — the API has no auth and accepts arbitrary
     # ZIPs, so it must never be reachable from outside the host.

--- a/docs/docs/agent-ops/index.md
+++ b/docs/docs/agent-ops/index.md
@@ -7,12 +7,12 @@ Agents and MCP tool servers.
 
 | Component | Image family |
 |---|---|
-| UI/BFF | `ghcr.io/cnoe-io/caipe-ui` |
-| Dynamic Agents | `ghcr.io/cnoe-io/caipe-dynamic-agents` |
-| MCP servers | `ghcr.io/cnoe-io/mcp-<name>` or external MCP image |
-| Slack bot | `ghcr.io/cnoe-io/caipe-slack-bot` |
-| Webex bot | `ghcr.io/cnoe-io/caipe-webex-bot` |
-| Audit service | `ghcr.io/cnoe-io/caipe-audit-service` |
+| UI/BFF | `ghcr.io/caipe-io/caipe-ui` |
+| Dynamic Agents | `ghcr.io/caipe-io/caipe-dynamic-agents` |
+| MCP servers | `ghcr.io/caipe-io/mcp-<name>` or external MCP image |
+| Slack bot | `ghcr.io/caipe-io/caipe-slack-bot` |
+| Webex bot | `ghcr.io/caipe-io/caipe-webex-bot` |
+| Audit service | `ghcr.io/caipe-io/caipe-audit-service` |
 
 ## Validation
 

--- a/docs/docs/development/advanced/ci-infrastructure.md
+++ b/docs/docs/development/advanced/ci-infrastructure.md
@@ -16,26 +16,24 @@ automation on the same package reference from prebuild through final release.
 
 ```mermaid
 flowchart LR
-  PR[prebuild/* pull request] --> PREBUILD[prebuild-*.yml]
-  MAIN[main merge] --> TAG[auto-tag.yml]
-  RELEASE[release/* merge] --> TAG
-  HOTFIX[release/x.y.z-hotfix merge] --> TAG
+  SOURCE["1 · Source events<br/>prebuild PR · main · release/*"]
+  SELECTOR["2 · Lifecycle selector<br/>temporary · dev · rc · hotfix · final"]
+  PUBLISH["3 · Publish workflows<br/>prebuild-* · ci-* · ci-helm"]
+  GHCR["4 · Canonical public GHCR<br/>images · charts"]
+  CONSUMERS["5 · Consumers<br/>Compose · Helm · Argo CD"]
 
-  PREBUILD --> IMAGE[Image CI]
-  PREBUILD --> CHART[Helm CI]
-  TAG --> IMAGE
-  TAG --> CHART
+  SOURCE --> SELECTOR --> PUBLISH --> GHCR --> CONSUMERS
+```
 
-  IMAGE --> IPKG[ghcr.io/caipe-io/image-name]
-  CHART --> HPKG[ghcr.io/caipe-io/charts/chart-name]
+Prebuild cleanup is a separate lifecycle around the same canonical packages:
 
-  IPKG --> CONSUMERS[Compose, Helm, and Argo CD]
-  HPKG --> CONSUMERS
-
-  PR --> CLOSE[PR merged or closed]
-  CLOSE --> CLEANUP[prebuild-image-cleanup.yml]
-  CLEANUP --> IPKG
-  CLEANUP --> HPKG
+```mermaid
+flowchart LR
+  OPEN["PR opened or updated"] --> PUBLISHED["Temporary selectors published"]
+  PUBLISHED --> TESTED["Artifacts tested"]
+  TESTED --> CLOSED["PR merged or closed"]
+  CLOSED --> CLEANUP["Temporary selectors deleted"]
+  CLEANUP --> PACKAGE["Canonical packages remain"]
 ```
 
 ## Package Model

--- a/docs/docs/development/advanced/ci-infrastructure.md
+++ b/docs/docs/development/advanced/ci-infrastructure.md
@@ -1,0 +1,190 @@
+---
+title: CI Infrastructure
+description: Package, workflow, visibility, and artifact-lifecycle architecture for CAIPE CI.
+---
+
+# CI Infrastructure
+
+CAIPE publishes each repo-owned artifact to one canonical GitHub Container
+Registry (GHCR) package. The artifact lifecycle is encoded in its tag or chart
+version, not in a separate registry path.
+
+This keeps Argo CD, Helm values, Compose files, vulnerability scans, and release
+automation on the same package reference from prebuild through final release.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  PR[prebuild/* pull request] --> PREBUILD[prebuild-*.yml]
+  MAIN[main merge] --> TAG[auto-tag.yml]
+  RELEASE[release/* merge] --> TAG
+  HOTFIX[release/x.y.z-hotfix merge] --> TAG
+
+  PREBUILD --> IMAGE[Image CI]
+  PREBUILD --> CHART[Helm CI]
+  TAG --> IMAGE
+  TAG --> CHART
+
+  IMAGE --> IPKG[ghcr.io/caipe-io/image-name]
+  CHART --> HPKG[ghcr.io/caipe-io/charts/chart-name]
+
+  IPKG --> CONSUMERS[Compose, Helm, and Argo CD]
+  HPKG --> CONSUMERS
+
+  PR --> CLOSE[PR merged or closed]
+  CLOSE --> CLEANUP[prebuild-image-cleanup.yml]
+  CLEANUP --> IPKG
+  CLEANUP --> HPKG
+```
+
+## Package Model
+
+| Artifact | Canonical package | Lifecycle selector |
+| --- | --- | --- |
+| Container image | `ghcr.io/caipe-io/<image>` | Docker tag |
+| Helm chart | `oci://ghcr.io/caipe-io/charts/<chart>` | Chart version |
+
+Examples:
+
+```text
+ghcr.io/caipe-io/caipe-ui:0.6.0-dev.6
+ghcr.io/caipe-io/caipe-ui:0.6.0-rc.1
+ghcr.io/caipe-io/caipe-ui:0.6.0
+
+oci://ghcr.io/caipe-io/charts/ai-platform-engineering:0.6.0-dev.6
+oci://ghcr.io/caipe-io/charts/ai-platform-engineering:0.6.0-rc.1
+oci://ghcr.io/caipe-io/charts/ai-platform-engineering:0.6.0
+```
+
+Do not create lifecycle-specific package paths such as:
+
+```text
+ghcr.io/caipe-io/prebuild/<image>
+ghcr.io/caipe-io/pre-release/<image>
+ghcr.io/caipe-io/pre-release-helm-charts/<chart>
+```
+
+One package preserves download history and package permissions while allowing a
+deployment to move between lifecycles by changing only its immutable tag or
+version.
+
+## Artifact Lifecycles
+
+| Lifecycle | Source | Example selector | Retention |
+| --- | --- | --- | --- |
+| PR prebuild | `prebuild/*` pull request | `feature-name-3` | Deleted when the PR closes |
+| Development | Merge to `main` | `0.6.0-dev.6` | Retained |
+| Release candidate | `release/x.y.z` | `0.6.0-rc.1` | Retained until release cleanup |
+| Hotfix candidate | Hotfix flow | `0.6.0-hotfix.1` | Retained until release cleanup |
+| Final release | Release finalization | `0.6.0` | Retained |
+
+`release/*` and hotfix branches remain supported. Their workflows select a
+different version; they do not select a different package tree.
+
+## Workflow Responsibilities
+
+| Workflow or action | Responsibility |
+| --- | --- |
+| `pr-version-bump.yml` | Determines PR flow and version changes; dispatches prebuild work |
+| `auto-tag.yml` | Creates development, release-candidate, hotfix, and chart-only tags |
+| `prebuild-*.yml` | Builds temporary PR images in canonical packages |
+| `prebuild-helm.yml` | Publishes temporary chart versions in canonical chart packages |
+| `ci-*.yml` | Builds or retags versioned images after a Git tag |
+| `ci-helm.yml` | Publishes versioned charts after a Git tag |
+| `release-manual.yml` | Creates the final release tag and draft GitHub Release |
+| `release-finalize.yml` | Publishes the release after required artifact workflows complete |
+| `prebuild-image-cleanup.yml` | Deletes temporary image tags and chart versions when a PR closes |
+| `security-scan.yml` | Scans the exact canonical image package and selected tag |
+
+See [CI/CD and Releases](../ci-cd-and-releases.md) for the branch and version
+state machine and [Prebuild Flow](../prebuild-flow.md) for PR artifact details.
+
+## Package Ownership Boundary
+
+Only artifacts built by this repository move to `caipe-io` packages. A chart
+may still reference an external image when another repository owns its build
+and release lifecycle.
+
+Examples of external packages include legacy `agent-*` images and the custom
+Playwright image. Do not rename those references until the owning repository
+publishes an equivalent package and version in the new organization.
+
+## Public Package Visibility
+
+The source repository being public does not automatically make a new GHCR
+package public. A new package is initially governed by the CAIPE organization
+package policy and its own visibility setting.
+
+For OSS artifacts, the required state is:
+
+- The CAIPE organization allows **Public** package creation under
+  **Settings → Packages → Package creation**.
+- Every repo-owned image and chart package is set to **Public**.
+- `ai-platform-engineering` retains Actions access with the role required to
+  publish and clean up package versions.
+- Anonymous consumers can pull the selected image or chart version.
+
+Changing the organization policy is broader than changing one package: it lets
+organization members create public packages in the future. Treat it as an
+organization-level governance decision.
+
+After the first publication of a new package:
+
+1. Open the package's **Package settings** page.
+2. Select **Change visibility**.
+3. Change the package to **Public** and confirm the package name.
+4. Verify anonymous image or chart access.
+
+Changing visibility does not republish or retag the artifact.
+
+## Stable Migration Compatibility
+
+Do not change a stable installer from `cnoe-io` to `caipe-io` until every tag it
+references exists and is public in the new organization. Otherwise, the source
+configuration is correct but first installation fails with an authentication or
+manifest-not-found error.
+
+During migration:
+
+- New development, prebuild, release-candidate, and final artifacts publish to
+  canonical `caipe-io` packages.
+- Source chart defaults and future release tooling use the canonical packages.
+- A stable Compose or installation example may temporarily retain a pinned
+  `cnoe-io` artifact.
+- Update the repository and version together after verifying the new artifact.
+
+The compatibility exception is for consumers only. Do not publish new artifacts
+to legacy package trees.
+
+## Verification
+
+Verify an image without relying on a local registry login:
+
+```bash
+docker manifest inspect ghcr.io/caipe-io/<image>:<tag>
+```
+
+Verify a chart:
+
+```bash
+helm show chart \
+  oci://ghcr.io/caipe-io/charts/<chart> \
+  --version <version>
+```
+
+Before changing a stable consumer, verify every image and chart referenced by
+that installation path. A successful prerelease package does not prove that an
+older stable tag was copied.
+
+## Invariants
+
+CI changes must preserve these rules:
+
+- One canonical package per repo-owned artifact.
+- Lifecycle encoded in the tag or chart version.
+- Public read access for OSS artifacts.
+- Write access limited to approved repositories and release automation.
+- Temporary PR artifacts deleted when the PR closes.
+- No stable consumer cutover before all referenced artifacts exist publicly.
+- External package references change only with coordination from their owner.

--- a/docs/docs/development/ci-cd-and-releases.md
+++ b/docs/docs/development/ci-cd-and-releases.md
@@ -38,8 +38,8 @@ Artifact lifecycle is encoded in immutable tags, while registry paths remain sta
 
 | Artifact type | Flow | Registry path |
 | --- | --- | --- |
-| Docker images | all release and prebuild flows | `ghcr.io/cnoe-io/<image>` |
-| Helm charts | all release and prebuild flows | `ghcr.io/cnoe-io/charts` |
+| Docker images | all release and prebuild flows | `ghcr.io/caipe-io/<image>` |
+| Helm charts | all release and prebuild flows | `ghcr.io/caipe-io/charts` |
 
 ## PR Flow
 
@@ -115,7 +115,7 @@ Use prebuilds when you want to test Docker images or Helm charts without waiting
 1. Create a branch called `prebuild/*`, for example `prebuild/feat/add-feature-a`.
 2. Open a PR from the prebuild branch to the intended target branch (this can be any).
 3. The `pr-version-bump.yml` workflow detects the `prebuild/*` source branch and dispatches a prebuild workflow (as well as the normal version bump flow if the target branch is `main` or `release/**`).
-4. The prebuild workflow publishes changed images to their canonical packages and charts to `ghcr.io/cnoe-io/charts` with branch- and commit-specific tags.
+4. The prebuild workflow publishes changed images to their canonical packages and charts to `ghcr.io/caipe-io/charts` with branch- and commit-specific tags.
 5. Each new commit to the prebuild branch publishes a new temporary tag.
 6. Use the prebuild artifacts for testing.
 7. Upon PR merge or closure, all prebuild artifacts with the branch tag are automatically deleted.
@@ -132,9 +132,9 @@ Use a `release/x.y.z` branch when preparing a new release.
 6. Tag pushes trigger Docker and Helm CI.
 7. Test the published RC artifacts from GHCR.
 
-RC Docker images are under `ghcr.io/cnoe-io/<image>`.
+RC Docker images are under `ghcr.io/caipe-io/<image>`.
 
-RC Helm charts are under `ghcr.io/cnoe-io/charts`.
+RC Helm charts are under `ghcr.io/caipe-io/charts`.
 
 ## Final Release Flow
 

--- a/docs/docs/features/custom-agents.md
+++ b/docs/docs/features/custom-agents.md
@@ -18,7 +18,7 @@ Dynamic Agents is the chat runtime and agent-builder service.
 - MCP tool support: connect registered MCP servers over `stdio` or streamable `http`
 - Built-in tools include URL fetch, current datetime, user info, wait, and approved workflow execution
 - REST + SSE API for browser, bot, workflow, and service callers
-- Deploy via Helm: `oci://ghcr.io/cnoe-io/charts/dynamic-agents`
+- Deploy via Helm: `oci://ghcr.io/caipe-io/charts/dynamic-agents`
 
 ## Agent Builder UI
 

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/audit-service.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/audit-service.md
@@ -63,7 +63,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
 | extraEnvFrom | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-audit-service"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-audit-service"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | livenessProbe.failureThreshold | int | `3` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/autonomous-agents.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/autonomous-agents.md
@@ -72,7 +72,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-autonomous-agents"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-autonomous-agents"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/caipe-ui.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/caipe-ui.md
@@ -132,7 +132,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-ui"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-ui"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/dynamic-agents.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/dynamic-agents.md
@@ -91,7 +91,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-dynamic-agents"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-dynamic-agents"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/index.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/index.md
@@ -120,7 +120,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | caipe-ui.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | caipe-ui.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | caipe-ui.image.pullPolicy | string | `"IfNotPresent"` |  |
-| caipe-ui.image.repository | string | `"ghcr.io/cnoe-io/caipe-ui"` |  |
+| caipe-ui.image.repository | string | `"ghcr.io/caipe-io/caipe-ui"` |  |
 | caipe-ui.image.tag | string | `""` |  |
 | caipe-ui.ingress.annotations | object | `{}` |  |
 | caipe-ui.ingress.className | string | `"nginx"` |  |
@@ -191,7 +191,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | dynamic-agents.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | dynamic-agents.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | dynamic-agents.image.pullPolicy | string | `"IfNotPresent"` |  |
-| dynamic-agents.image.repository | string | `"ghcr.io/cnoe-io/caipe-dynamic-agents"` |  |
+| dynamic-agents.image.repository | string | `"ghcr.io/caipe-io/caipe-dynamic-agents"` |  |
 | dynamic-agents.image.tag | string | `""` |  |
 | dynamic-agents.nameOverride | string | `"dynamic-agents"` |  |
 | dynamic-agents.service.metricsPort | int | `0` |  |
@@ -225,7 +225,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | global.agentgateway.static.configBridge.enabled | bool | `true` |  |
 | global.agentgateway.static.configBridge.extraEnv | list | `[]` |  |
 | global.agentgateway.static.configBridge.image.pullPolicy | string | `"IfNotPresent"` |  |
-| global.agentgateway.static.configBridge.image.repository | string | `"ghcr.io/cnoe-io/agentgateway-config-bridge"` |  |
+| global.agentgateway.static.configBridge.image.repository | string | `"ghcr.io/caipe-io/agentgateway-config-bridge"` |  |
 | global.agentgateway.static.configBridge.image.tag | string | `""` |  |
 | global.agentgateway.static.configBridge.pollSeconds | int | `5` |  |
 | global.agentgateway.static.configBridge.ui.existingSecret.key | string | `"AGENTGATEWAY_TARGETS_TOKEN"` |  |
@@ -327,7 +327,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | litellmMcp.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | litellmMcp.fullnameOverride | string | `""` |  |
 | litellmMcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| litellmMcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-litellm"` |  |
+| litellmMcp.image.repository | string | `"ghcr.io/caipe-io/mcp-litellm"` |  |
 | litellmMcp.image.tag | string | `""` |  |
 | litellmMcp.imagePullSecrets | list | `[]` |  |
 | litellmMcp.livenessProbe.failureThreshold | int | `3` |  |
@@ -356,11 +356,11 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | litellmMcp.service.type | string | `"ClusterIP"` |  |
 | litellmMcp.tolerations | list | `[]` |  |
 | mcp-argocd.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-argocd.image.repository | string | `"ghcr.io/cnoe-io/mcp-argocd"` |  |
+| mcp-argocd.image.repository | string | `"ghcr.io/caipe-io/mcp-argocd"` |  |
 | mcp-argocd.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-argocd.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-argocd.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-argocd.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-argocd"` |  |
+| mcp-argocd.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-argocd"` |  |
 | mcp-argocd.mcp.image.tag | string | `""` |  |
 | mcp-argocd.mcp.mode | string | `"http"` |  |
 | mcp-argocd.mcp.port | int | `8000` |  |
@@ -376,7 +376,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-aws.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-aws.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-aws.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-aws.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-aws"` |  |
+| mcp-aws.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-aws"` |  |
 | mcp-aws.mcp.image.tag | string | `""` |  |
 | mcp-aws.mcp.mode | string | `"http"` |  |
 | mcp-aws.mcp.port | int | `8000` |  |
@@ -386,7 +386,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-backstage.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-backstage.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-backstage.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-backstage.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-backstage"` |  |
+| mcp-backstage.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-backstage"` |  |
 | mcp-backstage.mcp.image.tag | string | `""` |  |
 | mcp-backstage.mcp.mode | string | `"http"` |  |
 | mcp-backstage.mcp.port | int | `8000` |  |
@@ -403,7 +403,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-confluence.mcp.port | int | `8000` |  |
 | mcp-confluence.nameOverride | string | `"mcp-confluence"` |  |
 | mcp-github.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-github.image.repository | string | `"ghcr.io/cnoe-io/mcp-github"` |  |
+| mcp-github.image.repository | string | `"ghcr.io/caipe-io/mcp-github"` |  |
 | mcp-github.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-github.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-github.mcp.agentgateway.providerTokenAuth | bool | `true` |  |
@@ -437,7 +437,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-jira.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-jira.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-jira.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-jira.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-jira"` |  |
+| mcp-jira.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-jira"` |  |
 | mcp-jira.mcp.image.tag | string | `""` |  |
 | mcp-jira.mcp.mode | string | `"http"` |  |
 | mcp-jira.mcp.port | int | `8000` |  |
@@ -447,7 +447,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-komodor.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-komodor.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-komodor.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-komodor.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-komodor"` |  |
+| mcp-komodor.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-komodor"` |  |
 | mcp-komodor.mcp.image.tag | string | `""` |  |
 | mcp-komodor.mcp.mode | string | `"http"` |  |
 | mcp-komodor.mcp.port | int | `8000` |  |
@@ -458,7 +458,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-netutils.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-netutils.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-netutils.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-netutils.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-netutils"` |  |
+| mcp-netutils.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-netutils"` |  |
 | mcp-netutils.mcp.image.tag | string | `""` |  |
 | mcp-netutils.mcp.mode | string | `"http"` |  |
 | mcp-netutils.mcp.port | int | `8000` |  |
@@ -468,7 +468,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-pagerduty.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-pagerduty.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-pagerduty.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-pagerduty.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-pagerduty"` |  |
+| mcp-pagerduty.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-pagerduty"` |  |
 | mcp-pagerduty.mcp.image.tag | string | `""` |  |
 | mcp-pagerduty.mcp.mode | string | `"http"` |  |
 | mcp-pagerduty.mcp.port | int | `8000` |  |
@@ -492,7 +492,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-splunk.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-splunk.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-splunk.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-splunk.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-splunk"` |  |
+| mcp-splunk.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-splunk"` |  |
 | mcp-splunk.mcp.image.tag | string | `""` |  |
 | mcp-splunk.mcp.mode | string | `"http"` |  |
 | mcp-splunk.mcp.port | int | `8000` |  |
@@ -502,7 +502,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-victorops.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-victorops.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-victorops.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-victorops.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-victorops"` |  |
+| mcp-victorops.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-victorops"` |  |
 | mcp-victorops.mcp.image.tag | string | `""` |  |
 | mcp-victorops.mcp.mode | string | `"http"` |  |
 | mcp-victorops.mcp.port | int | `8000` |  |
@@ -516,7 +516,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-webex-meetings.mcp.agentgateway.pathPrefix | string | `"/mcp/webex_meetings"` |  |
 | mcp-webex-meetings.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-webex-meetings.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex-meetings.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-webex-meetings"` |  |
+| mcp-webex-meetings.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-webex-meetings"` |  |
 | mcp-webex-meetings.mcp.image.tag | string | `""` |  |
 | mcp-webex-meetings.mcp.mode | string | `"http"` |  |
 | mcp-webex-meetings.mcp.port | int | `8000` |  |
@@ -527,7 +527,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-webex.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-webex.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-webex.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-webex"` |  |
+| mcp-webex.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-webex"` |  |
 | mcp-webex.mcp.image.tag | string | `""` |  |
 | mcp-webex.mcp.mode | string | `"http"` |  |
 | mcp-webex.mcp.port | int | `8000` |  |
@@ -549,7 +549,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | openfga-authz-bridge.audit.subjectSalt | string | `"caipe-098-audit"` |  |
 | openfga-authz-bridge.audit.tenantId | string | `"default"` |  |
 | openfga-authz-bridge.image.pullPolicy | string | `"IfNotPresent"` |  |
-| openfga-authz-bridge.image.repository | string | `"ghcr.io/cnoe-io/openfga-authz-bridge"` |  |
+| openfga-authz-bridge.image.repository | string | `"ghcr.io/caipe-io/openfga-authz-bridge"` |  |
 | openfga-authz-bridge.image.tag | string | `""` |  |
 | openfga-authz-bridge.openfga.httpUrl | string | `""` |  |
 | openfga-authz-bridge.openfga.object | string | `"mcp_gateway:list"` |  |
@@ -577,7 +577,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | rag-stack.agent-ontology.enabled | bool | `true` |  |
 | rag-stack.agent-rag.enabled | bool | `true` |  |
 | rag-stack.agent-rag.image.pullPolicy | string | `"IfNotPresent"` |  |
-| rag-stack.agent-rag.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-rag"` |  |
+| rag-stack.agent-rag.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-rag"` |  |
 | rag-stack.agent-rag.image.tag | string | `""` |  |
 | rag-stack.milvus.enabled | bool | `true` |  |
 | rag-stack.neo4j.enabled | bool | `true` |  |
@@ -590,18 +590,18 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | rag-stack.rag-server.env.CAIPE_UNSAFE_RBAC_BYPASS | string | `"false"` |  |
 | rag-stack.rag-server.env.OPENFGA_STORE_NAME | string | `"caipe-openfga"` |  |
 | rag-stack.rag-server.image.pullPolicy | string | `"IfNotPresent"` |  |
-| rag-stack.rag-server.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| rag-stack.rag-server.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | rag-stack.rag-server.image.tag | string | `""` |  |
 | scheduler.args | list | `[]` |  |
 | scheduler.caipe.apiUrl | string | `"http://{{ .Release.Name }}-caipe-ui:3000"` |  |
 | scheduler.caipe.chatPath | string | `"/api/v1/chat/invoke"` |  |
 | scheduler.command | list | `[]` |  |
 | scheduler.cronRunner.image.pullPolicy | string | `"IfNotPresent"` |  |
-| scheduler.cronRunner.image.repository | string | `"ghcr.io/cnoe-io/caipe-cron-runner"` |  |
+| scheduler.cronRunner.image.repository | string | `"ghcr.io/caipe-io/caipe-cron-runner"` |  |
 | scheduler.cronRunner.image.tag | string | `""` |  |
 | scheduler.fullnameOverride | string | `"caipe-scheduler"` |  |
 | scheduler.image.pullPolicy | string | `"IfNotPresent"` |  |
-| scheduler.image.repository | string | `"ghcr.io/cnoe-io/caipe-scheduler"` |  |
+| scheduler.image.repository | string | `"ghcr.io/caipe-io/caipe-scheduler"` |  |
 | scheduler.image.tag | string | `""` |  |
 | scheduler.mongo.database | string | `"caipe"` |  |
 | scheduler.mongo.existingSecret | string | `""` |  |
@@ -621,7 +621,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | schedulerMcp.env.MCP_PORT | string | `"8000"` |  |
 | schedulerMcp.env.SCHEDULER_URL | string | `"http://caipe-scheduler:8080"` |  |
 | schedulerMcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| schedulerMcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-scheduler"` |  |
+| schedulerMcp.image.repository | string | `"ghcr.io/caipe-io/mcp-scheduler"` |  |
 | schedulerMcp.image.tag | string | `""` |  |
 | schedulerMcp.nameOverride | string | `"mcp-scheduler"` |  |
 | schedulerMcp.resources | object | `{}` |  |
@@ -633,7 +633,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | slack-bot.existingSecret | string | `"slack-bot-secrets"` | Reference to a pre-existing Kubernetes Secret. Should contain: SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_SIGNING_SECRET, and optionally OAUTH2_CLIENT_SECRET. |
 | slack-bot.externalSecrets | object | `{"apiVersion":"v1beta1","data":[],"enabled":false,"secretStoreRef":{"kind":"ClusterSecretStore","name":"vault"}}` | External Secrets configuration for sensitive data |
 | slack-bot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| slack-bot.image.repository | string | `"ghcr.io/cnoe-io/caipe-slack-bot"` |  |
+| slack-bot.image.repository | string | `"ghcr.io/caipe-io/caipe-slack-bot"` |  |
 | slack-bot.image.tag | string | `""` |  |
 | slack-bot.resources.limits.cpu | string | `"500m"` |  |
 | slack-bot.resources.limits.memory | string | `"512Mi"` |  |
@@ -689,7 +689,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | webex-bot.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | webex-bot.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | webex-bot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| webex-bot.image.repository | string | `"ghcr.io/cnoe-io/caipe-webex-bot"` |  |
+| webex-bot.image.repository | string | `"ghcr.io/caipe-io/caipe-webex-bot"` |  |
 | webex-bot.image.tag | string | `""` |  |
 | webex-bot.keycloakBot.clientSecretFromSecret.key | string | `"KC_WEBEX_BOT_CLIENT_SECRET"` |  |
 | webex-bot.keycloakBot.clientSecretFromSecret.name | string | `""` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/keycloak.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/keycloak.md
@@ -146,7 +146,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
 | ingress.hosts[0].paths[1].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | initImage.pullPolicy | string | `"IfNotPresent"` |  |
-| initImage.repository | string | `"ghcr.io/cnoe-io/keycloak-init"` |  |
+| initImage.repository | string | `"ghcr.io/caipe-io/keycloak-init"` |  |
 | initImage.tag | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/openfga-authz-bridge.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/openfga-authz-bridge.md
@@ -67,7 +67,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5
 | callerToolCheck.enabled | bool | `false` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/openfga-authz-bridge"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/openfga-authz-bridge"` |  |
 | image.tag | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/scheduler.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/scheduler.md
@@ -70,7 +70,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
 | caipe.apiUrl | string | `"http://caipe-ui:3000"` |  |
 | caipe.chatPath | string | `"/api/v1/chat/invoke"` |  |
 | cronRunner.image.pullPolicy | string | `"IfNotPresent"` |  |
-| cronRunner.image.repository | string | `"ghcr.io/cnoe-io/caipe-cron-runner"` |  |
+| cronRunner.image.repository | string | `"ghcr.io/caipe-io/caipe-cron-runner"` |  |
 | cronRunner.image.tag | string | `""` |  |
 | cronRunner.resources.limits.cpu | string | `"100m"` |  |
 | cronRunner.resources.limits.memory | string | `"128Mi"` |  |
@@ -80,7 +80,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
 | cronRunnerServiceAccount.name | string | `"caipe-cron-runner"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-scheduler"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-scheduler"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | limits.maxMessageChars | int | `2000` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/skill-scanner.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/skill-scanner.md
@@ -63,7 +63,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
 | affinity | object | `{}` | Pod affinity rules |
 | fullnameOverride | string | `""` | Override the full release name |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ghcr.io/cnoe-io/skill-scanner"` | Container image repository. Build via build/Dockerfile.skill-scanner and push to your registry; override in the parent values.yaml. |
+| image.repository | string | `"ghcr.io/caipe-io/skill-scanner"` | Container image repository. Build via build/Dockerfile.skill-scanner and push to your registry; override in the parent values.yaml. |
 | image.tag | string | `""` | Image tag. Defaults to the parent chart's appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":0,"periodSeconds":20,"timeoutSeconds":3}` | Liveness probe — hits the FastAPI /health endpoint. |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/slack-bot.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/slack-bot.md
@@ -64,7 +64,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
 | externalSecrets | object | `{"apiVersion":"v1beta1","data":[],"enabled":false,"secretStoreRef":{"kind":"ClusterSecretStore","name":"vault"}}` | External Secrets configuration for sensitive data (Slack tokens, OAuth2 client secret, etc.) |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-slack-bot"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-slack-bot"` |  |
 | image.tag | string | `""` |  |
 | keycloakBot | object | `{"clientSecretFromSecret":{"key":"KC_BOT_CLIENT_SECRET","name":""}}` | Cross-chart binding to the Keycloak bot client_secret used by the Slack bot's RFC 8693 OBO exchange helper. In umbrella installs this usually points at the same Secret/key as oauth2.clientSecretFromSecret. |
 | nameOverride | string | `""` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/webex-bot.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/webex-bot.md
@@ -69,7 +69,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-webex-bot"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-webex-bot"` |  |
 | image.tag | string | `""` |  |
 | keycloakAdmin | object | `{"clientId":"","clientSecretFromSecret":{"key":"KC_PLATFORM_CLIENT_SECRET","name":""}}` | Keycloak Admin API credentials for webex_user_id lookups (typically caipe-platform). |
 | keycloakBot | object | `{"clientSecretFromSecret":{"key":"KC_WEBEX_BOT_CLIENT_SECRET","name":""}}` | Single source of truth: Keycloak chart Secret \{\{release\}\}-keycloak-webex-bot (KC_WEBEX_BOT_CLIENT_SECRET). |

--- a/docs/docs/installation/helm-charts/rag-stack/agent-ontology.md
+++ b/docs/docs/installation/helm-charts/rag-stack/agent-ontology.md
@@ -68,7 +68,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
 | env | object | `{}` |  |
 | fullnameOverride | string | `"agent-ontology"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-ontology"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-ontology"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/rag-stack/index.md
+++ b/docs/docs/installation/helm-charts/rag-stack/index.md
@@ -63,7 +63,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
 | agent-ontology.enabled | bool | `true` |  |
 | agent-ontology.fullnameOverride | string | `"agent-ontology"` |  |
 | agent-ontology.image.pullPolicy | string | `"Always"` |  |
-| agent-ontology.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-ontology"` |  |
+| agent-ontology.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-ontology"` |  |
 | agent-ontology.image.tag | string | `""` |  |
 | agent-ontology.livenessProbe.failureThreshold | int | `3` |  |
 | agent-ontology.livenessProbe.httpGet.path | string | `"/v1/graph/ontology/agent/status"` |  |
@@ -211,7 +211,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
 | rag-server.envFrom | list | `[]` |  |
 | rag-server.fullnameOverride | string | `"rag-server"` |  |
 | rag-server.image.pullPolicy | string | `"Always"` |  |
-| rag-server.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| rag-server.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | rag-server.image.tag | string | `""` |  |
 | rag-server.podAnnotations | object | `{}` |  |
 | rag-server.resources.limits.cpu | string | `"500m"` |  |

--- a/docs/docs/installation/helm-charts/rag-stack/rag-ingestors.md
+++ b/docs/docs/installation/helm-charts/rag-stack/rag-ingestors.md
@@ -65,7 +65,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
 | defaultResources.requests.ephemeral-storage | string | `"256Mi"` |  |
 | defaultResources.requests.memory | string | `"256Mi"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-ingestors"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-ingestors"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingestors | list | `[]` |  |

--- a/docs/docs/installation/helm-charts/rag-stack/rag-server.md
+++ b/docs/docs/installation/helm-charts/rag-stack/rag-server.md
@@ -64,7 +64,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `"rag-server"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |

--- a/docs/docs/repo-ops/releases.md
+++ b/docs/docs/repo-ops/releases.md
@@ -56,7 +56,7 @@ gh workflow run release-finalize.yml \
 
 This workflow:
 - Promotes `x.y.z-rc.N` → `x.y.z`
-- Publishes the Helm chart to `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering`
+- Publishes the Helm chart to `oci://ghcr.io/caipe-io/charts/ai-platform-engineering`
 - Creates a GitHub Release with auto-generated notes
 
 ---

--- a/docs/docs/security/rbac/caipe-rbac-migration.md
+++ b/docs/docs/security/rbac/caipe-rbac-migration.md
@@ -23,6 +23,12 @@ chart_version: 0.5.1-rc.25
 namespace: caipe-rbac
 ```
 
+This is the legacy location for the currently pinned RC. New prerelease and
+release charts are published to the same canonical package as every other
+lifecycle: `ghcr.io/caipe-io/charts/ai-platform-engineering`. Change the
+repository and version together after the selected chart version exists in the
+new organization; do not publish new charts to `pre-release-helm-charts`.
+
 The deployment already enables the RBAC runtime stack:
 
 - `tags.keycloak: true`

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -204,6 +204,17 @@ const sidebars: SidebarsConfig = {
         { type: 'doc', id: 'repo-ops/issue-triage', label: 'Issue Triage Dashboard' },
         {
           type: 'category',
+          label: 'Advanced',
+          items: [
+            {
+              type: 'doc',
+              id: 'development/advanced/ci-infrastructure',
+              label: 'CI Infrastructure',
+            },
+          ],
+        },
+        {
+          type: 'category',
           label: 'Skills',
           items: [
             { type: 'doc', id: 'repo-ops/skills/index', label: 'Overview' },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "0.6.0-dev.6"
+version = "0.6.0-dev.7"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CNOE Contributors"}

--- a/scripts/generate-helm-chart-docs.sh
+++ b/scripts/generate-helm-chart-docs.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_NAME="scripts/generate-helm-chart-docs.sh"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-OCI_REGISTRY="oci://ghcr.io/cnoe-io/charts/ai-platform-engineering"
+OCI_REGISTRY="oci://ghcr.io/caipe-io/charts/ai-platform-engineering"
 PARENT_CHARTS=("ai-platform-engineering" "rag-stack")
 CHARTS_ROOT="${REPO_ROOT}/charts"
 DOCS_HELM_ROOT="${REPO_ROOT}/docs/docs/installation/helm-charts"
@@ -300,9 +300,9 @@ generate_source_readme() {
   local parent_group
   parent_group=$(parent_group_of "$chart_dir")
 
-  local oci_url="oci://ghcr.io/cnoe-io/charts/${name}"
+  local oci_url="oci://ghcr.io/caipe-io/charts/${name}"
   if is_parent_chart "$chart_dir"; then
-    oci_url="oci://ghcr.io/cnoe-io/charts/${name}"
+    oci_url="oci://ghcr.io/caipe-io/charts/${name}"
   fi
 
   cat > "${chart_dir}/README.md" <<EOF
@@ -398,7 +398,7 @@ generate_docusaurus_page() {
     deps_section=$(generate_dependencies_section "$chart_dir")
   fi
 
-  local oci_url="oci://ghcr.io/cnoe-io/charts/${name}"
+  local oci_url="oci://ghcr.io/caipe-io/charts/${name}"
 
   {
     cat <<EOF

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "0.6.0.dev6"
+version = "0.6.0.dev7"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Finishes the package-routing cleanup started in #2467 and implements the package layout proposed in [Discussion #2468](https://github.com/orgs/caipe-io/discussions/2468).

Repo-owned artifacts now use one canonical package per artifact:

- Docker: `ghcr.io/caipe-io/<image>:<lifecycle-tag>`
- Helm: `oci://ghcr.io/caipe-io/charts/<chart>:<lifecycle-version>`

Prebuild, prerelease, hotfix, and final-release status is represented by tags or chart versions, not by separate package paths.

This PR:

- updates source Helm values, generated values tables, dev Compose images, security scanning, release-document generation, and developer documentation
- keeps external images that this repository does not publish, such as `agent-*` and the Playwright image, in `cnoe-io`
- preserves `release/*`, `hotfix/*`, `release-manual.yml`, `release-prerelease.yml`, auto-tagging, release-branch sync, and version-bump behavior
- retains the stable first-install Compose/setup paths in `cnoe-io` until matching stable tags are available in `caipe-io`
- marks the currently pinned RBAC prerelease chart path as legacy and documents the canonical destination for the ArgoCD cutover

The stable cutover is intentionally deferred: anonymous registry checks confirmed that `caipe-ui:0.5.66`, `caipe-dynamic-agents:0.5.66`, and chart `0.5.68` are not yet present under `caipe-io`.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [x] Documentation
- [x] Other: package routing and release-tooling cleanup

## Temporary Helm Charts (Optional)

This branch uses the `prebuild/` prefix. Temporary charts should publish to `ghcr.io/caipe-io/charts` with PR-specific versions and be deleted when the PR closes.

## Validation

- [x] Required first-install and dev Compose configurations render successfully
- [x] Dev Compose resolves repo-owned images under `ghcr.io/caipe-io`
- [x] All source Helm charts pass `helm lint`
- [x] Changed workflows pass `actionlint`
- [x] Scheduler tests pass: 19 tests
- [x] Ruff passes for the changed Python configuration
- [x] Package-tree invariants pass; no nested `prebuild/` or `pre-release/` package path remains
- [x] Preserved release/hotfix workflows have no diff

A broader pre-existing Helm probe suite still has unrelated dependency/configuration drift; this PR does not expand scope to repair those baseline failures.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing work is referenced: #2467 and Discussion #2468
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All changed code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All repository-wide existing tests pass
