### PR TITLE
fix(ui): hide API-created conversations from chat history

### DIFF
--- a/ui/src/app/api/__tests__/chat-conversations-agent-auth.test.ts
+++ b/ui/src/app/api/__tests__/chat-conversations-agent-auth.test.ts
@@ -170,6 +170,42 @@ describe("POST /api/chat/conversations agent authorization", () => {
     );
   });
 
+  it("persists source: 'api' when the caller declares an api origin", async () => {
+    const insertOne = jest.fn().mockResolvedValue({ insertedId: "conv-1" });
+    mockGetCollection.mockResolvedValue({ findOne: jest.fn(), insertOne });
+    const { POST } = await import("../chat/conversations/route");
+
+    const response = await POST(
+      request({
+        title: "ask-forge",
+        client_type: "webui",
+        agent_id: "default",
+        source: "api",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(insertOne).toHaveBeenCalledWith(expect.objectContaining({ source: "api" }));
+  });
+
+  it("ignores an unrecognized source value from the caller", async () => {
+    const insertOne = jest.fn().mockResolvedValue({ insertedId: "conv-1" });
+    mockGetCollection.mockResolvedValue({ findOne: jest.fn(), insertOne });
+    const { POST } = await import("../chat/conversations/route");
+
+    const response = await POST(
+      request({
+        title: "New Conversation",
+        client_type: "webui",
+        agent_id: "foo-bar",
+        source: "autonomous",
+      }),
+    );
+
+    expect(response.status).toBe(201);
+    expect(insertOne).toHaveBeenCalledWith(expect.not.objectContaining({ source: expect.anything() }));
+  });
+
   it("does not create the conversation when OpenFGA denies agent use", async () => {
     const insertOne = jest.fn();
     mockGetCollection.mockResolvedValue({ findOne: jest.fn(), insertOne });

--- a/ui/src/app/api/__tests__/chat-conversations-client-type.test.ts
+++ b/ui/src/app/api/__tests__/chat-conversations-client-type.test.ts
@@ -236,6 +236,25 @@ describe('GET /api/chat/conversations — client_type filtering', () => {
     ]));
   });
 
+  it('excludes api-origin conversations from the default listing', async () => {
+    mockGetServerSession.mockResolvedValue(userSession());
+
+    const conversationsCol = createMockCollection();
+    mockCollections['conversations'] = conversationsCol;
+
+    const req = makeRequest('/api/chat/conversations?page_size=100');
+    const res = await GET(req);
+
+    expect(res.status).toBe(200);
+    expect(conversationsCol.countDocuments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $and: expect.arrayContaining([
+          expect.objectContaining({ source: { $nin: ['slack', 'api'] } }),
+        ]),
+      }),
+    );
+  });
+
   it('enriches conversation agent participants with display names', async () => {
     mockGetServerSession.mockResolvedValue(userSession());
 

--- a/ui/src/app/api/__tests__/recycle-bin.test.ts
+++ b/ui/src/app/api/__tests__/recycle-bin.test.ts
@@ -533,12 +533,13 @@ describe('Archive API', () => {
       );
     });
 
-    it('default listing INCLUDES autonomous conversations (only excludes slack)', async () => {
+    it('default listing INCLUDES autonomous conversations (only excludes slack and api)', async () => {
       // Regression: pre-fix the default branch used
       // ``$nin: ['slack', 'autonomous']`` which contradicted the
       // sidebar's "All" filter and made autonomous threads vanish
       // from the All view. The fix narrows the exclusion to slack
-      // only so autonomous chats appear alongside human ones.
+      // (and api, for script-created conversations with no UI
+      // transcript) so autonomous chats appear alongside human ones.
       const convCollection = createMockCollection();
       convCollection.find.mockReturnValue({
         sort: jest.fn().mockReturnValue({
@@ -557,7 +558,7 @@ describe('Archive API', () => {
       const findCall = convCollection.find.mock.calls[0][0];
       // Source filter lives in $and alongside the ownership $or.
       expect(findCall.$and).toEqual(
-        expect.arrayContaining([{ source: { $nin: ['slack'] } }]),
+        expect.arrayContaining([{ source: { $nin: ['slack', 'api'] } }]),
       );
     });
 

--- a/ui/src/app/api/chat/conversations/route.ts
+++ b/ui/src/app/api/chat/conversations/route.ts
@@ -242,8 +242,11 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     // Default ("All") view: include autonomous conversations alongside
     // regular human chats so the sidebar's "All" filter actually shows
     // both. Slack threads are still excluded because they have their
-    // own dedicated UI and were never wanted in this list.
-    query.$and.push({ source: { $nin: ['slack'] } });
+    // own dedicated UI, and `api` conversations are excluded because they
+    // were created by a direct API caller (e.g. the ask-forge CLI) with no
+    // UI transcript to show — they still count in insights/stats, which
+    // query `conversations`/`messages` directly without this filter.
+    query.$and.push({ source: { $nin: ['slack', 'api'] } });
   }
 
   // Get total count
@@ -398,6 +401,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     // Provenance: stamp the SA sub so the audit/reconcile step can find SA-created
     // conversations and verify/repair the writer grant. Only set for SA callers.
     ...(saSub ? { created_by_service_account: saSub } : {}),
+    // Caller-declared 'api' origin only — see CreateConversationRequest['source'].
+    ...(body.source === 'api' ? { source: 'api' as const } : {}),
     participants: buildParticipants(body.agent_id, ownerId),
     created_at: now,
     updated_at: now,

--- a/ui/src/types/mongodb.ts
+++ b/ui/src/types/mongodb.ts
@@ -114,13 +114,17 @@ export interface Conversation {
   is_pinned: boolean;
   deleted_at?: Date | null; // Soft-delete timestamp; null = not deleted; auto-purged after 7 days
   // Origin marker. The chat sidebar's "All" view shows both human-typed
-  // and autonomous conversations; only `slack` is excluded from the
-  // default listing because Slack threads have their own dedicated UI.
-  // The autonomous_agents service writes conversations with
-  // `source: 'autonomous'` so operators can also pivot the sidebar to
+  // and autonomous conversations; `slack` and `api` are excluded from the
+  // default listing because Slack threads have their own dedicated UI and
+  // `api` conversations (e.g. scripts calling /api/chat/conversations +
+  // /api/v1/chat/invoke directly, like the ask-forge CLI) have no UI
+  // transcript to show. The autonomous_agents service writes conversations
+  // with `source: 'autonomous'` so operators can also pivot the sidebar to
   // "what did the autonomous agent do today?" via the Autonomous filter
-  // chip. Undefined = legacy human-typed conversation.
-  source?: 'web' | 'slack' | 'autonomous';
+  // chip. Undefined = legacy human-typed conversation. Stats/insights
+  // endpoints intentionally do not filter on `source`, so `api` conversations
+  // are hidden from chat history but still counted there.
+  source?: 'web' | 'slack' | 'autonomous' | 'api';
   // Set when `source === 'autonomous'`: the upstream autonomous task
   // and the specific run that produced this conversation. Lets the
   // run-history UI deep-link from a run row into the chat thread.
@@ -354,6 +358,12 @@ export interface CreateConversationRequest {
   idempotency_key?: string; // Maps integration-specific identity (e.g. Slack thread_ts) to conversation_id used by UI/checkpoints
   metadata?: Record<string, unknown>; // Optional: arbitrary key/values from client
   tags?: string[];
+  // Optional: caller-declared origin. Only 'api' is honored here — it marks a
+  // conversation created by a direct API caller (script/CLI) rather than the
+  // web UI, so the sidebar can hide it while insights/stats keep counting it.
+  // Other values are ignored; 'web'/'slack'/'autonomous' are still assigned
+  // by their respective server-side paths, not the client.
+  source?: 'api';
 }
 
 /** Response from POST /api/chat/conversations */


### PR DESCRIPTION
# Description

Scripts that create conversations via `POST /api/chat/conversations` and then call `/api/v1/chat/invoke` directly (e.g. an internal `ask-forge` CLI) show up as empty entries in the chat History sidebar — the invoke proxy path never writes `Message` docs the way the UI transcript view expects, but the conversation itself is still listed.

This adds an opt-in `source: 'api'` marker:
- `CreateConversationRequest` now accepts `source: 'api'` (ignored for any other value — `web`/`slack`/`autonomous` remain server-assigned, not caller-set)
- `POST /api/chat/conversations` persists it when the caller declares it
- `GET /api/chat/conversations`'s default listing (used by the sidebar) excludes `source: 'api'`, the same way it already excludes `slack`

Insights and stats endpoints (`/api/users/me/insights`, `/api/users/me/stats`, `/api/admin/stats`) are unchanged — they query the `conversations`/`messages` collections directly without a `source` filter, so these conversations still count there.

Companion change (separate, internal-only skills repo): the calling `ask-forge` CLI has already been updated to send `source: "api"` on conversation create, and that change has merged. This PR is the other half — until it deploys, that flag has no visible effect.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] Functionality is documented (inline comments on the new `source` value)
- [x] All code style checks pass (lint + typecheck clean)
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Test plan
- [x] Added tests for default listing excluding `source: 'api'` and for POST persisting/ignoring the caller-declared `source`
- [ ] Manually verify an ask-forge-created conversation no longer appears in the sidebar once this PR is deployed