### PR TITLE
fix(ci): support RC versions in manual releases

### DIFF
--- a/.github/actions/prepare-release/action.yml
+++ b/.github/actions/prepare-release/action.yml
@@ -6,7 +6,7 @@ description: >
 
 inputs:
   version:
-    description: 'Release version (bare x.y.z, e.g. 0.3.0)'
+    description: 'Release version (e.g. 1.0.0 or 1.0.0-rc.1)'
     required: true
 
 runs:

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'New version to release (e.g., 0.2.9, 0.3.0, 1.0.0)'
+        description: 'New version to release (e.g., 1.0.0 or 1.0.0-rc.1)'
         required: true
         type: string
 
@@ -51,8 +51,8 @@ jobs:
           VERSION="$RELEASE_VERSION"
           echo "📦 Requested version: $VERSION"
 
-          if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "❌ ERROR: Version must be in semver format (e.g., 0.2.9, 0.3.0, 1.0.0)"
+          if ! [[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-rc\.(0|[1-9][0-9]*))?$ ]]; then
+            echo "❌ ERROR: Version must be a final or RC semver (e.g., 1.0.0 or 1.0.0-rc.1)"
             echo "   Received: '$VERSION'"
             exit 1
           fi
@@ -62,27 +62,53 @@ jobs:
       - name: 🔍 Get current version and validate
         id: validate
         run: |
+          set -euo pipefail
+
           # Extract current version from pyproject.toml (strip any pre-release suffix to bare x.y.z)
           RAW_VERSION=$(grep '^version = ' pyproject.toml | sed 's/version = "\(.*\)"/\1/')
           CURRENT_BARE=$(echo "$RAW_VERSION" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
           NEW_VERSION="$RELEASE_VERSION"
+          NEW_BARE=$(echo "$NEW_VERSION" | grep -oE '^[0-9]+\.[0-9]+\.[0-9]+')
 
           echo "📋 Current version (raw): $RAW_VERSION"
           echo "📋 Current version (bare): $CURRENT_BARE"
           echo "📦 New version: $NEW_VERSION"
-          echo "current_version=$RAW_VERSION" >> $GITHUB_OUTPUT
+          echo "current_version=$RAW_VERSION" >> "$GITHUB_OUTPUT"
 
-          # If current bare version already matches, that's fine (pr-version-bump already ran)
-          if [[ "$CURRENT_BARE" == "$NEW_VERSION" || "$RAW_VERSION" == "$NEW_VERSION" ]]; then
+          if [[ "$RAW_VERSION" == "$NEW_VERSION" ]]; then
             echo "✅ Version already at $NEW_VERSION (pr-version-bump likely ran) — will verify files"
+          elif [[ "$CURRENT_BARE" == "$NEW_BARE" ]]; then
+            # Within the same base version, allow dev → RC, increasing RCs,
+            # or any prerelease → final. Reject stable → RC and RC downgrades.
+            if [[ "$NEW_VERSION" =~ -rc\.([0-9]+)$ ]]; then
+              NEW_RC_NUMBER="${BASH_REMATCH[1]}"
+              BASE_VERSION_RE="${NEW_BARE//./\\.}"
+
+              if [[ "$RAW_VERSION" =~ ^${BASE_VERSION_RE}-dev\.[0-9]+$ ]]; then
+                echo "✅ Version increment validated: $RAW_VERSION -> $NEW_VERSION"
+              elif [[ "$RAW_VERSION" =~ ^${BASE_VERSION_RE}-rc\.([0-9]+)$ ]]; then
+                CURRENT_RC_NUMBER="${BASH_REMATCH[1]}"
+                if (( 10#$NEW_RC_NUMBER < 10#$CURRENT_RC_NUMBER )); then
+                  echo "❌ ERROR: RC version ($NEW_VERSION) must not be lower than current version ($RAW_VERSION)"
+                  exit 1
+                fi
+                echo "✅ RC increment validated: $RAW_VERSION -> $NEW_VERSION"
+              else
+                echo "❌ ERROR: Cannot move from $RAW_VERSION to prerelease $NEW_VERSION"
+                exit 1
+              fi
+            else
+              echo "✅ Final release validated: $RAW_VERSION -> $NEW_VERSION"
+            fi
           else
-            # Check for downgrade
-            HIGHER=$(echo -e "$CURRENT_BARE\n$NEW_VERSION" | sort -V | tail -n1)
-            if [[ "$HIGHER" == "$CURRENT_BARE" && "$CURRENT_BARE" != "$NEW_VERSION" ]]; then
-              echo "❌ ERROR: New version ($NEW_VERSION) must be greater than or equal to current version ($CURRENT_BARE)"
+            # Compare bare versions so prerelease suffix ordering cannot make a
+            # higher base version look like a downgrade.
+            HIGHER=$(printf '%s\n' "$CURRENT_BARE" "$NEW_BARE" | sort -V | tail -n1)
+            if [[ "$HIGHER" == "$CURRENT_BARE" ]]; then
+              echo "❌ ERROR: New version ($NEW_VERSION) must be greater than current version ($RAW_VERSION)"
               exit 1
             fi
-            echo "✅ Version increment validated: $CURRENT_BARE -> $NEW_VERSION"
+            echo "✅ Version increment validated: $RAW_VERSION -> $NEW_VERSION"
           fi
 
       - name: 🔍 Check tag doesn't already exist


### PR DESCRIPTION
## Description

Allow the existing manual release workflow to release RC versions such as `1.0.0-rc.1`.

The downstream version-update action already supports RC versions, but `release-manual.yml` rejected them during its initial format check. This change:

- accepts strict final and `-rc.N` SemVer inputs
- supports dev to RC, increasing RC, and RC to final transitions
- rejects RC downgrades and stable to RC regressions
- documents RC inputs on the shared prepare-release action

This addresses the failure in [Actions run 32784099444](https://github.com/caipe-io/ai-platform-engineering/actions/runs/32784099444).

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

No chart source changes. The `prebuild/` branch prefix is used per repository policy.

## Verification

- `git diff --check`
- focused format tests for final, RC, and invalid inputs
- focused transition tests for dev to RC, RC increments, RC downgrade rejection, stable to RC rejection, and RC to final
- `actionlint` with pre-existing workflow description and summary-step warnings ignored

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] Relevant code style checks pass
- [ ] New code contribution is covered by automated tests
- [ ] All new and existing tests pass