### PR TITLE
fix(auth): reject tokens missing allowed client ID

### DIFF
--- a/ai_platform_engineering/mcp/common/mcp-auth/README.md
+++ b/ai_platform_engineering/mcp/common/mcp-auth/README.md
@@ -14,6 +14,11 @@ without forcing each MCP to re-implement JWT parsing and JWKS validation.
 - `MCP_AUTH_MODE=oauth2` — validates JWTs against `JWKS_URI`, `AUDIENCE`, and
   `ISSUER`
 
+In OAuth2 mode, `OAUTH2_CLIENT_ID` optionally defines a comma-separated client
+ID allow-list. When configured, a token must contain a non-empty `cid` claim in
+the allow-list. When unset or empty, client ID filtering is disabled and a
+token without `cid` is accepted after the other JWT checks pass.
+
 ## Local development carve-out
 
 Set `MCP_TRUSTED_LOCALHOST=true` to bypass auth for requests that originate from

--- a/ai_platform_engineering/mcp/common/mcp-auth/mcp_agent_auth/middleware.py
+++ b/ai_platform_engineering/mcp/common/mcp-auth/mcp_agent_auth/middleware.py
@@ -155,11 +155,21 @@ def _verify_jwt(token: str) -> bool:
         logger.warning("Token verification error: %s", exc)
         return False
 
-    if "cid" in payload:
-        cid = payload["cid"]
-        if OAUTH2_CLIENT_IDS and cid not in OAUTH2_CLIENT_IDS:
+    cid = payload.get("cid")
+    if OAUTH2_CLIENT_IDS:
+        if not isinstance(cid, str) or not cid:
+            logger.warning(
+                "Token missing or invalid cid claim; rejecting because the client ID "
+                "allow-list is configured"
+            )
+            return False
+        if cid not in OAUTH2_CLIENT_IDS:
             logger.warning("Token cid %r not in allowed client IDs", cid)
             return False
+    elif cid is None:
+        logger.debug(
+            "Token missing cid claim; no client ID allow-list configured, accepting"
+        )
 
     return True
 

--- a/ai_platform_engineering/mcp/common/mcp-auth/tests/test_oauth2.py
+++ b/ai_platform_engineering/mcp/common/mcp-auth/tests/test_oauth2.py
@@ -253,6 +253,29 @@ def test_oauth2_enforces_client_id_allowlist(
     )
 
 
+def test_oauth2_rejects_missing_client_id_when_allowlist_configured(
+    reload_middleware, rsa_keypair, monkeypatch
+):
+    private_pem, jwk = rsa_keypair
+    mod = reload_middleware(
+        {
+            "MCP_AUTH_MODE": "oauth2",
+            "JWKS_URI": "https://issuer.example/jwks",
+            "AUDIENCE": "mcp-test",
+            "ISSUER": "https://issuer.example",
+            "OAUTH2_CLIENT_ID": "trusted-app",
+        }
+    )
+    _install_jwks(monkeypatch, mod, jwk)
+    token = _mint(private_pem)
+
+    response = _client(mod).get(
+        "/", headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert response.status_code == 401
+
+
 def test_oauth2_requires_jwks_uri_at_import(reload_middleware):
     with pytest.raises(ValueError, match="JWKS_URI"):
         reload_middleware({"MCP_AUTH_MODE": "oauth2", "AUDIENCE": "x", "ISSUER": "y"})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.1"
+version = "1.0.0-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev1"
+version = "1.0.0.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Fail closed when direct-MCP OAuth2 mode has an `OAUTH2_CLIENT_ID` allow-list configured but a valid JWT omits `cid` or provides an invalid value.

The middleware now logs the rejection through the module logger. When the allow-list is unset or empty, the documented existing behavior remains unchanged and tokens without `cid` may pass the other JWT checks.

Adds an HTTP-level regression test proving the missing-`cid` request returns 401.

Closes #1271

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

Not applicable; no chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Validation

- `uv run pytest -q` — 42 passed
- `uv run --with ruff ruff check mcp_agent_auth/middleware.py tests/test_oauth2.py` — passed
- `git diff --check` — passed