### PR TITLE
fix(release): complete artifact registry cutover

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -25,7 +25,7 @@ Please ensure commits conform to the [Commit Guideline](https://www.conventional
 For chart changes, you can test pre-release versions before merging:
 - **Base repo contributors:** Create a branch starting with `prebuild/` for automatic pre-release builds
 - **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
-- Pre-release charts are published to `ghcr.io/cnoe-io/pre-release-helm-charts`
+- Pre-release charts are published to `ghcr.io/caipe-io/pre-release-helm-charts`
 - Cleanup happens automatically when the PR closes or label is removed
 
 ## Checklist

--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -303,7 +303,7 @@ jobs:
       packages: read
     container:
       # assisted-by Codex Codex-sonnet-4-6
-      image: ghcr.io/cnoe-io/playwright:v1.61.0-noble
+      image: ghcr.io/caipe-io/playwright:v1.61.0-noble
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -10,7 +10,7 @@ description: "Build and push Skill Scanner Docker image"
 #
 # Pre-release tags (-rc.N, -hotfix.N) push to ghcr.io/<owner>/pre-release/skill-scanner.
 # Final release / -dev.N tags push to ghcr.io/<owner>/skill-scanner — this is
-# the path the parent chart's `image.repository` (ghcr.io/cnoe-io/skill-scanner)
+# the path the parent chart's `image.repository` (ghcr.io/caipe-io/skill-scanner)
 # expects. -chart.N tags skip image work entirely (chart-only releases).
 #
 # This workflow notifies release-finalize.yml via repository_dispatch so the

--- a/.github/workflows/docs-release.yml
+++ b/.github/workflows/docs-release.yml
@@ -129,7 +129,7 @@ jobs:
             echo ""
             echo '```bash'
             echo "helm upgrade ai-platform-engineering \\"
-            echo "  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\"
+            echo "  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \\"
             echo "  --version ${NEW_VERSION} \\"
             echo "  -f your-values.yaml"
             echo '```'

--- a/.github/workflows/docs-snapshot.yml
+++ b/.github/workflows/docs-snapshot.yml
@@ -98,7 +98,7 @@ jobs:
 
           # persist-credentials: false means the checkout step does not configure
           # git credentials. Wire the App token into the remote URL so git push works.
-          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/cnoe-io/ai-platform-engineering.git"
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/caipe-io/ai-platform-engineering.git"
 
           # Only the published-versions list (and any current-version helm docs that
           # legitimately changed) are committed — versioned_docs is never committed.

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -186,7 +186,7 @@ jobs:
         uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7.4.0
         id: scan
         with:
-          image: "ghcr.io/cnoe-io/${{ matrix.image }}:${{ steps.tag.outputs.tag }}"
+          image: "ghcr.io/caipe-io/${{ matrix.image }}:${{ steps.tag.outputs.tag }}"
           fail-build: false
           severity-cutoff: high
           output-format: sarif

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ permissions: read-all
 jobs:
   mark-stale:
     # Call reusable workflow file
-    uses: cnoe-io/ai-platform-engineering/.github/workflows/_stale.yml@c6661a4f7cc4be50f0951f0ef6854940a1ba4592 # main
+    uses: caipe-io/ai-platform-engineering/.github/workflows/_stale.yml@c6661a4f7cc4be50f0951f0ef6854940a1ba4592 # main
     permissions:
       contents: read
       issues: write

--- a/Makefile
+++ b/Makefile
@@ -462,7 +462,7 @@ scan-images: ## Scan all locally built images with grype (make scan-images GRYPE
 		echo "✓ All images passed grype scan"; \
 	fi
 
-scan-image: ## Scan a single image with grype (make scan-image IMG=ghcr.io/cnoe-io/mcp-splunk:localtag)
+scan-image: ## Scan a single image with grype (make scan-image IMG=ghcr.io/caipe-io/mcp-splunk:localtag)
 	@command -v grype >/dev/null 2>&1 || { echo "grype not found. Install: brew install grype"; exit 1; }
 	@[ -n "$(IMG)" ] || { echo "Usage: make scan-image IMG=<image:tag>"; exit 1; }
 	@grype "$(IMG)" --fail-on "$(GRYPE_SEVERITY)"

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 * **Every Monday**
   * 🕕 19:00–20:00 CET | 🕔 18:00–19:00 GMT (London) | 🕘 10:00–11:00 PST
-* 🔗 [Webex Meeting](https://go.webex.com/meet/cnoe) | 📅 [Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=064a2adfce866ccb02e61663a09f99147f22f06374e7a8994066bdc81e066986@group.calendar.google.com&ctz=America/Los_Angeles) | 📥 [.ics Download](https://github.com/cnoe-io/ai-platform-engineering/raw/main/docs/docs/community/cnoe-sig-agentic-ai-community-meeting.ics)
+* 🔗 [Webex Meeting](https://go.webex.com/meet/cnoe) | 📅 [Google Calendar](https://calendar.google.com/calendar/u/0/embed?src=064a2adfce866ccb02e61663a09f99147f22f06374e7a8994066bdc81e066986@group.calendar.google.com&ctz=America/Los_Angeles) | 📥 [.ics Download](https://github.com/caipe-io/ai-platform-engineering/raw/main/docs/docs/community/cnoe-sig-agentic-ai-community-meeting.ics)
 
 ### 💬 Slack
 
@@ -33,21 +33,21 @@ We’d love your contributions! To get started:
 2. **Create a branch** for your changes
 3. **Open a Pull Request**—just add a clear description so we know what you’re working on
 
-Thinking about a big change? Feel free to [start a discussion](https://github.com/cnoe-io/ai-platform-engineering/discussions) first so we can chat about it together.
+Thinking about a big change? Feel free to [start a discussion](https://github.com/caipe-io/ai-platform-engineering/discussions) first so we can chat about it together.
 
-* Browse our [open issues](https://github.com/cnoe-io/ai-platform-engineering/issues) to see what needs doing
-* New here? Check out the [good first issues](https://github.com/cnoe-io/ai-platform-engineering/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) for some beginner-friendly tasks
+* Browse our [open issues](https://github.com/caipe-io/ai-platform-engineering/issues) to see what needs doing
+* New here? Check out the [good first issues](https://github.com/caipe-io/ai-platform-engineering/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22) for some beginner-friendly tasks
 
 We’re excited to collaborate with you!
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=cnoe-io/ai-platform-engineering&type=Date)](https://www.star-history.com/#cnoe-io/ai-platform-engineering&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=caipe-io/ai-platform-engineering&type=Date)](https://www.star-history.com/#caipe-io/ai-platform-engineering&Date)
 
 ## Contributors
 
-<a href="https://github.com/cnoe-io/ai-platform-engineering/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=cnoe-io/ai-platform-engineering" />
+<a href="https://github.com/caipe-io/ai-platform-engineering/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=caipe-io/ai-platform-engineering" />
 </a>
 
 ## 📄 License

--- a/ai_platform_engineering/knowledge_bases/rag/server/Makefile
+++ b/ai_platform_engineering/knowledge_bases/rag/server/Makefile
@@ -99,17 +99,17 @@ build-docker-a2a:            ## Build A2A Docker image
 	docker build -t $(AGENT_DIR_NAME):a2a-latest -f docker/Dockerfile.a2a .
 
 build-docker-a2a-tag:        ## Tag A2A Docker image
-	docker tag $(AGENT_DIR_NAME):a2a-latest ghcr.io/cnoe-io/$(AGENT_DIR_NAME):a2a-latest
+	docker tag $(AGENT_DIR_NAME):a2a-latest ghcr.io/caipe-io/$(AGENT_DIR_NAME):a2a-latest
 
 build-docker-a2a-push:       ## Push A2A Docker image
-	docker push ghcr.io/cnoe-io/$(AGENT_DIR_NAME):a2a-latest
+	docker push ghcr.io/caipe-io/$(AGENT_DIR_NAME):a2a-latest
 
 build-docker-a2a-tag-and-push: ## Tag and push A2A Docker image
 	@$(MAKE) build-docker-a2a build-docker-a2a-tag build-docker-a2a-push
 
 run-docker-a2a: ## Run the A2A agent in Docker
 	@A2A_AGENT_PORT=$$(grep A2A_AGENT_PORT .env | cut -d '=' -f2); \
-	LOCAL_A2A_AGENT_IMAGE=$${A2A_AGENT_IMAGE:-ghcr.io/cnoe-io/$(AGENT_DIR_NAME):a2a-latest}; \
+	LOCAL_A2A_AGENT_IMAGE=$${A2A_AGENT_IMAGE:-ghcr.io/caipe-io/$(AGENT_DIR_NAME):a2a-latest}; \
 	LOCAL_A2A_AGENT_PORT=$${A2A_AGENT_PORT:-8000}; \
 	echo "==================================================================="; \
 	echo "                      A2A AGENT DOCKER RUN                         "; \

--- a/ai_platform_engineering/scheduler/caipe_scheduler/config.py
+++ b/ai_platform_engineering/scheduler/caipe_scheduler/config.py
@@ -43,7 +43,7 @@ class Settings(BaseModel):
 
   # Kubernetes
   namespace: str = Field(default_factory=lambda: os.environ.get("SCHEDULER_NAMESPACE", "caipe"))
-  cron_runner_image: str = Field(default_factory=lambda: os.environ.get("CRON_RUNNER_IMAGE", "ghcr.io/cnoe-io/caipe-cron-runner:latest"))
+  cron_runner_image: str = Field(default_factory=lambda: os.environ.get("CRON_RUNNER_IMAGE", "ghcr.io/caipe-io/caipe-cron-runner:latest"))
   cron_runner_image_pull_policy: str = Field(default_factory=lambda: os.environ.get("CRON_RUNNER_IMAGE_PULL_POLICY", "IfNotPresent"))
   # ServiceAccount for the per-schedule CronJob runner pods. No perms.
   cron_runner_service_account: str = Field(default_factory=lambda: os.environ.get("CRON_RUNNER_SERVICE_ACCOUNT", "caipe-cron-runner"))

--- a/charts/ai-platform-engineering/Chart.yaml
+++ b/charts/ai-platform-engineering/Chart.yaml
@@ -4,7 +4,7 @@ appVersion: 0.6.0-dev.4 # Do NOT modify. It will be updated automatically using 
 name: ai-platform-engineering
 description: Parent chart to deploy CAIPE — dynamic agents, per-agent MCP servers, RBAC, and the UI
 sources:
-  - https://github.com/cnoe-io/ai-platform-engineering/charts
+  - https://github.com/caipe-io/ai-platform-engineering/charts
 # Chart version for ai-platform-engineering parent chart
 version: 0.6.0-dev.4 # Do NOT bump this. It will be updated automatically using the PR or release workflow
 dependencies:

--- a/charts/ai-platform-engineering/README.md
+++ b/charts/ai-platform-engineering/README.md
@@ -15,10 +15,10 @@ Parent chart to deploy CAIPE — dynamic agents, per-agent MCP servers, RBAC, an
 
 ```bash
 # Add and install the chart
-helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68
+helm install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68
+helm upgrade ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68 \
+helm install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68 \
+helm install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -114,7 +114,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | caipe-ui.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | caipe-ui.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | caipe-ui.image.pullPolicy | string | `"IfNotPresent"` |  |
-| caipe-ui.image.repository | string | `"ghcr.io/cnoe-io/caipe-ui"` |  |
+| caipe-ui.image.repository | string | `"ghcr.io/caipe-io/caipe-ui"` |  |
 | caipe-ui.image.tag | string | `""` |  |
 | caipe-ui.ingress.annotations | object | `{}` |  |
 | caipe-ui.ingress.className | string | `"nginx"` |  |
@@ -185,7 +185,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | dynamic-agents.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | dynamic-agents.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | dynamic-agents.image.pullPolicy | string | `"IfNotPresent"` |  |
-| dynamic-agents.image.repository | string | `"ghcr.io/cnoe-io/caipe-dynamic-agents"` |  |
+| dynamic-agents.image.repository | string | `"ghcr.io/caipe-io/caipe-dynamic-agents"` |  |
 | dynamic-agents.image.tag | string | `""` |  |
 | dynamic-agents.nameOverride | string | `"dynamic-agents"` |  |
 | dynamic-agents.service.metricsPort | int | `0` |  |
@@ -219,7 +219,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | global.agentgateway.static.configBridge.enabled | bool | `true` |  |
 | global.agentgateway.static.configBridge.extraEnv | list | `[]` |  |
 | global.agentgateway.static.configBridge.image.pullPolicy | string | `"IfNotPresent"` |  |
-| global.agentgateway.static.configBridge.image.repository | string | `"ghcr.io/cnoe-io/agentgateway-config-bridge"` |  |
+| global.agentgateway.static.configBridge.image.repository | string | `"ghcr.io/caipe-io/agentgateway-config-bridge"` |  |
 | global.agentgateway.static.configBridge.image.tag | string | `""` |  |
 | global.agentgateway.static.configBridge.pollSeconds | int | `5` |  |
 | global.agentgateway.static.configBridge.ui.existingSecret.key | string | `"AGENTGATEWAY_TARGETS_TOKEN"` |  |
@@ -322,7 +322,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | litellmMcp.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | litellmMcp.fullnameOverride | string | `""` |  |
 | litellmMcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| litellmMcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-litellm"` |  |
+| litellmMcp.image.repository | string | `"ghcr.io/caipe-io/mcp-litellm"` |  |
 | litellmMcp.image.tag | string | `""` |  |
 | litellmMcp.imagePullSecrets | list | `[]` |  |
 | litellmMcp.livenessProbe.failureThreshold | int | `3` |  |
@@ -351,11 +351,11 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | litellmMcp.service.type | string | `"ClusterIP"` |  |
 | litellmMcp.tolerations | list | `[]` |  |
 | mcp-argocd.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-argocd.image.repository | string | `"ghcr.io/cnoe-io/mcp-argocd"` |  |
+| mcp-argocd.image.repository | string | `"ghcr.io/caipe-io/mcp-argocd"` |  |
 | mcp-argocd.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-argocd.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-argocd.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-argocd.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-argocd"` |  |
+| mcp-argocd.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-argocd"` |  |
 | mcp-argocd.mcp.image.tag | string | `""` |  |
 | mcp-argocd.mcp.mode | string | `"http"` |  |
 | mcp-argocd.mcp.port | int | `8000` |  |
@@ -367,27 +367,27 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-aws.env.RESTRICT_KUBECTL_PROXY | string | `"true"` | Block kubectl proxy, which exposes the entire Kubernetes API server. Defaults to true (on). |
 | mcp-aws.env.RESTRICT_KUBECTL_SECRETS | string | `"true"` | Block kubectl get/describe secret(s) and redact Secret data from output. Defaults to true (on). |
 | mcp-aws.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-aws.image.repository | string | `"ghcr.io/cnoe-io/agent-aws"` |  |
+| mcp-aws.image.repository | string | `"ghcr.io/caipe-io/agent-aws"` |  |
 | mcp-aws.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-aws.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-aws.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-aws.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-aws"` |  |
+| mcp-aws.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-aws"` |  |
 | mcp-aws.mcp.image.tag | string | `""` |  |
 | mcp-aws.mcp.mode | string | `"http"` |  |
 | mcp-aws.mcp.port | int | `8000` |  |
 | mcp-aws.nameOverride | string | `"mcp-aws"` |  |
 | mcp-backstage.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-backstage.image.repository | string | `"ghcr.io/cnoe-io/agent-backstage"` |  |
+| mcp-backstage.image.repository | string | `"ghcr.io/caipe-io/agent-backstage"` |  |
 | mcp-backstage.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-backstage.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-backstage.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-backstage.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-backstage"` |  |
+| mcp-backstage.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-backstage"` |  |
 | mcp-backstage.mcp.image.tag | string | `""` |  |
 | mcp-backstage.mcp.mode | string | `"http"` |  |
 | mcp-backstage.mcp.port | int | `8000` |  |
 | mcp-backstage.nameOverride | string | `"mcp-backstage"` |  |
 | mcp-confluence.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-confluence.image.repository | string | `"ghcr.io/cnoe-io/agent-confluence"` |  |
+| mcp-confluence.image.repository | string | `"ghcr.io/caipe-io/agent-confluence"` |  |
 | mcp-confluence.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-confluence.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-confluence.mcp.env.TRANSPORT | string | `"streamable-http"` |  |
@@ -398,7 +398,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-confluence.mcp.port | int | `8000` |  |
 | mcp-confluence.nameOverride | string | `"mcp-confluence"` |  |
 | mcp-github.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-github.image.repository | string | `"ghcr.io/cnoe-io/mcp-github"` |  |
+| mcp-github.image.repository | string | `"ghcr.io/caipe-io/mcp-github"` |  |
 | mcp-github.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-github.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-github.mcp.agentgateway.providerTokenAuth | bool | `true` |  |
@@ -410,7 +410,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-gitlab.env.GIT_COMMITTER_EMAIL | string | `"ai-agent@cnoe.io"` |  |
 | mcp-gitlab.env.GIT_COMMITTER_NAME | string | `"AI Agent"` |  |
 | mcp-gitlab.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-gitlab.image.repository | string | `"ghcr.io/cnoe-io/agent-gitlab"` |  |
+| mcp-gitlab.image.repository | string | `"ghcr.io/caipe-io/agent-gitlab"` |  |
 | mcp-gitlab.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-gitlab.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-gitlab.mcp.agentgateway.providerTokenAuth | bool | `true` |  |
@@ -428,48 +428,48 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-gitlab.mcp.port | int | `8000` |  |
 | mcp-gitlab.nameOverride | string | `"mcp-gitlab"` |  |
 | mcp-jira.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-jira.image.repository | string | `"ghcr.io/cnoe-io/agent-jira"` |  |
+| mcp-jira.image.repository | string | `"ghcr.io/caipe-io/agent-jira"` |  |
 | mcp-jira.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-jira.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-jira.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-jira.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-jira"` |  |
+| mcp-jira.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-jira"` |  |
 | mcp-jira.mcp.image.tag | string | `""` |  |
 | mcp-jira.mcp.mode | string | `"http"` |  |
 | mcp-jira.mcp.port | int | `8000` |  |
 | mcp-jira.nameOverride | string | `"mcp-jira"` |  |
 | mcp-komodor.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-komodor.image.repository | string | `"ghcr.io/cnoe-io/agent-komodor"` |  |
+| mcp-komodor.image.repository | string | `"ghcr.io/caipe-io/agent-komodor"` |  |
 | mcp-komodor.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-komodor.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-komodor.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-komodor.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-komodor"` |  |
+| mcp-komodor.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-komodor"` |  |
 | mcp-komodor.mcp.image.tag | string | `""` |  |
 | mcp-komodor.mcp.mode | string | `"http"` |  |
 | mcp-komodor.mcp.port | int | `8000` |  |
 | mcp-komodor.nameOverride | string | `"mcp-komodor"` |  |
 | mcp-netutils.agentSecrets.requiresSecret | bool | `false` |  |
 | mcp-netutils.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-netutils.image.repository | string | `"ghcr.io/cnoe-io/agent-netutils"` |  |
+| mcp-netutils.image.repository | string | `"ghcr.io/caipe-io/agent-netutils"` |  |
 | mcp-netutils.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-netutils.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-netutils.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-netutils.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-netutils"` |  |
+| mcp-netutils.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-netutils"` |  |
 | mcp-netutils.mcp.image.tag | string | `""` |  |
 | mcp-netutils.mcp.mode | string | `"http"` |  |
 | mcp-netutils.mcp.port | int | `8000` |  |
 | mcp-netutils.nameOverride | string | `"mcp-netutils"` |  |
 | mcp-pagerduty.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-pagerduty.image.repository | string | `"ghcr.io/cnoe-io/agent-pagerduty"` |  |
+| mcp-pagerduty.image.repository | string | `"ghcr.io/caipe-io/agent-pagerduty"` |  |
 | mcp-pagerduty.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-pagerduty.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-pagerduty.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-pagerduty.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-pagerduty"` |  |
+| mcp-pagerduty.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-pagerduty"` |  |
 | mcp-pagerduty.mcp.image.tag | string | `""` |  |
 | mcp-pagerduty.mcp.mode | string | `"http"` |  |
 | mcp-pagerduty.mcp.port | int | `8000` |  |
 | mcp-pagerduty.nameOverride | string | `"mcp-pagerduty"` |  |
 | mcp-slack.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-slack.image.repository | string | `"ghcr.io/cnoe-io/agent-slack"` |  |
+| mcp-slack.image.repository | string | `"ghcr.io/caipe-io/agent-slack"` |  |
 | mcp-slack.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-slack.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-slack.mcp.command[0] | string | `"--transport"` |  |
@@ -483,21 +483,21 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-slack.mcp.port | int | `3001` |  |
 | mcp-slack.nameOverride | string | `"mcp-slack"` |  |
 | mcp-splunk.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-splunk.image.repository | string | `"ghcr.io/cnoe-io/agent-splunk"` |  |
+| mcp-splunk.image.repository | string | `"ghcr.io/caipe-io/agent-splunk"` |  |
 | mcp-splunk.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-splunk.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-splunk.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-splunk.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-splunk"` |  |
+| mcp-splunk.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-splunk"` |  |
 | mcp-splunk.mcp.image.tag | string | `""` |  |
 | mcp-splunk.mcp.mode | string | `"http"` |  |
 | mcp-splunk.mcp.port | int | `8000` |  |
 | mcp-splunk.nameOverride | string | `"mcp-splunk"` |  |
 | mcp-victorops.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-victorops.image.repository | string | `"ghcr.io/cnoe-io/agent-victorops"` |  |
+| mcp-victorops.image.repository | string | `"ghcr.io/caipe-io/agent-victorops"` |  |
 | mcp-victorops.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-victorops.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-victorops.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-victorops.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-victorops"` |  |
+| mcp-victorops.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-victorops"` |  |
 | mcp-victorops.mcp.image.tag | string | `""` |  |
 | mcp-victorops.mcp.mode | string | `"http"` |  |
 | mcp-victorops.mcp.port | int | `8000` |  |
@@ -511,18 +511,18 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-webex-meetings.mcp.agentgateway.pathPrefix | string | `"/mcp/webex_meetings"` |  |
 | mcp-webex-meetings.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-webex-meetings.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex-meetings.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-webex-meetings"` |  |
+| mcp-webex-meetings.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-webex-meetings"` |  |
 | mcp-webex-meetings.mcp.image.tag | string | `""` |  |
 | mcp-webex-meetings.mcp.mode | string | `"http"` |  |
 | mcp-webex-meetings.mcp.port | int | `8000` |  |
 | mcp-webex-meetings.mcpSecrets.requiresSecret | bool | `false` |  |
 | mcp-webex-meetings.nameOverride | string | `"mcp-webex-meetings"` |  |
 | mcp-webex.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex.image.repository | string | `"ghcr.io/cnoe-io/agent-webex"` |  |
+| mcp-webex.image.repository | string | `"ghcr.io/caipe-io/agent-webex"` |  |
 | mcp-webex.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-webex.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-webex.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-webex"` |  |
+| mcp-webex.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-webex"` |  |
 | mcp-webex.mcp.image.tag | string | `""` |  |
 | mcp-webex.mcp.mode | string | `"http"` |  |
 | mcp-webex.mcp.port | int | `8000` |  |
@@ -544,7 +544,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | openfga-authz-bridge.audit.subjectSalt | string | `"caipe-098-audit"` |  |
 | openfga-authz-bridge.audit.tenantId | string | `"default"` |  |
 | openfga-authz-bridge.image.pullPolicy | string | `"IfNotPresent"` |  |
-| openfga-authz-bridge.image.repository | string | `"ghcr.io/cnoe-io/openfga-authz-bridge"` |  |
+| openfga-authz-bridge.image.repository | string | `"ghcr.io/caipe-io/openfga-authz-bridge"` |  |
 | openfga-authz-bridge.image.tag | string | `""` |  |
 | openfga-authz-bridge.openfga.httpUrl | string | `""` |  |
 | openfga-authz-bridge.openfga.object | string | `"mcp_gateway:list"` |  |
@@ -572,7 +572,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | rag-stack.agent-ontology.enabled | bool | `true` |  |
 | rag-stack.agent-rag.enabled | bool | `true` |  |
 | rag-stack.agent-rag.image.pullPolicy | string | `"IfNotPresent"` |  |
-| rag-stack.agent-rag.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-rag"` |  |
+| rag-stack.agent-rag.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-rag"` |  |
 | rag-stack.agent-rag.image.tag | string | `""` |  |
 | rag-stack.milvus.enabled | bool | `true` |  |
 | rag-stack.neo4j.enabled | bool | `true` |  |
@@ -585,18 +585,18 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | rag-stack.rag-server.env.CAIPE_UNSAFE_RBAC_BYPASS | string | `"false"` |  |
 | rag-stack.rag-server.env.OPENFGA_STORE_NAME | string | `"caipe-openfga"` |  |
 | rag-stack.rag-server.image.pullPolicy | string | `"IfNotPresent"` |  |
-| rag-stack.rag-server.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| rag-stack.rag-server.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | rag-stack.rag-server.image.tag | string | `""` |  |
 | scheduler.args | list | `[]` |  |
 | scheduler.caipe.apiUrl | string | `"http://{{ .Release.Name }}-caipe-ui:3000"` |  |
 | scheduler.caipe.chatPath | string | `"/api/v1/chat/invoke"` |  |
 | scheduler.command | list | `[]` |  |
 | scheduler.cronRunner.image.pullPolicy | string | `"IfNotPresent"` |  |
-| scheduler.cronRunner.image.repository | string | `"ghcr.io/cnoe-io/caipe-cron-runner"` |  |
+| scheduler.cronRunner.image.repository | string | `"ghcr.io/caipe-io/caipe-cron-runner"` |  |
 | scheduler.cronRunner.image.tag | string | `""` |  |
 | scheduler.fullnameOverride | string | `"caipe-scheduler"` |  |
 | scheduler.image.pullPolicy | string | `"IfNotPresent"` |  |
-| scheduler.image.repository | string | `"ghcr.io/cnoe-io/caipe-scheduler"` |  |
+| scheduler.image.repository | string | `"ghcr.io/caipe-io/caipe-scheduler"` |  |
 | scheduler.image.tag | string | `""` |  |
 | scheduler.mongo.database | string | `"caipe"` |  |
 | scheduler.mongo.existingSecret | string | `""` |  |
@@ -616,7 +616,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | schedulerMcp.env.MCP_PORT | string | `"8000"` |  |
 | schedulerMcp.env.SCHEDULER_URL | string | `"http://caipe-scheduler:8080"` |  |
 | schedulerMcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| schedulerMcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-scheduler"` |  |
+| schedulerMcp.image.repository | string | `"ghcr.io/caipe-io/mcp-scheduler"` |  |
 | schedulerMcp.image.tag | string | `""` |  |
 | schedulerMcp.nameOverride | string | `"mcp-scheduler"` |  |
 | schedulerMcp.resources | object | `{}` |  |
@@ -628,7 +628,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | slack-bot.existingSecret | string | `"slack-bot-secrets"` | Reference to a pre-existing Kubernetes Secret. Should contain: SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_SIGNING_SECRET, and optionally OAUTH2_CLIENT_SECRET. |
 | slack-bot.externalSecrets | object | `{"apiVersion":"v1beta1","data":[],"enabled":false,"secretStoreRef":{"kind":"ClusterSecretStore","name":"vault"}}` | External Secrets configuration for sensitive data |
 | slack-bot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| slack-bot.image.repository | string | `"ghcr.io/cnoe-io/caipe-slack-bot"` |  |
+| slack-bot.image.repository | string | `"ghcr.io/caipe-io/caipe-slack-bot"` |  |
 | slack-bot.image.tag | string | `""` |  |
 | slack-bot.resources.limits.cpu | string | `"500m"` |  |
 | slack-bot.resources.limits.memory | string | `"512Mi"` |  |
@@ -684,7 +684,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | webex-bot.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | webex-bot.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | webex-bot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| webex-bot.image.repository | string | `"ghcr.io/cnoe-io/caipe-webex-bot"` |  |
+| webex-bot.image.repository | string | `"ghcr.io/caipe-io/caipe-webex-bot"` |  |
 | webex-bot.image.tag | string | `""` |  |
 | webex-bot.keycloakBot.clientSecretFromSecret.key | string | `"KC_WEBEX_BOT_CLIENT_SECRET"` |  |
 | webex-bot.keycloakBot.clientSecretFromSecret.name | string | `""` |  |

--- a/charts/ai-platform-engineering/charts/agentgateway/README.md
+++ b/charts/ai-platform-engineering/charts/agentgateway/README.md
@@ -15,10 +15,10 @@ AgentGateway standalone proxy for CAIPE MCP traffic
 
 ```bash
 # Add and install the chart
-helm install agentgateway oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68
+helm install agentgateway oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade agentgateway oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68
+helm upgrade agentgateway oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install agentgateway oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68 \
+helm install agentgateway oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install agentgateway oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68 \
+helm install agentgateway oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/agentgateway/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
       */ -}}
       {{- $cbEnabled := and $agwGlobal.enabled (eq ($agwGlobal.routingMode | default "static") "static") $cb.enabled }}
       {{- $cbImage := $cb.image | default dict }}
-      {{- $cbImageRepo := $cbImage.repository | default "ghcr.io/cnoe-io/agentgateway-config-bridge" }}
+      {{- $cbImageRepo := $cbImage.repository | default "ghcr.io/caipe-io/agentgateway-config-bridge" }}
       {{- $cbImageTag := $cbImage.tag | default .Chart.AppVersion }}
       {{- $cbImagePull := $cbImage.pullPolicy | default "IfNotPresent" }}
       serviceAccountName: {{ include "agentgateway.serviceAccountName" . }}

--- a/charts/ai-platform-engineering/charts/audit-service/README.md
+++ b/charts/ai-platform-engineering/charts/audit-service/README.md
@@ -15,10 +15,10 @@ Lightweight CAIPE audit log read/write service
 
 ```bash
 # Add and install the chart
-helm install audit-service oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
+helm install audit-service oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade audit-service oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
+helm upgrade audit-service oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install audit-service oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68 \
+helm install audit-service oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install audit-service oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68 \
+helm install audit-service oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -57,7 +57,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
 | extraEnvFrom | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-audit-service"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-audit-service"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | livenessProbe.failureThreshold | int | `3` |  |

--- a/charts/ai-platform-engineering/charts/audit-service/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/audit-service/templates/_helpers.tpl
@@ -80,7 +80,7 @@ Usage:
   include "audit-service.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -98,10 +98,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/audit-service/values.yaml
+++ b/charts/ai-platform-engineering/charts/audit-service/values.yaml
@@ -8,7 +8,7 @@ replicaCount: 1
 revisionHistoryLimit: 3
 
 image:
-  repository: ghcr.io/cnoe-io/caipe-audit-service
+  repository: ghcr.io/caipe-io/caipe-audit-service
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/charts/ai-platform-engineering/charts/autonomous-agents/README.md
+++ b/charts/ai-platform-engineering/charts/autonomous-agents/README.md
@@ -15,10 +15,10 @@ A Helm chart for Autonomous Agents - Standalone scheduler that fires tasks (cron
 
 ```bash
 # Add and install the chart
-helm install autonomous-agents oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1
+helm install autonomous-agents oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1
 
 # Upgrade an existing release
-helm upgrade autonomous-agents oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1
+helm upgrade autonomous-agents oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install autonomous-agents oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1 \
+helm install autonomous-agents oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install autonomous-agents oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1 \
+helm install autonomous-agents oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1
+helm show values oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1
 ```
 
 ## Reading the Values Table
@@ -72,7 +72,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-autonomous-agents"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-autonomous-agents"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/autonomous-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/autonomous-agents/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 # Container image configuration
 image:
-  repository: "ghcr.io/cnoe-io/caipe-autonomous-agents"
+  repository: "ghcr.io/caipe-io/caipe-autonomous-agents"
   pullPolicy: "Always"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""

--- a/charts/ai-platform-engineering/charts/caipe-ui-mongodb/README.md
+++ b/charts/ai-platform-engineering/charts/caipe-ui-mongodb/README.md
@@ -15,10 +15,10 @@ MongoDB database for CAIPE UI persistence
 
 ```bash
 # Add and install the chart
-helm install caipe-ui-mongodb oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68
+helm install caipe-ui-mongodb oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade caipe-ui-mongodb oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68
+helm upgrade caipe-ui-mongodb oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install caipe-ui-mongodb oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68 \
+helm install caipe-ui-mongodb oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install caipe-ui-mongodb oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68 \
+helm install caipe-ui-mongodb oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/charts/ai-platform-engineering/charts/caipe-ui/README.md
+++ b/charts/ai-platform-engineering/charts/caipe-ui/README.md
@@ -15,10 +15,10 @@ A Helm chart for CAIPE UI - chat interface for AI Platform Engineering
 
 ```bash
 # Add and install the chart
-helm install caipe-ui oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
+helm install caipe-ui oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade caipe-ui oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
+helm upgrade caipe-ui oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install caipe-ui oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68 \
+helm install caipe-ui oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install caipe-ui oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68 \
+helm install caipe-ui oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -126,7 +126,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-ui"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-ui"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/caipe-ui/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/caipe-ui/templates/_helpers.tpl
@@ -90,7 +90,7 @@ Usage:
   include "caipe-ui.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -108,10 +108,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
+++ b/charts/ai-platform-engineering/charts/caipe-ui/values.yaml
@@ -8,7 +8,7 @@ fullnameOverride: ""
 
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
-  repository: "ghcr.io/cnoe-io/caipe-ui"
+  repository: "ghcr.io/caipe-io/caipe-ui"
   pullPolicy: "Always"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""

--- a/charts/ai-platform-engineering/charts/dynamic-agents/README.md
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/README.md
@@ -15,10 +15,10 @@ A Helm chart for Dynamic Agents - Standalone agent builder service with MCP tool
 
 ```bash
 # Add and install the chart
-helm install dynamic-agents oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
+helm install dynamic-agents oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade dynamic-agents oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
+helm upgrade dynamic-agents oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install dynamic-agents oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68 \
+helm install dynamic-agents oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install dynamic-agents oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68 \
+helm install dynamic-agents oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -85,7 +85,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-dynamic-agents"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-dynamic-agents"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/templates/_helpers.tpl
@@ -108,7 +108,7 @@ Usage:
   include "dynamic-agents.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -126,10 +126,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
+++ b/charts/ai-platform-engineering/charts/dynamic-agents/values.yaml
@@ -7,7 +7,7 @@ fullnameOverride: ""
 
 # Container image configuration
 image:
-  repository: "ghcr.io/cnoe-io/caipe-dynamic-agents"
+  repository: "ghcr.io/caipe-io/caipe-dynamic-agents"
   pullPolicy: "Always"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""

--- a/charts/ai-platform-engineering/charts/keycloak/README.md
+++ b/charts/ai-platform-engineering/charts/keycloak/README.md
@@ -15,10 +15,10 @@ Keycloak identity provider for CAIPE RBAC, token exchange, and identity federati
 
 ```bash
 # Add and install the chart
-helm install keycloak oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
+helm install keycloak oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade keycloak oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
+helm upgrade keycloak oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install keycloak oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68 \
+helm install keycloak oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install keycloak oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68 \
+helm install keycloak oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -140,7 +140,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
 | ingress.hosts[0].paths[1].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | initImage.pullPolicy | string | `"IfNotPresent"` |  |
-| initImage.repository | string | `"ghcr.io/cnoe-io/keycloak-init"` |  |
+| initImage.repository | string | `"ghcr.io/caipe-io/keycloak-init"` |  |
 | initImage.tag | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/keycloak/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/_helpers.tpl
@@ -232,7 +232,7 @@ Usage:
   include "keycloak.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -250,10 +250,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -14,7 +14,7 @@ image:
 #
 # Override with --set initImage.repository=… for air-gapped registries.
 initImage:
-  repository: ghcr.io/cnoe-io/keycloak-init
+  repository: ghcr.io/caipe-io/keycloak-init
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/charts/ai-platform-engineering/charts/mcp-server/README.md
+++ b/charts/ai-platform-engineering/charts/mcp-server/README.md
@@ -15,10 +15,10 @@ Deploys one agent's MCP server (Deployment + Service) for CAIPE
 
 ```bash
 # Add and install the chart
-helm install mcp-server oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68
+helm install mcp-server oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade mcp-server oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68
+helm upgrade mcp-server oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install mcp-server oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68 \
+helm install mcp-server oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install mcp-server oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68 \
+helm install mcp-server oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/charts/ai-platform-engineering/charts/mcp-server/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/mcp-server/templates/_helpers.tpl
@@ -286,7 +286,7 @@ Usage:
   include "agent.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -304,10 +304,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/README.md
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/README.md
@@ -15,10 +15,10 @@ Envoy ext_authz bridge that adapts AgentGateway authorization checks to OpenFGA
 
 ```bash
 # Add and install the chart
-helm install openfga-authz-bridge oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68
+helm install openfga-authz-bridge oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade openfga-authz-bridge oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68
+helm upgrade openfga-authz-bridge oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install openfga-authz-bridge oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68 \
+helm install openfga-authz-bridge oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install openfga-authz-bridge oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68 \
+helm install openfga-authz-bridge oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -61,7 +61,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5
 | callerToolCheck.enabled | bool | `false` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/openfga-authz-bridge"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/openfga-authz-bridge"` |  |
 | image.tag | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/templates/_helpers.tpl
@@ -66,7 +66,7 @@ Usage:
   include "openfga-authz-bridge.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -84,10 +84,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/openfga-authz-bridge/values.yaml
+++ b/charts/ai-platform-engineering/charts/openfga-authz-bridge/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cnoe-io/openfga-authz-bridge
+  repository: ghcr.io/caipe-io/openfga-authz-bridge
   tag: ""
   pullPolicy: IfNotPresent
 

--- a/charts/ai-platform-engineering/charts/openfga/README.md
+++ b/charts/ai-platform-engineering/charts/openfga/README.md
@@ -15,10 +15,10 @@ OpenFGA authorization service for CAIPE relationship-based access control
 
 ```bash
 # Add and install the chart
-helm install openfga oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68
+helm install openfga oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade openfga oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68
+helm upgrade openfga oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install openfga oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68 \
+helm install openfga oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install openfga oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68 \
+helm install openfga oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/charts/ai-platform-engineering/charts/scheduler/README.md
+++ b/charts/ai-platform-engineering/charts/scheduler/README.md
@@ -15,10 +15,10 @@ A Helm chart for caipe-scheduler - cron schedule registry + k8s CronJob orchestr
 
 ```bash
 # Add and install the chart
-helm install scheduler oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
+helm install scheduler oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade scheduler oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
+helm upgrade scheduler oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install scheduler oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68 \
+helm install scheduler oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install scheduler oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68 \
+helm install scheduler oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -64,7 +64,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
 | caipe.apiUrl | string | `"http://caipe-ui:3000"` |  |
 | caipe.chatPath | string | `"/api/v1/chat/invoke"` |  |
 | cronRunner.image.pullPolicy | string | `"IfNotPresent"` |  |
-| cronRunner.image.repository | string | `"ghcr.io/cnoe-io/caipe-cron-runner"` |  |
+| cronRunner.image.repository | string | `"ghcr.io/caipe-io/caipe-cron-runner"` |  |
 | cronRunner.image.tag | string | `""` |  |
 | cronRunner.resources.limits.cpu | string | `"100m"` |  |
 | cronRunner.resources.limits.memory | string | `"128Mi"` |  |
@@ -74,7 +74,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
 | cronRunnerServiceAccount.name | string | `"caipe-cron-runner"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-scheduler"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-scheduler"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | limits.maxMessageChars | int | `2000` |  |

--- a/charts/ai-platform-engineering/charts/scheduler/values.yaml
+++ b/charts/ai-platform-engineering/charts/scheduler/values.yaml
@@ -4,7 +4,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 image:
-  repository: "ghcr.io/cnoe-io/caipe-scheduler"
+  repository: "ghcr.io/caipe-io/caipe-scheduler"
   pullPolicy: "Always"
   tag: ""
 
@@ -13,7 +13,7 @@ image:
 # time; user-controlled fields are limited to schedule, timezone, and SCHEDULE_ID.
 cronRunner:
   image:
-    repository: "ghcr.io/cnoe-io/caipe-cron-runner"
+    repository: "ghcr.io/caipe-io/caipe-cron-runner"
     pullPolicy: "IfNotPresent"
     tag: ""
   # Resource limits per cron-runner pod. Kept tight - the runner makes 2-3 HTTP calls and exits.

--- a/charts/ai-platform-engineering/charts/skill-scanner/README.md
+++ b/charts/ai-platform-engineering/charts/skill-scanner/README.md
@@ -18,10 +18,10 @@ cluster-internal (ClusterIP only — no Ingress).
 
 ```bash
 # Add and install the chart
-helm install skill-scanner oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
+helm install skill-scanner oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade skill-scanner oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
+helm upgrade skill-scanner oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68
 ```
 
 ## Customizing Values
@@ -30,15 +30,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install skill-scanner oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68 \
+helm install skill-scanner oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install skill-scanner oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68 \
+helm install skill-scanner oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -57,7 +57,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
 | affinity | object | `{}` | Pod affinity rules |
 | fullnameOverride | string | `""` | Override the full release name |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ghcr.io/cnoe-io/skill-scanner"` | Container image repository. Build via build/Dockerfile.skill-scanner and push to your registry; override in the parent values.yaml. |
+| image.repository | string | `"ghcr.io/caipe-io/skill-scanner"` | Container image repository. Build via build/Dockerfile.skill-scanner and push to your registry; override in the parent values.yaml. |
 | image.tag | string | `""` | Image tag. Defaults to the parent chart's appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":0,"periodSeconds":20,"timeoutSeconds":3}` | Liveness probe — hits the FastAPI /health endpoint. |

--- a/charts/ai-platform-engineering/charts/skill-scanner/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/skill-scanner/templates/_helpers.tpl
@@ -81,7 +81,7 @@ Usage:
   include "skill-scanner.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -99,10 +99,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/skill-scanner/values.yaml
+++ b/charts/ai-platform-engineering/charts/skill-scanner/values.yaml
@@ -13,7 +13,7 @@ revisionHistoryLimit: 3
 image:
   # -- Container image repository. Build via build/Dockerfile.skill-scanner
   # and push to your registry; override in the parent values.yaml.
-  repository: ghcr.io/cnoe-io/skill-scanner
+  repository: ghcr.io/caipe-io/skill-scanner
   # -- Image tag. Defaults to the parent chart's appVersion.
   tag: ""
   # -- Image pull policy

--- a/charts/ai-platform-engineering/charts/slack-bot/README.md
+++ b/charts/ai-platform-engineering/charts/slack-bot/README.md
@@ -15,10 +15,10 @@ Slack bot integration for AI Platform Engineering using the CAIPE UI BFF
 
 ```bash
 # Add and install the chart
-helm install slack-bot oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
+helm install slack-bot oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade slack-bot oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
+helm upgrade slack-bot oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install slack-bot oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68 \
+helm install slack-bot oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install slack-bot oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68 \
+helm install slack-bot oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -58,7 +58,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
 | externalSecrets | object | `{"apiVersion":"v1beta1","data":[],"enabled":false,"secretStoreRef":{"kind":"ClusterSecretStore","name":"vault"}}` | External Secrets configuration for sensitive data (Slack tokens, OAuth2 client secret, etc.) |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-slack-bot"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-slack-bot"` |  |
 | image.tag | string | `""` |  |
 | keycloakBot | object | `{"clientSecretFromSecret":{"key":"KC_BOT_CLIENT_SECRET","name":""}}` | Cross-chart binding to the Keycloak bot client_secret used by the Slack bot's RFC 8693 OBO exchange helper. In umbrella installs this usually points at the same Secret/key as oauth2.clientSecretFromSecret. |
 | nameOverride | string | `""` |  |

--- a/charts/ai-platform-engineering/charts/slack-bot/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/slack-bot/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Usage:
   include "slack-bot.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -88,10 +88,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/slack-bot/values.yaml
+++ b/charts/ai-platform-engineering/charts/slack-bot/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cnoe-io/caipe-slack-bot
+  repository: ghcr.io/caipe-io/caipe-slack-bot
   tag: ""
   pullPolicy: Always
 

--- a/charts/ai-platform-engineering/charts/webex-bot/README.md
+++ b/charts/ai-platform-engineering/charts/webex-bot/README.md
@@ -15,10 +15,10 @@ Webex bot integration for AI Platform Engineering using the CAIPE UI BFF
 
 ```bash
 # Add and install the chart
-helm install webex-bot oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
+helm install webex-bot oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade webex-bot oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
+helm upgrade webex-bot oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install webex-bot oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68 \
+helm install webex-bot oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install webex-bot oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68 \
+helm install webex-bot oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -63,7 +63,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-webex-bot"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-webex-bot"` |  |
 | image.tag | string | `""` |  |
 | keycloakAdmin | object | `{"clientId":"","clientSecretFromSecret":{"key":"KC_PLATFORM_CLIENT_SECRET","name":""}}` | Keycloak Admin API credentials for webex_user_id lookups (typically caipe-platform). |
 | keycloakBot | object | `{"clientSecretFromSecret":{"key":"KC_WEBEX_BOT_CLIENT_SECRET","name":""}}` | Single source of truth: Keycloak chart Secret {{release}}-keycloak-webex-bot (KC_WEBEX_BOT_CLIENT_SECRET). |

--- a/charts/ai-platform-engineering/charts/webex-bot/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/charts/webex-bot/templates/_helpers.tpl
@@ -70,7 +70,7 @@ Usage:
   include "webex-bot.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -88,10 +88,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/charts/webex-bot/values.yaml
+++ b/charts/ai-platform-engineering/charts/webex-bot/values.yaml
@@ -1,7 +1,7 @@
 replicaCount: 1
 
 image:
-  repository: ghcr.io/cnoe-io/caipe-webex-bot
+  repository: ghcr.io/caipe-io/caipe-webex-bot
   tag: ""
   pullPolicy: Always
 

--- a/charts/ai-platform-engineering/templates/_helpers.tpl
+++ b/charts/ai-platform-engineering/templates/_helpers.tpl
@@ -282,7 +282,7 @@ Usage:
   include "ai-platform-engineering.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -300,10 +300,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/ai-platform-engineering/values-mongodb.yaml.example
+++ b/charts/ai-platform-engineering/values-mongodb.yaml.example
@@ -76,7 +76,7 @@ caipe-ui:
 
   # CAIPE UI application configuration
   image:
-    repository: "ghcr.io/cnoe-io/caipe-ui"
+    repository: "ghcr.io/caipe-io/caipe-ui"
     pullPolicy: "Always"
 
   service:

--- a/charts/ai-platform-engineering/values.yaml
+++ b/charts/ai-platform-engineering/values.yaml
@@ -195,7 +195,7 @@ global:
       configBridge:
         enabled: true
         image:
-          repository: ghcr.io/cnoe-io/agentgateway-config-bridge
+          repository: ghcr.io/caipe-io/agentgateway-config-bridge
           tag: ""              # defaults to agentgateway subchart appVersion
           pullPolicy: IfNotPresent
         pollSeconds: 5
@@ -405,11 +405,11 @@ skillsLiveSkills: ""           # Inline custom live-skills skill (overrides ever
 mcp-argocd:
   nameOverride: "mcp-argocd"
   image:
-    repository: "ghcr.io/cnoe-io/mcp-argocd"
+    repository: "ghcr.io/caipe-io/mcp-argocd"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-argocd"
+      repository: "ghcr.io/caipe-io/mcp-argocd"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -425,11 +425,11 @@ mcp-argocd:
 mcp-backstage:
   nameOverride: "mcp-backstage"
   image:
-    repository: "ghcr.io/cnoe-io/agent-backstage"
+    repository: "ghcr.io/caipe-io/agent-backstage"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-backstage"
+      repository: "ghcr.io/caipe-io/mcp-backstage"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -442,7 +442,7 @@ mcp-backstage:
 mcp-confluence:
   nameOverride: "mcp-confluence"
   image:
-    repository: "ghcr.io/cnoe-io/agent-confluence"
+    repository: "ghcr.io/caipe-io/agent-confluence"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
@@ -460,7 +460,7 @@ mcp-confluence:
 mcp-github:
   nameOverride: "mcp-github"
   image:
-    repository: "ghcr.io/cnoe-io/mcp-github"
+    repository: "ghcr.io/caipe-io/mcp-github"
     pullPolicy: "IfNotPresent"
   mcp:
     mode: "stdio"
@@ -474,7 +474,7 @@ mcp-github:
 mcp-gitlab:
   nameOverride: "mcp-gitlab"
   image:
-    repository: "ghcr.io/cnoe-io/agent-gitlab"
+    repository: "ghcr.io/caipe-io/agent-gitlab"
     pullPolicy: "IfNotPresent"
   env:
     GIT_AUTHOR_NAME: "AI Agent"
@@ -529,11 +529,11 @@ mcp-gitlab:
 mcp-jira:
   nameOverride: "mcp-jira"
   image:
-    repository: "ghcr.io/cnoe-io/agent-jira"
+    repository: "ghcr.io/caipe-io/agent-jira"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-jira"
+      repository: "ghcr.io/caipe-io/mcp-jira"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -546,11 +546,11 @@ mcp-jira:
 mcp-pagerduty:
   nameOverride: "mcp-pagerduty"
   image:
-    repository: "ghcr.io/cnoe-io/agent-pagerduty"
+    repository: "ghcr.io/caipe-io/agent-pagerduty"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-pagerduty"
+      repository: "ghcr.io/caipe-io/mcp-pagerduty"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -563,7 +563,7 @@ mcp-pagerduty:
 mcp-slack:
   nameOverride: "mcp-slack"
   image:
-    repository: "ghcr.io/cnoe-io/agent-slack"
+    repository: "ghcr.io/caipe-io/agent-slack"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
@@ -586,11 +586,11 @@ mcp-slack:
 mcp-aws:
   nameOverride: "mcp-aws"
   image:
-    repository: "ghcr.io/cnoe-io/agent-aws"
+    repository: "ghcr.io/caipe-io/agent-aws"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-aws"
+      repository: "ghcr.io/caipe-io/mcp-aws"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -616,11 +616,11 @@ mcp-aws:
 mcp-splunk:
   nameOverride: "mcp-splunk"
   image:
-    repository: "ghcr.io/cnoe-io/agent-splunk"
+    repository: "ghcr.io/caipe-io/agent-splunk"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-splunk"
+      repository: "ghcr.io/caipe-io/mcp-splunk"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -633,11 +633,11 @@ mcp-splunk:
 mcp-victorops:
   nameOverride: "mcp-victorops"
   image:
-    repository: "ghcr.io/cnoe-io/agent-victorops"
+    repository: "ghcr.io/caipe-io/agent-victorops"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-victorops"
+      repository: "ghcr.io/caipe-io/mcp-victorops"
       tag: ""
       pullPolicy: "IfNotPresent"
     mode: "http" # Options: stdio, http
@@ -649,11 +649,11 @@ mcp-victorops:
 mcp-webex:
   nameOverride: "mcp-webex"
   image:
-    repository: "ghcr.io/cnoe-io/agent-webex"
+    repository: "ghcr.io/caipe-io/agent-webex"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-webex"
+      repository: "ghcr.io/caipe-io/mcp-webex"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -669,7 +669,7 @@ mcp-webex-meetings:
     requiresSecret: false
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-webex-meetings"
+      repository: "ghcr.io/caipe-io/mcp-webex-meetings"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -689,11 +689,11 @@ mcp-webex-meetings:
 mcp-komodor:
   nameOverride: "mcp-komodor"
   image:
-    repository: "ghcr.io/cnoe-io/agent-komodor"
+    repository: "ghcr.io/caipe-io/agent-komodor"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-komodor"
+      repository: "ghcr.io/caipe-io/mcp-komodor"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -708,11 +708,11 @@ mcp-netutils:
   agentSecrets:
     requiresSecret: false
   image:
-    repository: "ghcr.io/cnoe-io/agent-netutils"
+    repository: "ghcr.io/caipe-io/agent-netutils"
     pullPolicy: "IfNotPresent"
   mcp:
     image:
-      repository: "ghcr.io/cnoe-io/mcp-netutils"
+      repository: "ghcr.io/caipe-io/mcp-netutils"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -748,7 +748,7 @@ caipe-ui:
     secretKey: "KC_SCHEDULER_CLIENT_SECRET"
     clientId: "caipe-scheduler-runner"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-ui"
+    repository: "ghcr.io/caipe-io/caipe-ui"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1022,7 +1022,7 @@ litellmMcp:
   replicaCount: 1
   revisionHistoryLimit: 3
   image:
-    repository: "ghcr.io/cnoe-io/mcp-litellm"
+    repository: "ghcr.io/caipe-io/mcp-litellm"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1093,7 +1093,7 @@ litellmMcp:
 dynamic-agents:
   nameOverride: "dynamic-agents"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-dynamic-agents"
+    repository: "ghcr.io/caipe-io/caipe-dynamic-agents"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1176,7 +1176,7 @@ dynamic-agents:
 autonomous-agents:
   nameOverride: "autonomous-agents"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-autonomous-agents"
+    repository: "ghcr.io/caipe-io/caipe-autonomous-agents"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1228,14 +1228,14 @@ autonomous-agents:
 scheduler:
   fullnameOverride: "caipe-scheduler"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-scheduler"
+    repository: "ghcr.io/caipe-io/caipe-scheduler"
     tag: ""
     pullPolicy: "IfNotPresent"
   command: []
   args: []
   cronRunner:
     image:
-      repository: "ghcr.io/cnoe-io/caipe-cron-runner"
+      repository: "ghcr.io/caipe-io/caipe-cron-runner"
       tag: ""
       pullPolicy: "IfNotPresent"
   caipe:
@@ -1259,7 +1259,7 @@ schedulerMcp:
   enabled: true
   nameOverride: "mcp-scheduler"
   image:
-    repository: "ghcr.io/cnoe-io/mcp-scheduler"
+    repository: "ghcr.io/caipe-io/mcp-scheduler"
     tag: ""
     pullPolicy: "IfNotPresent"
   command: ["mcp-server-scheduler"]
@@ -1285,7 +1285,7 @@ schedulerMcp:
 # Enable with: global.integrations.slackBot.enabled=true
 slack-bot:
   image:
-    repository: "ghcr.io/cnoe-io/caipe-slack-bot"
+    repository: "ghcr.io/caipe-io/caipe-slack-bot"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "IfNotPresent"
@@ -1388,7 +1388,7 @@ slack-bot:
 # Enable with Helm tag: webex-bot=true
 webex-bot:
   image:
-    repository: "ghcr.io/cnoe-io/caipe-webex-bot"
+    repository: "ghcr.io/caipe-io/caipe-webex-bot"
     tag: ""
     pullPolicy: "IfNotPresent"
 
@@ -1573,7 +1573,7 @@ openfgaAuthzBridge:
 # above is kept as the dependency condition flag.
 openfga-authz-bridge:
   image:
-    repository: ghcr.io/cnoe-io/openfga-authz-bridge
+    repository: ghcr.io/caipe-io/openfga-authz-bridge
     tag: ""
     pullPolicy: IfNotPresent
   # Must match caipe-ui.config.CAIPE_ORG_KEY.
@@ -1616,7 +1616,7 @@ rag-stack:
   rag-server:
     enabled: true
     image:
-      repository: "ghcr.io/cnoe-io/caipe-rag-server"
+      repository: "ghcr.io/caipe-io/caipe-rag-server"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"
@@ -1627,7 +1627,7 @@ rag-stack:
   agent-rag:
     enabled: true
     image:
-      repository: "ghcr.io/cnoe-io/caipe-rag-agent-rag"
+      repository: "ghcr.io/caipe-io/caipe-rag-agent-rag"
       # tag defaults to .Chart.AppVersion when not specified
       tag: ""
       pullPolicy: "IfNotPresent"

--- a/charts/rag-stack/README.md
+++ b/charts/rag-stack/README.md
@@ -15,10 +15,10 @@ A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 
 ```bash
 # Add and install the chart
-helm install rag-stack oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
+helm install rag-stack oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade rag-stack oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
+helm upgrade rag-stack oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install rag-stack oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68 \
+helm install rag-stack oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install rag-stack oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68 \
+helm install rag-stack oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -57,7 +57,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
 | agent-ontology.enabled | bool | `true` |  |
 | agent-ontology.fullnameOverride | string | `"agent-ontology"` |  |
 | agent-ontology.image.pullPolicy | string | `"Always"` |  |
-| agent-ontology.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-ontology"` |  |
+| agent-ontology.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-ontology"` |  |
 | agent-ontology.image.tag | string | `""` |  |
 | agent-ontology.livenessProbe.failureThreshold | int | `3` |  |
 | agent-ontology.livenessProbe.httpGet.path | string | `"/v1/graph/ontology/agent/status"` |  |
@@ -206,7 +206,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
 | rag-server.envFrom | list | `[]` |  |
 | rag-server.fullnameOverride | string | `"rag-server"` |  |
 | rag-server.image.pullPolicy | string | `"Always"` |  |
-| rag-server.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| rag-server.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | rag-server.image.tag | string | `""` |  |
 | rag-server.podAnnotations | object | `{}` |  |
 | rag-server.resources.limits.cpu | string | `"500m"` |  |

--- a/charts/rag-stack/charts/agent-ontology/README.md
+++ b/charts/rag-stack/charts/agent-ontology/README.md
@@ -15,10 +15,10 @@ A Helm chart for Kubernetes
 
 ```bash
 # Add and install the chart
-helm install agent-ontology oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
+helm install agent-ontology oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade agent-ontology oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
+helm upgrade agent-ontology oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install agent-ontology oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68 \
+helm install agent-ontology oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install agent-ontology oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68 \
+helm install agent-ontology oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -62,7 +62,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
 | env | object | `{}` |  |
 | fullnameOverride | string | `"agent-ontology"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-ontology"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-ontology"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/rag-stack/charts/agent-ontology/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/agent-ontology/templates/_helpers.tpl
@@ -250,7 +250,7 @@ Usage:
   include "agent-ontology.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -268,10 +268,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/rag-stack/charts/agent-ontology/values.yaml
+++ b/charts/rag-stack/charts/agent-ontology/values.yaml
@@ -27,7 +27,7 @@ revisionHistoryLimit: 3
 # This sets the container image more information can be found here: https://kubernetes.io/docs/concepts/containers/images/
 image:
   # This sets the image repository for the corresponding agent.
-  repository: "ghcr.io/cnoe-io/caipe-rag-agent-ontology"
+  repository: "ghcr.io/caipe-io/caipe-rag-agent-ontology"
   # This sets the pull policy for images.
   pullPolicy: IfNotPresent
   # tag defaults to .Chart.AppVersion when not specified

--- a/charts/rag-stack/charts/rag-ingestors/README.md
+++ b/charts/rag-stack/charts/rag-ingestors/README.md
@@ -15,10 +15,10 @@ Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and We
 
 ```bash
 # Add and install the chart
-helm install rag-ingestors oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
+helm install rag-ingestors oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade rag-ingestors oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
+helm upgrade rag-ingestors oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install rag-ingestors oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68 \
+helm install rag-ingestors oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install rag-ingestors oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68 \
+helm install rag-ingestors oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -59,7 +59,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
 | defaultResources.requests.ephemeral-storage | string | `"256Mi"` |  |
 | defaultResources.requests.memory | string | `"256Mi"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-ingestors"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-ingestors"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingestors | list | `[]` |  |

--- a/charts/rag-stack/charts/rag-ingestors/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-ingestors/templates/_helpers.tpl
@@ -96,7 +96,7 @@ Usage:
   include "rag-ingestors.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -114,10 +114,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/rag-stack/charts/rag-ingestors/values.yaml
+++ b/charts/rag-stack/charts/rag-ingestors/values.yaml
@@ -4,7 +4,7 @@
 
 # Global image configuration
 image:
-  repository: "ghcr.io/cnoe-io/caipe-rag-ingestors"
+  repository: "ghcr.io/caipe-io/caipe-rag-ingestors"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""
   pullPolicy: IfNotPresent

--- a/charts/rag-stack/charts/rag-redis/README.md
+++ b/charts/rag-stack/charts/rag-redis/README.md
@@ -15,10 +15,10 @@ A Helm chart for Kubernetes
 
 ```bash
 # Add and install the chart
-helm install rag-redis oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68
+helm install rag-redis oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade rag-redis oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68
+helm upgrade rag-redis oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install rag-redis oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68 \
+helm install rag-redis oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install rag-redis oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68 \
+helm install rag-redis oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/charts/rag-stack/charts/rag-server/README.md
+++ b/charts/rag-stack/charts/rag-server/README.md
@@ -15,10 +15,10 @@ RAG server
 
 ```bash
 # Add and install the chart
-helm install rag-server oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
+helm install rag-server oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade rag-server oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
+helm upgrade rag-server oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68
 ```
 
 ## Customizing Values
@@ -27,15 +27,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install rag-server oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68 \
+helm install rag-server oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install rag-server oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68 \
+helm install rag-server oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -58,7 +58,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `"rag-server"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |

--- a/charts/rag-stack/charts/rag-server/templates/_helpers.tpl
+++ b/charts/rag-stack/charts/rag-server/templates/_helpers.tpl
@@ -231,7 +231,7 @@ Usage:
   include "rag-server.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -249,10 +249,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/rag-stack/charts/rag-server/values.yaml
+++ b/charts/rag-stack/charts/rag-server/values.yaml
@@ -5,7 +5,7 @@ fullnameOverride: "rag-server"
 enableGraphRag: true
 
 image:
-  repository: "ghcr.io/cnoe-io/caipe-rag-server"
+  repository: "ghcr.io/caipe-io/caipe-rag-server"
   # tag defaults to .Chart.AppVersion when not specified
   tag: ""
   pullPolicy: IfNotPresent
@@ -91,7 +91,7 @@ affinity: {}
 # Init containers to run before the main containers (e.g. install Playwright browsers)
 initContainers: []
 # - name: playwright-install
-#   image: "ghcr.io/cnoe-io/caipe-rag-ingestors:0.4.4"
+#   image: "ghcr.io/caipe-io/caipe-rag-ingestors:0.4.4"
 #   command: ["sh", "-c", "playwright install chromium"]
 #   volumeMounts:
 #     - name: playwright-browsers

--- a/charts/rag-stack/templates/_helpers.tpl
+++ b/charts/rag-stack/templates/_helpers.tpl
@@ -68,7 +68,7 @@ Usage:
   include "rag-stack.imageRepository" (dict "root" . "repository" .Values.image.repository)
 
 The default channel is derived from .Chart.AppVersion: rc/hotfix/dev versions use
-`ghcr.io/cnoe-io/pre-release/*`, final versions use `ghcr.io/cnoe-io/*`.
+`ghcr.io/caipe-io/pre-release/*`, final versions use `ghcr.io/caipe-io/*`.
 Operators may force either channel with global.image.channel=pre-release|release.
 Explicit non-CAIPE repositories are left unchanged.
 */}
@@ -86,10 +86,10 @@ Explicit non-CAIPE repositories are left unchanged.
 {{- $channel = "release" -}}
 {{- end -}}
 {{- end -}}
-{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/cnoe-io/" $repository) (not (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository)) -}}
-{{- printf "ghcr.io/cnoe-io/pre-release/%s" (trimPrefix "ghcr.io/cnoe-io/" $repository) -}}
-{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
-{{- printf "ghcr.io/cnoe-io/%s" (trimPrefix "ghcr.io/cnoe-io/pre-release/" $repository) -}}
+{{- if and (eq $channel "pre-release") (hasPrefix "ghcr.io/caipe-io/" $repository) (not (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository)) -}}
+{{- printf "ghcr.io/caipe-io/pre-release/%s" (trimPrefix "ghcr.io/caipe-io/" $repository) -}}
+{{- else if and (eq $channel "release") (hasPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
+{{- printf "ghcr.io/caipe-io/%s" (trimPrefix "ghcr.io/caipe-io/pre-release/" $repository) -}}
 {{- else -}}
 {{- $repository -}}
 {{- end -}}

--- a/charts/rag-stack/values.yaml
+++ b/charts/rag-stack/values.yaml
@@ -77,7 +77,7 @@ rag-server:
   enabled: true
   fullnameOverride: "rag-server"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-rag-server"
+    repository: "ghcr.io/caipe-io/caipe-rag-server"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: Always
@@ -133,7 +133,7 @@ agent-ontology:
   enabled: true
   fullnameOverride: "agent-ontology"
   image:
-    repository: "ghcr.io/cnoe-io/caipe-rag-agent-ontology"
+    repository: "ghcr.io/caipe-io/caipe-rag-agent-ontology"
     # tag defaults to .Chart.AppVersion when not specified
     tag: ""
     pullPolicy: "Always"

--- a/deploy/eks/argocd-application.yaml.example
+++ b/deploy/eks/argocd-application.yaml.example
@@ -10,14 +10,14 @@ spec:
   sources:
     # Main chart from GHCR
     - chart: ai-platform-engineering
-      repoURL: ghcr.io/cnoe-io/charts
+      repoURL: ghcr.io/caipe-io/charts
       targetRevision: <CHART VERSION>
       helm:
         valueFiles:
           - $values/helm/values.yaml
           - $values/helm/values-existing-secrets.yaml
     # Values files from Git repository (your custom branch)
-    - repoURL: https://github.com/cnoe-io/ai-platform-engineering.git
+    - repoURL: https://github.com/caipe-io/ai-platform-engineering.git
       targetRevision: <YOUR BRANCH NAME>
       ref: values
   destination:

--- a/deploy/openfga/bridge/tests/test_helm_values.py
+++ b/deploy/openfga/bridge/tests/test_helm_values.py
@@ -140,7 +140,7 @@ def test_umbrella_values_define_webex_bot_section() -> None:
     assert webex["config"]["WEBEX_ADMIN_JWT_AUDIENCE"] == "caipe-webex-bot-admin"
     assert webex["config"]["WEBEX_ADMIN_API_ENABLED"] == "true"
     assert webex["config"]["WEBEX_ADMIN_API_PORT"] == "3002"
-    assert "ghcr.io/cnoe-io/caipe-webex-bot" in webex["image"]["repository"]
+    assert "ghcr.io/caipe-io/caipe-webex-bot" in webex["image"]["repository"]
 
 
 def test_caipe_ui_values_wire_webex_bot_admin_env() -> None:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -118,7 +118,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=backstage
-    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-backstage:${IMAGE_TAG:-localtag}
     container_name: mcp-backstage
     env_file: [.env]
     ports: ["18001:8000"]
@@ -145,7 +145,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=argocd
-    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-argocd:${IMAGE_TAG:-localtag}
     container_name: mcp-argocd
     env_file: [.env]
     ports: ["18002:8000"]
@@ -186,7 +186,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=jira
-    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-jira:${IMAGE_TAG:-localtag}
     container_name: mcp-jira
     env_file: [.env]
     ports: ["18004:8000"]
@@ -229,7 +229,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=komodor
-    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-komodor:${IMAGE_TAG:-localtag}
     container_name: mcp-komodor
     env_file: [.env]
     ports: ["18005:8000"]
@@ -255,7 +255,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=pagerduty
-    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-pagerduty:${IMAGE_TAG:-localtag}
     container_name: mcp-pagerduty
     env_file: [.env]
     ports: ["18006:8000"]
@@ -309,7 +309,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=splunk
-    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-splunk:${IMAGE_TAG:-localtag}
     container_name: mcp-splunk
     env_file: [.env]
     ports: ["18008:8000"]
@@ -336,7 +336,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=webex
-    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-webex:${IMAGE_TAG:-localtag}
     container_name: mcp-webex
     env_file: [.env]
     ports: ["18009:8000"]
@@ -363,7 +363,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=webex-meetings
-    image: ghcr.io/cnoe-io/mcp-webex-meetings:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-webex-meetings:${IMAGE_TAG:-localtag}
     container_name: mcp-webex-meetings
     env_file: [.env]
     ports: ["18013:8000"]
@@ -390,7 +390,7 @@ services:
       dockerfile: build/agents/Dockerfile.mcp
       args:
         - AGENT_NAME=victorops
-    image: ghcr.io/cnoe-io/mcp-victorops:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-victorops:${IMAGE_TAG:-localtag}
     container_name: mcp-victorops
     env_file: [.env]
     ports: ["18012:8000"]
@@ -417,7 +417,7 @@ services:
       args:
         - AGENT_NAME=netutils
         - INSTALL_NETUTILS=true
-    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/mcp-netutils:${IMAGE_TAG:-localtag}
     container_name: mcp-netutils
     env_file: [.env]
     ports: ["18011:8000"]
@@ -478,7 +478,7 @@ services:
         # Local prod-parity rebuilds skip Next's duplicate typecheck; run
         # `npm run lint` / targeted tests separately when validating changes.
         - CAIPE_UI_FAST_BUILD=${CAIPE_UI_FAST_BUILD:-true}
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-localtag}-dev
+    image: ghcr.io/caipe-io/caipe-ui:${IMAGE_TAG:-localtag}-dev
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -739,7 +739,7 @@ services:
         # Local prod-parity rebuilds skip Next's duplicate typecheck; run
         # `npm run lint` / targeted tests separately when validating changes.
         - CAIPE_UI_FAST_BUILD=${CAIPE_UI_FAST_BUILD:-true}
-    image: ghcr.io/cnoe-io/caipe-ui-prod:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-ui-prod:${IMAGE_TAG:-localtag}
     container_name: caipe-ui-prod
     # Same host port as caipe-ui — these two services are mutually exclusive.
     # Keycloak's caipe-ui client only allow-lists http://localhost:3000/*.
@@ -905,7 +905,7 @@ services:
     build:
       context: .
       dockerfile: build/Dockerfile.audit-service
-    image: ghcr.io/cnoe-io/caipe-audit-service:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-audit-service:${IMAGE_TAG:-localtag}
     container_name: audit-service
     ports:
       - "127.0.0.1:${AUDIT_SERVICE_PORT:-8010}:8010"
@@ -966,7 +966,7 @@ services:
     build:
       context: ./ai_platform_engineering/dynamic_agents
       dockerfile: build/Dockerfile
-    image: ghcr.io/cnoe-io/caipe-dynamic-agents:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-dynamic-agents:${IMAGE_TAG:-localtag}
     container_name: dynamic-agents
     ports: ["8100:8001"]
     volumes:
@@ -1120,7 +1120,7 @@ services:
       # Dockerfile itself lives at the repo root under build/
       context: ./ai_platform_engineering/autonomous_agents
       dockerfile: ../../build/Dockerfile.autonomous-agents
-    image: ghcr.io/cnoe-io/caipe-autonomous-agents:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-autonomous-agents:${IMAGE_TAG:-localtag}
     container_name: autonomous-agents
     ports: ["8002:8002"]
     env_file: [.env]
@@ -1176,7 +1176,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.server
-    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-server:${IMAGE_TAG:-localtag}
     container_name: rag-server
     # Network alias preserves the legacy `rag_server` hostname for any client
     # that still has it hardcoded. AGW's hickory-dns resolver rejects DNS
@@ -1256,7 +1256,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.agent-ontology
-    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-localtag}
     container_name: agent_ontology
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/agent_ontology/src/agent_ontology:/app/agent_ontology/src/agent_ontology
@@ -1290,7 +1290,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: web-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1322,7 +1322,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: backstage-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1349,7 +1349,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: aws-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1383,7 +1383,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: k8s-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1417,7 +1417,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: slack-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1446,7 +1446,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: webex-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1474,7 +1474,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: argocd-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1501,7 +1501,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: github-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1563,7 +1563,7 @@ services:
     build:
       context: ./ai_platform_engineering/knowledge_bases/rag
       dockerfile: ./build/Dockerfile.ingestors
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-localtag}
     container_name: confluence-ingestor
     volumes:
       - ./ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors:/app/ingestors/src/ingestors
@@ -1890,7 +1890,7 @@ services:
     build:
       context: .
       dockerfile: build/Dockerfile.slack-bot
-    image: ghcr.io/cnoe-io/caipe-slack-bot:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-slack-bot:${IMAGE_TAG:-localtag}
     container_name: slack-bot
     volumes:
       - ./ai_platform_engineering/integrations/slack_bot:/app
@@ -1994,7 +1994,7 @@ services:
     build:
       context: .
       dockerfile: build/Dockerfile.webex-bot
-    image: ghcr.io/cnoe-io/caipe-webex-bot:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/caipe-webex-bot:${IMAGE_TAG:-localtag}
     container_name: webex-bot
     volumes:
       - ./ai_platform_engineering/integrations/webex_bot:/app/ai_platform_engineering/integrations/webex_bot
@@ -2406,7 +2406,7 @@ services:
     build:
       context: ./deploy/agentgateway
       dockerfile: Dockerfile.config-bridge
-    image: ghcr.io/cnoe-io/agentgateway-config-bridge:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/agentgateway-config-bridge:${IMAGE_TAG:-localtag}
     container_name: agentgateway-config-bridge
     restart: unless-stopped
     read_only: true
@@ -2519,7 +2519,7 @@ services:
         # Bumping requires verifying /scan-upload response shape vs
         # ui/src/lib/skill-scan.ts.
         - SKILL_SCANNER_VERSION=${SKILL_SCANNER_VERSION:-2.0.11}
-    image: ghcr.io/cnoe-io/skill-scanner:${IMAGE_TAG:-localtag}
+    image: ghcr.io/caipe-io/skill-scanner:${IMAGE_TAG:-localtag}
     container_name: skill-scanner
     # Bind to 127.0.0.1 only — the API has no auth and accepts arbitrary
     # ZIPs, so it must never be reachable from outside the host.

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,7 @@ services:
       - mcp-servers
 
   mcp-backstage:
-    image: ghcr.io/cnoe-io/mcp-backstage:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/mcp-backstage:${IMAGE_TAG:-0.5.66}
     container_name: mcp-backstage
     env_file: [.env]
     ports: ["18001:8000"]
@@ -49,7 +49,7 @@ services:
   # ArgoCD MCP
 
   mcp-argocd:
-    image: ghcr.io/cnoe-io/mcp-argocd:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/mcp-argocd:${IMAGE_TAG:-0.5.66}
     container_name: mcp-argocd
     env_file: [.env]
     ports: ["18002:8000"]
@@ -87,7 +87,7 @@ services:
   # Jira MCP
 
   mcp-jira:
-    image: ghcr.io/cnoe-io/mcp-jira:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/mcp-jira:${IMAGE_TAG:-0.5.66}
     container_name: mcp-jira
     env_file: [.env]
     ports: ["18004:8000"]
@@ -109,7 +109,7 @@ services:
   # Komodor MCP
 
   mcp-komodor:
-    image: ghcr.io/cnoe-io/mcp-komodor:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/mcp-komodor:${IMAGE_TAG:-0.5.66}
     container_name: mcp-komodor
     env_file: [.env]
     ports: ["18005:8000"]
@@ -130,7 +130,7 @@ services:
   # PagerDuty MCP
 
   mcp-pagerduty:
-    image: ghcr.io/cnoe-io/mcp-pagerduty:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/mcp-pagerduty:${IMAGE_TAG:-0.5.66}
     container_name: mcp-pagerduty
     env_file: [.env]
     ports: ["18006:8000"]
@@ -180,7 +180,7 @@ services:
   # Splunk
 
   mcp-splunk:
-    image: ghcr.io/cnoe-io/mcp-splunk:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/mcp-splunk:${IMAGE_TAG:-0.5.66}
     container_name: mcp-splunk
     env_file: [.env]
     ports: ["18008:8000"]
@@ -202,7 +202,7 @@ services:
   # Webex
 
   mcp-webex:
-    image: ghcr.io/cnoe-io/mcp-webex:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/mcp-webex:${IMAGE_TAG:-0.5.66}
     container_name: mcp-webex
     env_file: [.env]
     ports: ["18009:8000"]
@@ -224,7 +224,7 @@ services:
   # NetUtils MCP
 
   mcp-netutils:
-    image: ghcr.io/cnoe-io/mcp-netutils:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/mcp-netutils:${IMAGE_TAG:-0.5.66}
     container_name: mcp-netutils
     env_file: [.env]
     ports: ["18011:8000"]
@@ -298,7 +298,7 @@ services:
   #   - Configure via MONGODB_* environment variables
   #   - See mongodb service configuration above
   caipe-ui:
-    image: ghcr.io/cnoe-io/caipe-ui:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-ui:${IMAGE_TAG:-0.5.66}
     container_name: caipe-ui
     ports: ["3000:3000"]
     env_file:
@@ -405,7 +405,7 @@ services:
     build:
       context: .
       dockerfile: build/Dockerfile.audit-service
-    image: ghcr.io/cnoe-io/caipe-audit-service:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-audit-service:${IMAGE_TAG:-0.5.66}
     container_name: audit-service
     ports:
       - "127.0.0.1:${AUDIT_SERVICE_PORT:-8010}:8010"
@@ -456,7 +456,7 @@ services:
   #                                      RAG Services                                                #
   ####################################################################################################
   rag-server:
-    image: ghcr.io/cnoe-io/caipe-rag-server:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-rag-server:${IMAGE_TAG:-0.5.66}
     container_name: rag-server
     # Network alias keeps the legacy `rag_server` hostname working for any
     # client that still has it hardcoded. AGW's hickory-dns resolver rejects
@@ -507,7 +507,7 @@ services:
   # Ports:
   #   - 8100: Dynamic Agents API (proxied via UI at /api/dynamic-agents)
   dynamic-agents:
-    image: ghcr.io/cnoe-io/caipe-dynamic-agents:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-dynamic-agents:${IMAGE_TAG:-0.5.66}
     container_name: dynamic-agents
     ports: ["8100:8001"]
     volumes:
@@ -571,7 +571,7 @@ services:
   # Ports:
   #   - 8002: Autonomous Agents API (proxied via UI at /api/autonomous, admin-only)
   autonomous-agents:
-    image: ghcr.io/cnoe-io/caipe-autonomous-agents:${IMAGE_TAG:-0.2.36}
+    image: ghcr.io/caipe-io/caipe-autonomous-agents:${IMAGE_TAG:-0.2.36}
     container_name: autonomous-agents
     # Bind to loopback only -- the FastAPI service has no auth layer of
     # its own; auth and admin gating live in the UI's /api/autonomous
@@ -631,7 +631,7 @@ services:
       - autonomous-agents
 
   agent_ontology:
-    image: ghcr.io/cnoe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-rag-agent-ontology:${IMAGE_TAG:-0.5.66}
     container_name: agent_ontology
     ports: ["8098:8098"]
     environment:
@@ -650,7 +650,7 @@ services:
 
 
   web_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
     container_name: web-ingestor
     environment:
       - INGESTOR_TYPE=webloader
@@ -667,7 +667,7 @@ services:
       - web_ingestor
 
   jira_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
     container_name: jira-ingestor
     environment:
       - INGESTOR_TYPE=jira
@@ -687,7 +687,7 @@ services:
       - jira-ingestor
 
   confluence_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
     container_name: confluence-ingestor
     environment:
       - INGESTOR_TYPE=confluence
@@ -709,7 +709,7 @@ services:
       - confluence-ingestor
 
   slack_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
     container_name: slack-ingestor
     environment:
       - INGESTOR_TYPE=slack
@@ -732,7 +732,7 @@ services:
       - slack-ingestor
 
   webex_ingestor:
-    image: ghcr.io/cnoe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-rag-ingestors:${IMAGE_TAG:-0.5.66}
     container_name: webex-ingestor
     environment:
       - INGESTOR_TYPE=webex
@@ -1037,7 +1037,7 @@ services:
   #                                 Slack Bot Integration                                            #
   ####################################################################################################
   slack-bot:
-    image: ghcr.io/cnoe-io/caipe-slack-bot:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-slack-bot:${IMAGE_TAG:-0.5.66}
     container_name: slack-bot
     env_file: [.env]
     ports: ["8030:3000"]
@@ -1074,7 +1074,7 @@ services:
   #                                 Webex Bot Integration                                            #
   ####################################################################################################
   webex-bot:
-    image: ghcr.io/cnoe-io/caipe-webex-bot:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/caipe-webex-bot:${IMAGE_TAG:-0.5.66}
     container_name: webex-bot
     env_file: [.env]
     ports: ["8032:3002"]
@@ -1473,7 +1473,7 @@ services:
     build:
       context: ./deploy/agentgateway
       dockerfile: Dockerfile.config-bridge
-    image: ghcr.io/cnoe-io/agentgateway-config-bridge:${IMAGE_TAG:-0.5.66}
+    image: ghcr.io/caipe-io/agentgateway-config-bridge:${IMAGE_TAG:-0.5.66}
     container_name: agentgateway-config-bridge
     restart: unless-stopped
     read_only: true

--- a/docs/docs/agent-ops/index.md
+++ b/docs/docs/agent-ops/index.md
@@ -7,12 +7,12 @@ Agents and MCP tool servers.
 
 | Component | Image family |
 |---|---|
-| UI/BFF | `ghcr.io/cnoe-io/caipe-ui` |
-| Dynamic Agents | `ghcr.io/cnoe-io/caipe-dynamic-agents` |
-| MCP servers | `ghcr.io/cnoe-io/mcp-<name>` or external MCP image |
-| Slack bot | `ghcr.io/cnoe-io/caipe-slack-bot` |
-| Webex bot | `ghcr.io/cnoe-io/caipe-webex-bot` |
-| Audit service | `ghcr.io/cnoe-io/caipe-audit-service` |
+| UI/BFF | `ghcr.io/caipe-io/caipe-ui` |
+| Dynamic Agents | `ghcr.io/caipe-io/caipe-dynamic-agents` |
+| MCP servers | `ghcr.io/caipe-io/mcp-<name>` or external MCP image |
+| Slack bot | `ghcr.io/caipe-io/caipe-slack-bot` |
+| Webex bot | `ghcr.io/caipe-io/caipe-webex-bot` |
+| Audit service | `ghcr.io/caipe-io/caipe-audit-service` |
 
 ## Validation
 

--- a/docs/docs/contributing/index.md
+++ b/docs/docs/contributing/index.md
@@ -2,7 +2,7 @@
 
 ## How to Contribute
 
-We welcome contributions to CAIPE! To get started, please review our [Contributing Guide](https://github.com/cnoe-io/ai-platform-engineering/blob/main/CONTRIBUTING.md). It outlines the process for submitting issues, proposing changes, and creating pull requests.
+We welcome contributions to CAIPE! To get started, please review our [Contributing Guide](https://github.com/caipe-io/ai-platform-engineering/blob/main/CONTRIBUTING.md). It outlines the process for submitting issues, proposing changes, and creating pull requests.
 
 ### Steps to Contribute
 
@@ -14,13 +14,13 @@ We welcome contributions to CAIPE! To get started, please review our [Contributi
 
 ### Code of Conduct
 
-Please adhere to our [Code of Conduct](https://github.com/cnoe-io/ai-platform-engineering/blob/main/CODE_OF_CONDUCT.md) to ensure a welcoming and inclusive environment for all contributors.
+Please adhere to our [Code of Conduct](https://github.com/caipe-io/ai-platform-engineering/blob/main/CODE_OF_CONDUCT.md) to ensure a welcoming and inclusive environment for all contributors.
 
 ---
 
 ## 🏅 Contribution Badges
 
-CAIPE uses a gamified badge system to celebrate your contributions and learning journey. Earn badges as you go deeper into building and operating AI Platform Engineering. See the full announcement in [GitHub Discussions #245](https://github.com/cnoe-io/ai-platform-engineering/discussions/245).
+CAIPE uses a gamified badge system to celebrate your contributions and learning journey. Earn badges as you go deeper into building and operating AI Platform Engineering. See the full announcement in [GitHub Discussions #245](https://github.com/caipe-io/ai-platform-engineering/discussions/245).
 
 ### Level 1 — CAIPE Explorer 🧑‍🚀
 

--- a/docs/docs/development/ci-cd-and-releases.md
+++ b/docs/docs/development/ci-cd-and-releases.md
@@ -38,12 +38,12 @@ Docker image and Helm chart registry paths are separated by artifact lifecycle.
 
 | Artifact type | Flow | Registry path |
 | --- | --- | --- |
-| Docker images | `-dev.N` and final `x.y.z` | `ghcr.io/cnoe-io/<image>` |
-| Docker images | `-rc.N` and `-hotfix.N` | `ghcr.io/cnoe-io/pre-release/<image>` |
-| Docker images | `prebuild/*` branches | `ghcr.io/cnoe-io/prebuild/<image>` |
-| Helm charts | final `x.y.z` | `ghcr.io/cnoe-io/charts` |
-| Helm charts | prerelease and chart-only tags | `ghcr.io/cnoe-io/pre-release-helm-charts` |
-| Helm charts | prebuild PR testing | `ghcr.io/cnoe-io/prebuild-helm-charts` |
+| Docker images | `-dev.N` and final `x.y.z` | `ghcr.io/caipe-io/<image>` |
+| Docker images | `-rc.N` and `-hotfix.N` | `ghcr.io/caipe-io/pre-release/<image>` |
+| Docker images | `prebuild/*` branches | `ghcr.io/caipe-io/prebuild/<image>` |
+| Helm charts | final `x.y.z` | `ghcr.io/caipe-io/charts` |
+| Helm charts | prerelease and chart-only tags | `ghcr.io/caipe-io/pre-release-helm-charts` |
+| Helm charts | prebuild PR testing | `ghcr.io/caipe-io/prebuild-helm-charts` |
 
 ## PR Flow
 
@@ -119,7 +119,7 @@ Use prebuilds when you want to test Docker images or Helm charts without waiting
 1. Create a branch called `prebuild/*` e.g. `prebuild/feat/add-feature-A
 2. Open a PR from the prebuild branch to the intended target branch (this can be any).
 3. THe `pr-version-bump.yml` workflow detects the `prebuild/*` source branch and dispatches a prebuild workflow (as well as the normal version bump flow if the target branch is `main` or `release/**`).
-4. The prebuild workflow builds and publishes images to `ghcr.io/cnoe-io/prebuild/<image>` and charts to `ghcr.io/cnoe-io/prebuild-charts` with a tag matching the branch name *Note: only changed images / charts are built*.
+4. The prebuild workflow builds and publishes images to `ghcr.io/caipe-io/prebuild/<image>` and charts to `ghcr.io/caipe-io/prebuild-charts` with a tag matching the branch name *Note: only changed images / charts are built*.
 5. Each new commit to the prebuild branch triggers a new prebuild with the same tag, overwriting the previous prebuild artifacts.
 6. Use the prebuild artifacts for testing.
 7. Upon PR merge or closure, all prebuild artifacts with the branch tag are automatically deleted.
@@ -136,9 +136,9 @@ Use a `release/x.y.z` branch when preparing a new release.
 6. Tag pushes trigger Docker and Helm CI.
 7. Test the published RC artifacts from GHCR.
 
-RC Docker images are under `ghcr.io/cnoe-io/pre-release/<image>`.
+RC Docker images are under `ghcr.io/caipe-io/pre-release/<image>`.
 
-RC Helm charts are under `ghcr.io/cnoe-io/pre-release-helm-charts`.
+RC Helm charts are under `ghcr.io/caipe-io/pre-release-helm-charts`.
 
 ## Final Release Flow
 

--- a/docs/docs/development/index.md
+++ b/docs/docs/development/index.md
@@ -71,8 +71,8 @@ See the full badge guide and how to claim yours → [Contributing & Badges](../c
 
 ## 🤝 Getting Help
 
-- **Issues**: [GitHub Issues](https://github.com/cnoe-io/ai-platform-engineering/issues)
-- **Discussions**: [GitHub Discussions](https://github.com/cnoe-io/ai-platform-engineering/discussions)
+- **Issues**: [GitHub Issues](https://github.com/caipe-io/ai-platform-engineering/issues)
+- **Discussions**: [GitHub Discussions](https://github.com/caipe-io/ai-platform-engineering/discussions)
 - **Community**: [CNOE Community Meetings](../community/index.md)
 - **Slack**: Join our [CNOE Slack](https://slack.cnoe.io)
 

--- a/docs/docs/development/spec-driven-development.md
+++ b/docs/docs/development/spec-driven-development.md
@@ -79,11 +79,11 @@ Agents read these files at the start of every session to load project context:
 
 | File | Purpose |
 |------|---------|
-| [`.specify/memory/constitution.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/memory/constitution.md) | Governing principles (10 core principles) |
-| [`.specify/ARCHITECTURE.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/ARCHITECTURE.md) | Repo layout, key decisions, data flow |
-| [`.specify/TESTING.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/TESTING.md) | 7-gate quality framework |
-| [`.specify/SKILLS.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/SKILLS.md) | Skills inventory and sourcing policy |
-| [`.specify/SPECS.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/SPECS.md) | Spec/plan conventions and lifecycle |
+| [`.specify/memory/constitution.md`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.specify/memory/constitution.md) | Governing principles (10 core principles) |
+| [`.specify/ARCHITECTURE.md`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.specify/ARCHITECTURE.md) | Repo layout, key decisions, data flow |
+| [`.specify/TESTING.md`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.specify/TESTING.md) | 7-gate quality framework |
+| [`.specify/SKILLS.md`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.specify/SKILLS.md) | Skills inventory and sourcing policy |
+| [`.specify/SPECS.md`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.specify/SPECS.md) | Spec/plan conventions and lifecycle |
 
 ## Quick start: your first feature
 
@@ -204,7 +204,7 @@ prebuild/docs/update-architecture  # Documentation
 prebuild/chore/dependency-update   # Maintenance
 ```
 
-Branches without the `prebuild/` prefix will **not** produce testable Docker images or Helm charts. See the [Constitution](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/memory/constitution.md) for full CI pipeline details.
+Branches without the `prebuild/` prefix will **not** produce testable Docker images or Helm charts. See the [Constitution](https://github.com/caipe-io/ai-platform-engineering/blob/main/.specify/memory/constitution.md) for full CI pipeline details.
 
 ## Bug handling
 
@@ -245,7 +245,7 @@ make test            # Backend, runtime, and integration tests
 make caipe-ui-tests  # UI Jest tests
 ```
 
-See [`.specify/TESTING.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/TESTING.md) for the complete 7-gate quality framework.
+See [`.specify/TESTING.md`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.specify/TESTING.md) for the complete 7-gate quality framework.
 
 ## Agent autonomy levels
 
@@ -268,5 +268,5 @@ Based on [The 8 Levels of Agentic Engineering](https://www.bassimeledath.com/blo
 - [Spec-Driven Development](https://github.com/github/spec-kit/blob/main/spec-driven.md) — the methodology CAIPE implements
 - [agentskills.io](https://agentskills.io/specification) — the skills standard
 - [spec-kit](https://github.com/github/spec-kit) — the upstream framework
-- [`.specify/memory/constitution.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.specify/memory/constitution.md) — CAIPE's governing principles
+- [`.specify/memory/constitution.md`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.specify/memory/constitution.md) — CAIPE's governing principles
 - [Contributing Guide](../contributing/index.md) — contribution workflow and standards

--- a/docs/docs/evaluations/ui-performance-benchmark-results.md
+++ b/docs/docs/evaluations/ui-performance-benchmark-results.md
@@ -249,8 +249,8 @@ Runtime:
 | Item | Value |
 |------|-------|
 | Compose file | `docker-compose.dev.yaml` |
-| UI image | `ghcr.io/cnoe-io/caipe-ui:branch-s3-perf-prod` |
-| Audit image | `ghcr.io/cnoe-io/caipe-audit-service:branch-s3-perf` |
+| UI image | `ghcr.io/caipe-io/caipe-ui:branch-s3-perf-prod` |
+| Audit image | `ghcr.io/caipe-io/caipe-audit-service:branch-s3-perf` |
 | Audit mode | `AUDIT_LOG_BACKEND=service` |
 | Audit service backend | `AUDIT_SERVICE_BACKEND=s3` |
 | Users | 1,000 virtual HTTP users |

--- a/docs/docs/features/custom-agents.md
+++ b/docs/docs/features/custom-agents.md
@@ -18,7 +18,7 @@ Dynamic Agents is the chat runtime and agent-builder service.
 - MCP tool support: connect registered MCP servers over `stdio` or streamable `http`
 - Built-in tools include URL fetch, current datetime, user info, wait, and approved workflow execution
 - REST + SSE API for browser, bot, workflow, and service callers
-- Deploy via Helm: `oci://ghcr.io/cnoe-io/charts/dynamic-agents`
+- Deploy via Helm: `oci://ghcr.io/caipe-io/charts/dynamic-agents`
 
 ## Agent Builder UI
 

--- a/docs/docs/getting-started/docker-compose/configure-llms.md
+++ b/docs/docs/getting-started/docker-compose/configure-llms.md
@@ -6,7 +6,7 @@ sidebar_position: 3
 
 CAIPE leverages the [`cnoe-io/cnoe-agent-utils`](https://github.com/cnoe-io/cnoe-agent-utils) utility library to configure the `LLMFactory` class, enabling dynamic switching between LLM providers.
 
-> Refer to the [.env.example](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.env.example) file for sample environment variable configurations.
+> Refer to the [.env.example](https://github.com/caipe-io/ai-platform-engineering/blob/main/.env.example) file for sample environment variable configurations.
 
 ## 🧑‍💻 LLM Provider Usage
 

--- a/docs/docs/getting-started/docker-compose/setup.md
+++ b/docs/docs/getting-started/docker-compose/setup.md
@@ -16,7 +16,7 @@ servers, MongoDB, RBAC services, and optional RAG/tracing components.
 ## Configure
 
 ```bash
-git clone https://github.com/cnoe-io/ai-platform-engineering.git
+git clone https://github.com/caipe-io/ai-platform-engineering.git
 cd ai-platform-engineering
 cp .env.example .env
 ```

--- a/docs/docs/getting-started/eks/setup.md
+++ b/docs/docs/getting-started/eks/setup.md
@@ -17,7 +17,7 @@ This guide walks you through creating an **Amazon EKS** (Elastic Kubernetes Serv
 You need the repo to use the EKS cluster configuration example and to follow the same paths as this guide.
 
 ```bash
-git clone https://github.com/cnoe-io/ai-platform-engineering.git
+git clone https://github.com/caipe-io/ai-platform-engineering.git
 cd ai-platform-engineering
 ```
 
@@ -115,7 +115,7 @@ You have two main options:
 Install the CAIPE Helm chart directly on the cluster. Configure secrets and LLM settings as described in the Helm guide.
 
 ```bash
-helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+helm install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version 0.2.8 \
   --namespace ai-platform-engineering \
   --create-namespace \

--- a/docs/docs/getting-started/helm/cluster-setup.md
+++ b/docs/docs/getting-started/helm/cluster-setup.md
@@ -52,7 +52,7 @@ export AWS_DEFAULT_REGION=us-east-2
 ### Create the cluster
 
 ```bash
-git clone https://github.com/cnoe-io/ai-platform-engineering.git
+git clone https://github.com/caipe-io/ai-platform-engineering.git
 cd ai-platform-engineering
 cp deploy/eks/dev-eks-cluster-config.yaml.example dev-eks-cluster-config.yaml
 

--- a/docs/docs/getting-started/helm/setup.md
+++ b/docs/docs/getting-started/helm/setup.md
@@ -94,7 +94,7 @@ export CAIPE_VERSION=<release-version>
 Minimal install — UI, Dynamic Agents, MongoDB, and a starter MCP server:
 
 ```bash
-helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+helm install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version "${CAIPE_VERSION}" \
   --namespace ai-platform-engineering \
   --create-namespace \
@@ -106,7 +106,7 @@ helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-en
 With GitHub, ArgoCD, and RAG:
 
 ```bash
-helm upgrade --install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+helm upgrade --install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version "${CAIPE_VERSION}" \
   --namespace ai-platform-engineering \
   --create-namespace \
@@ -145,7 +145,7 @@ caipe-ui:
 ```
 
 ```bash
-helm upgrade --install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+helm upgrade --install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version "${CAIPE_VERSION}" \
   --namespace ai-platform-engineering \
   --create-namespace \

--- a/docs/docs/getting-started/kind/setup.md
+++ b/docs/docs/getting-started/kind/setup.md
@@ -15,12 +15,12 @@ This guide gets you from zero to a running **CAIPE** (Community AI Platform Engi
 No clone required. Run this in your terminal and follow the prompts:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh | bash
+curl -fsSL https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/setup-caipe.sh | bash
 ```
 
 The interactive script will ask for your LLM provider, API key, and optional components (RAG, tracing, persistence). That's it.
 
-> **Want to inspect the script first?** View it at [`setup-caipe.sh`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/setup-caipe.sh) before running.
+> **Want to inspect the script first?** View it at [`setup-caipe.sh`](https://github.com/caipe-io/ai-platform-engineering/blob/main/setup-caipe.sh) before running.
 
 <iframe src="https://asciinema.org/a/845278/iframe" width="100%" height="600" style={{border: 'none', borderRadius: '8px', overflow: 'hidden'}} scrolling="no" allowFullScreen />
 

--- a/docs/docs/getting-started/next-steps.md
+++ b/docs/docs/getting-started/next-steps.md
@@ -8,7 +8,7 @@ You have just learned the **basics of CAIPE (Community AI Platform Engineering)*
 
 CAIPE has **much more to offer**!
 
-Anything **unclear** or **buggy** in this tutorial? [Please report it!](https://github.com/cnoe-io/ai-platform-engineering/issues)
+Anything **unclear** or **buggy** in this tutorial? [Please report it!](https://github.com/caipe-io/ai-platform-engineering/issues)
 
 ## What's next?
 

--- a/docs/docs/getting-started/quick-start.md
+++ b/docs/docs/getting-started/quick-start.md
@@ -9,12 +9,12 @@ sidebar_position: 2
 No clone required. Run this in your terminal and follow the interactive prompts:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh | bash
+curl -fsSL https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/setup-caipe.sh | bash
 ```
 
 The script asks for your LLM provider, API key, and optional components (RAG, tracing, persistence). It creates a local KinD cluster or deploys to an existing one.
 
-> **Want to inspect the script first?** View [`setup-caipe.sh`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/setup-caipe.sh) on GitHub before running.
+> **Want to inspect the script first?** View [`setup-caipe.sh`](https://github.com/caipe-io/ai-platform-engineering/blob/main/setup-caipe.sh) on GitHub before running.
 
 <iframe src="https://asciinema.org/a/845278/iframe" width="100%" height="600" style={{border: 'none', borderRadius: '8px', overflow: 'hidden'}} scrolling="no" allowFullScreen />
 

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/agentgateway.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/agentgateway.md
@@ -21,10 +21,10 @@ AgentGateway standalone proxy for CAIPE MCP traffic
 
 ```bash
 # Add and install the chart
-helm install agentgateway oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68
+helm install agentgateway oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade agentgateway oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68
+helm upgrade agentgateway oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install agentgateway oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68 \
+helm install agentgateway oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install agentgateway oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68 \
+helm install agentgateway oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/agentgateway --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/agentgateway --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/audit-service.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/audit-service.md
@@ -21,10 +21,10 @@ Lightweight CAIPE audit log read/write service
 
 ```bash
 # Add and install the chart
-helm install audit-service oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
+helm install audit-service oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade audit-service oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
+helm upgrade audit-service oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install audit-service oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68 \
+helm install audit-service oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install audit-service oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68 \
+helm install audit-service oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/audit-service --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -63,7 +63,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/audit-service --version 0.5.68
 | extraEnvFrom | list | `[]` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-audit-service"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-audit-service"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | livenessProbe.failureThreshold | int | `3` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/autonomous-agents.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/autonomous-agents.md
@@ -21,10 +21,10 @@ A Helm chart for Autonomous Agents - Standalone scheduler that fires tasks (cron
 
 ```bash
 # Add and install the chart
-helm install autonomous-agents oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1
+helm install autonomous-agents oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1
 
 # Upgrade an existing release
-helm upgrade autonomous-agents oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1
+helm upgrade autonomous-agents oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install autonomous-agents oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1 \
+helm install autonomous-agents oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install autonomous-agents oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1 \
+helm install autonomous-agents oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10-dev.1
+helm show values oci://ghcr.io/caipe-io/charts/autonomous-agents --version 0.4.10-dev.1
 ```
 
 ## Reading the Values Table
@@ -72,7 +72,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/autonomous-agents --version 0.4.10
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-autonomous-agents"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-autonomous-agents"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/caipe-ui-mongodb.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/caipe-ui-mongodb.md
@@ -21,10 +21,10 @@ MongoDB database for CAIPE UI persistence
 
 ```bash
 # Add and install the chart
-helm install caipe-ui-mongodb oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68
+helm install caipe-ui-mongodb oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade caipe-ui-mongodb oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68
+helm upgrade caipe-ui-mongodb oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install caipe-ui-mongodb oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68 \
+helm install caipe-ui-mongodb oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install caipe-ui-mongodb oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68 \
+helm install caipe-ui-mongodb oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui-mongodb --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/caipe-ui-mongodb --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/caipe-ui.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/caipe-ui.md
@@ -21,10 +21,10 @@ A Helm chart for CAIPE UI - chat interface for AI Platform Engineering
 
 ```bash
 # Add and install the chart
-helm install caipe-ui oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
+helm install caipe-ui oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade caipe-ui oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
+helm upgrade caipe-ui oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install caipe-ui oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68 \
+helm install caipe-ui oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install caipe-ui oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68 \
+helm install caipe-ui oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/caipe-ui --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -132,7 +132,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/caipe-ui --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-ui"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-ui"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/dynamic-agents.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/dynamic-agents.md
@@ -21,10 +21,10 @@ A Helm chart for Dynamic Agents - Standalone agent builder service with MCP tool
 
 ```bash
 # Add and install the chart
-helm install dynamic-agents oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
+helm install dynamic-agents oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade dynamic-agents oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
+helm upgrade dynamic-agents oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install dynamic-agents oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68 \
+helm install dynamic-agents oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install dynamic-agents oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68 \
+helm install dynamic-agents oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/dynamic-agents --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -91,7 +91,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/dynamic-agents --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-dynamic-agents"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-dynamic-agents"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/index.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/index.md
@@ -21,10 +21,10 @@ Parent chart to deploy CAIPE — dynamic agents, per-agent MCP servers, RBAC, an
 
 ```bash
 # Add and install the chart
-helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68
+helm install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68
+helm upgrade ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68 \
+helm install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install ai-platform-engineering oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68 \
+helm install ai-platform-engineering oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -120,7 +120,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | caipe-ui.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | caipe-ui.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | caipe-ui.image.pullPolicy | string | `"IfNotPresent"` |  |
-| caipe-ui.image.repository | string | `"ghcr.io/cnoe-io/caipe-ui"` |  |
+| caipe-ui.image.repository | string | `"ghcr.io/caipe-io/caipe-ui"` |  |
 | caipe-ui.image.tag | string | `""` |  |
 | caipe-ui.ingress.annotations | object | `{}` |  |
 | caipe-ui.ingress.className | string | `"nginx"` |  |
@@ -191,7 +191,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | dynamic-agents.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | dynamic-agents.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | dynamic-agents.image.pullPolicy | string | `"IfNotPresent"` |  |
-| dynamic-agents.image.repository | string | `"ghcr.io/cnoe-io/caipe-dynamic-agents"` |  |
+| dynamic-agents.image.repository | string | `"ghcr.io/caipe-io/caipe-dynamic-agents"` |  |
 | dynamic-agents.image.tag | string | `""` |  |
 | dynamic-agents.nameOverride | string | `"dynamic-agents"` |  |
 | dynamic-agents.service.metricsPort | int | `0` |  |
@@ -225,7 +225,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | global.agentgateway.static.configBridge.enabled | bool | `true` |  |
 | global.agentgateway.static.configBridge.extraEnv | list | `[]` |  |
 | global.agentgateway.static.configBridge.image.pullPolicy | string | `"IfNotPresent"` |  |
-| global.agentgateway.static.configBridge.image.repository | string | `"ghcr.io/cnoe-io/agentgateway-config-bridge"` |  |
+| global.agentgateway.static.configBridge.image.repository | string | `"ghcr.io/caipe-io/agentgateway-config-bridge"` |  |
 | global.agentgateway.static.configBridge.image.tag | string | `""` |  |
 | global.agentgateway.static.configBridge.pollSeconds | int | `5` |  |
 | global.agentgateway.static.configBridge.ui.existingSecret.key | string | `"AGENTGATEWAY_TARGETS_TOKEN"` |  |
@@ -328,7 +328,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | litellmMcp.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | litellmMcp.fullnameOverride | string | `""` |  |
 | litellmMcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| litellmMcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-litellm"` |  |
+| litellmMcp.image.repository | string | `"ghcr.io/caipe-io/mcp-litellm"` |  |
 | litellmMcp.image.tag | string | `""` |  |
 | litellmMcp.imagePullSecrets | list | `[]` |  |
 | litellmMcp.livenessProbe.failureThreshold | int | `3` |  |
@@ -357,11 +357,11 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | litellmMcp.service.type | string | `"ClusterIP"` |  |
 | litellmMcp.tolerations | list | `[]` |  |
 | mcp-argocd.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-argocd.image.repository | string | `"ghcr.io/cnoe-io/mcp-argocd"` |  |
+| mcp-argocd.image.repository | string | `"ghcr.io/caipe-io/mcp-argocd"` |  |
 | mcp-argocd.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-argocd.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-argocd.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-argocd.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-argocd"` |  |
+| mcp-argocd.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-argocd"` |  |
 | mcp-argocd.mcp.image.tag | string | `""` |  |
 | mcp-argocd.mcp.mode | string | `"http"` |  |
 | mcp-argocd.mcp.port | int | `8000` |  |
@@ -373,27 +373,27 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-aws.env.RESTRICT_KUBECTL_PROXY | string | `"true"` | Block kubectl proxy, which exposes the entire Kubernetes API server. Defaults to true (on). |
 | mcp-aws.env.RESTRICT_KUBECTL_SECRETS | string | `"true"` | Block kubectl get/describe secret(s) and redact Secret data from output. Defaults to true (on). |
 | mcp-aws.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-aws.image.repository | string | `"ghcr.io/cnoe-io/agent-aws"` |  |
+| mcp-aws.image.repository | string | `"ghcr.io/caipe-io/agent-aws"` |  |
 | mcp-aws.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-aws.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-aws.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-aws.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-aws"` |  |
+| mcp-aws.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-aws"` |  |
 | mcp-aws.mcp.image.tag | string | `""` |  |
 | mcp-aws.mcp.mode | string | `"http"` |  |
 | mcp-aws.mcp.port | int | `8000` |  |
 | mcp-aws.nameOverride | string | `"mcp-aws"` |  |
 | mcp-backstage.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-backstage.image.repository | string | `"ghcr.io/cnoe-io/agent-backstage"` |  |
+| mcp-backstage.image.repository | string | `"ghcr.io/caipe-io/agent-backstage"` |  |
 | mcp-backstage.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-backstage.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-backstage.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-backstage.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-backstage"` |  |
+| mcp-backstage.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-backstage"` |  |
 | mcp-backstage.mcp.image.tag | string | `""` |  |
 | mcp-backstage.mcp.mode | string | `"http"` |  |
 | mcp-backstage.mcp.port | int | `8000` |  |
 | mcp-backstage.nameOverride | string | `"mcp-backstage"` |  |
 | mcp-confluence.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-confluence.image.repository | string | `"ghcr.io/cnoe-io/agent-confluence"` |  |
+| mcp-confluence.image.repository | string | `"ghcr.io/caipe-io/agent-confluence"` |  |
 | mcp-confluence.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-confluence.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-confluence.mcp.env.TRANSPORT | string | `"streamable-http"` |  |
@@ -404,7 +404,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-confluence.mcp.port | int | `8000` |  |
 | mcp-confluence.nameOverride | string | `"mcp-confluence"` |  |
 | mcp-github.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-github.image.repository | string | `"ghcr.io/cnoe-io/mcp-github"` |  |
+| mcp-github.image.repository | string | `"ghcr.io/caipe-io/mcp-github"` |  |
 | mcp-github.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-github.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-github.mcp.agentgateway.providerTokenAuth | bool | `true` |  |
@@ -416,7 +416,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-gitlab.env.GIT_COMMITTER_EMAIL | string | `"ai-agent@cnoe.io"` |  |
 | mcp-gitlab.env.GIT_COMMITTER_NAME | string | `"AI Agent"` |  |
 | mcp-gitlab.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-gitlab.image.repository | string | `"ghcr.io/cnoe-io/agent-gitlab"` |  |
+| mcp-gitlab.image.repository | string | `"ghcr.io/caipe-io/agent-gitlab"` |  |
 | mcp-gitlab.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-gitlab.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-gitlab.mcp.agentgateway.providerTokenAuth | bool | `true` |  |
@@ -434,48 +434,48 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-gitlab.mcp.port | int | `8000` |  |
 | mcp-gitlab.nameOverride | string | `"mcp-gitlab"` |  |
 | mcp-jira.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-jira.image.repository | string | `"ghcr.io/cnoe-io/agent-jira"` |  |
+| mcp-jira.image.repository | string | `"ghcr.io/caipe-io/agent-jira"` |  |
 | mcp-jira.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-jira.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-jira.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-jira.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-jira"` |  |
+| mcp-jira.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-jira"` |  |
 | mcp-jira.mcp.image.tag | string | `""` |  |
 | mcp-jira.mcp.mode | string | `"http"` |  |
 | mcp-jira.mcp.port | int | `8000` |  |
 | mcp-jira.nameOverride | string | `"mcp-jira"` |  |
 | mcp-komodor.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-komodor.image.repository | string | `"ghcr.io/cnoe-io/agent-komodor"` |  |
+| mcp-komodor.image.repository | string | `"ghcr.io/caipe-io/agent-komodor"` |  |
 | mcp-komodor.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-komodor.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-komodor.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-komodor.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-komodor"` |  |
+| mcp-komodor.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-komodor"` |  |
 | mcp-komodor.mcp.image.tag | string | `""` |  |
 | mcp-komodor.mcp.mode | string | `"http"` |  |
 | mcp-komodor.mcp.port | int | `8000` |  |
 | mcp-komodor.nameOverride | string | `"mcp-komodor"` |  |
 | mcp-netutils.agentSecrets.requiresSecret | bool | `false` |  |
 | mcp-netutils.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-netutils.image.repository | string | `"ghcr.io/cnoe-io/agent-netutils"` |  |
+| mcp-netutils.image.repository | string | `"ghcr.io/caipe-io/agent-netutils"` |  |
 | mcp-netutils.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-netutils.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-netutils.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-netutils.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-netutils"` |  |
+| mcp-netutils.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-netutils"` |  |
 | mcp-netutils.mcp.image.tag | string | `""` |  |
 | mcp-netutils.mcp.mode | string | `"http"` |  |
 | mcp-netutils.mcp.port | int | `8000` |  |
 | mcp-netutils.nameOverride | string | `"mcp-netutils"` |  |
 | mcp-pagerduty.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-pagerduty.image.repository | string | `"ghcr.io/cnoe-io/agent-pagerduty"` |  |
+| mcp-pagerduty.image.repository | string | `"ghcr.io/caipe-io/agent-pagerduty"` |  |
 | mcp-pagerduty.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-pagerduty.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-pagerduty.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-pagerduty.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-pagerduty"` |  |
+| mcp-pagerduty.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-pagerduty"` |  |
 | mcp-pagerduty.mcp.image.tag | string | `""` |  |
 | mcp-pagerduty.mcp.mode | string | `"http"` |  |
 | mcp-pagerduty.mcp.port | int | `8000` |  |
 | mcp-pagerduty.nameOverride | string | `"mcp-pagerduty"` |  |
 | mcp-slack.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-slack.image.repository | string | `"ghcr.io/cnoe-io/agent-slack"` |  |
+| mcp-slack.image.repository | string | `"ghcr.io/caipe-io/agent-slack"` |  |
 | mcp-slack.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-slack.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-slack.mcp.command[0] | string | `"--transport"` |  |
@@ -489,21 +489,21 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-slack.mcp.port | int | `3001` |  |
 | mcp-slack.nameOverride | string | `"mcp-slack"` |  |
 | mcp-splunk.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-splunk.image.repository | string | `"ghcr.io/cnoe-io/agent-splunk"` |  |
+| mcp-splunk.image.repository | string | `"ghcr.io/caipe-io/agent-splunk"` |  |
 | mcp-splunk.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-splunk.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-splunk.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-splunk.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-splunk"` |  |
+| mcp-splunk.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-splunk"` |  |
 | mcp-splunk.mcp.image.tag | string | `""` |  |
 | mcp-splunk.mcp.mode | string | `"http"` |  |
 | mcp-splunk.mcp.port | int | `8000` |  |
 | mcp-splunk.nameOverride | string | `"mcp-splunk"` |  |
 | mcp-victorops.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-victorops.image.repository | string | `"ghcr.io/cnoe-io/agent-victorops"` |  |
+| mcp-victorops.image.repository | string | `"ghcr.io/caipe-io/agent-victorops"` |  |
 | mcp-victorops.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-victorops.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-victorops.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-victorops.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-victorops"` |  |
+| mcp-victorops.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-victorops"` |  |
 | mcp-victorops.mcp.image.tag | string | `""` |  |
 | mcp-victorops.mcp.mode | string | `"http"` |  |
 | mcp-victorops.mcp.port | int | `8000` |  |
@@ -517,18 +517,18 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | mcp-webex-meetings.mcp.agentgateway.pathPrefix | string | `"/mcp/webex_meetings"` |  |
 | mcp-webex-meetings.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-webex-meetings.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex-meetings.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-webex-meetings"` |  |
+| mcp-webex-meetings.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-webex-meetings"` |  |
 | mcp-webex-meetings.mcp.image.tag | string | `""` |  |
 | mcp-webex-meetings.mcp.mode | string | `"http"` |  |
 | mcp-webex-meetings.mcp.port | int | `8000` |  |
 | mcp-webex-meetings.mcpSecrets.requiresSecret | bool | `false` |  |
 | mcp-webex-meetings.nameOverride | string | `"mcp-webex-meetings"` |  |
 | mcp-webex.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex.image.repository | string | `"ghcr.io/cnoe-io/agent-webex"` |  |
+| mcp-webex.image.repository | string | `"ghcr.io/caipe-io/agent-webex"` |  |
 | mcp-webex.mcp.agentgateway.enabled | bool | `false` |  |
 | mcp-webex.mcp.agentgateway.protocol | string | `"StreamableHTTP"` |  |
 | mcp-webex.mcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| mcp-webex.mcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-webex"` |  |
+| mcp-webex.mcp.image.repository | string | `"ghcr.io/caipe-io/mcp-webex"` |  |
 | mcp-webex.mcp.image.tag | string | `""` |  |
 | mcp-webex.mcp.mode | string | `"http"` |  |
 | mcp-webex.mcp.port | int | `8000` |  |
@@ -550,7 +550,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | openfga-authz-bridge.audit.subjectSalt | string | `"caipe-098-audit"` |  |
 | openfga-authz-bridge.audit.tenantId | string | `"default"` |  |
 | openfga-authz-bridge.image.pullPolicy | string | `"IfNotPresent"` |  |
-| openfga-authz-bridge.image.repository | string | `"ghcr.io/cnoe-io/openfga-authz-bridge"` |  |
+| openfga-authz-bridge.image.repository | string | `"ghcr.io/caipe-io/openfga-authz-bridge"` |  |
 | openfga-authz-bridge.image.tag | string | `""` |  |
 | openfga-authz-bridge.openfga.httpUrl | string | `""` |  |
 | openfga-authz-bridge.openfga.object | string | `"mcp_gateway:list"` |  |
@@ -578,7 +578,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | rag-stack.agent-ontology.enabled | bool | `true` |  |
 | rag-stack.agent-rag.enabled | bool | `true` |  |
 | rag-stack.agent-rag.image.pullPolicy | string | `"IfNotPresent"` |  |
-| rag-stack.agent-rag.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-rag"` |  |
+| rag-stack.agent-rag.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-rag"` |  |
 | rag-stack.agent-rag.image.tag | string | `""` |  |
 | rag-stack.milvus.enabled | bool | `true` |  |
 | rag-stack.neo4j.enabled | bool | `true` |  |
@@ -591,18 +591,18 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | rag-stack.rag-server.env.CAIPE_UNSAFE_RBAC_BYPASS | string | `"false"` |  |
 | rag-stack.rag-server.env.OPENFGA_STORE_NAME | string | `"caipe-openfga"` |  |
 | rag-stack.rag-server.image.pullPolicy | string | `"IfNotPresent"` |  |
-| rag-stack.rag-server.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| rag-stack.rag-server.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | rag-stack.rag-server.image.tag | string | `""` |  |
 | scheduler.args | list | `[]` |  |
 | scheduler.caipe.apiUrl | string | `"http://{{ .Release.Name }}-caipe-ui:3000"` |  |
 | scheduler.caipe.chatPath | string | `"/api/v1/chat/invoke"` |  |
 | scheduler.command | list | `[]` |  |
 | scheduler.cronRunner.image.pullPolicy | string | `"IfNotPresent"` |  |
-| scheduler.cronRunner.image.repository | string | `"ghcr.io/cnoe-io/caipe-cron-runner"` |  |
+| scheduler.cronRunner.image.repository | string | `"ghcr.io/caipe-io/caipe-cron-runner"` |  |
 | scheduler.cronRunner.image.tag | string | `""` |  |
 | scheduler.fullnameOverride | string | `"caipe-scheduler"` |  |
 | scheduler.image.pullPolicy | string | `"IfNotPresent"` |  |
-| scheduler.image.repository | string | `"ghcr.io/cnoe-io/caipe-scheduler"` |  |
+| scheduler.image.repository | string | `"ghcr.io/caipe-io/caipe-scheduler"` |  |
 | scheduler.image.tag | string | `""` |  |
 | scheduler.mongo.database | string | `"caipe"` |  |
 | scheduler.mongo.existingSecret | string | `""` |  |
@@ -622,7 +622,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | schedulerMcp.env.MCP_PORT | string | `"8000"` |  |
 | schedulerMcp.env.SCHEDULER_URL | string | `"http://caipe-scheduler:8080"` |  |
 | schedulerMcp.image.pullPolicy | string | `"IfNotPresent"` |  |
-| schedulerMcp.image.repository | string | `"ghcr.io/cnoe-io/mcp-scheduler"` |  |
+| schedulerMcp.image.repository | string | `"ghcr.io/caipe-io/mcp-scheduler"` |  |
 | schedulerMcp.image.tag | string | `""` |  |
 | schedulerMcp.nameOverride | string | `"mcp-scheduler"` |  |
 | schedulerMcp.resources | object | `{}` |  |
@@ -634,7 +634,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | slack-bot.existingSecret | string | `"slack-bot-secrets"` | Reference to a pre-existing Kubernetes Secret. Should contain: SLACK_BOT_TOKEN, SLACK_APP_TOKEN, SLACK_SIGNING_SECRET, and optionally OAUTH2_CLIENT_SECRET. |
 | slack-bot.externalSecrets | object | `{"apiVersion":"v1beta1","data":[],"enabled":false,"secretStoreRef":{"kind":"ClusterSecretStore","name":"vault"}}` | External Secrets configuration for sensitive data |
 | slack-bot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| slack-bot.image.repository | string | `"ghcr.io/cnoe-io/caipe-slack-bot"` |  |
+| slack-bot.image.repository | string | `"ghcr.io/caipe-io/caipe-slack-bot"` |  |
 | slack-bot.image.tag | string | `""` |  |
 | slack-bot.resources.limits.cpu | string | `"500m"` |  |
 | slack-bot.resources.limits.memory | string | `"512Mi"` |  |
@@ -690,7 +690,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version 
 | webex-bot.externalSecrets.secretStoreRef.kind | string | `"ClusterSecretStore"` |  |
 | webex-bot.externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | webex-bot.image.pullPolicy | string | `"IfNotPresent"` |  |
-| webex-bot.image.repository | string | `"ghcr.io/cnoe-io/caipe-webex-bot"` |  |
+| webex-bot.image.repository | string | `"ghcr.io/caipe-io/caipe-webex-bot"` |  |
 | webex-bot.image.tag | string | `""` |  |
 | webex-bot.keycloakBot.clientSecretFromSecret.key | string | `"KC_WEBEX_BOT_CLIENT_SECRET"` |  |
 | webex-bot.keycloakBot.clientSecretFromSecret.name | string | `""` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/keycloak.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/keycloak.md
@@ -21,10 +21,10 @@ Keycloak identity provider for CAIPE RBAC, token exchange, and identity federati
 
 ```bash
 # Add and install the chart
-helm install keycloak oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
+helm install keycloak oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade keycloak oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
+helm upgrade keycloak oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install keycloak oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68 \
+helm install keycloak oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install keycloak oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68 \
+helm install keycloak oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/keycloak --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -146,7 +146,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/keycloak --version 0.5.68
 | ingress.hosts[0].paths[1].pathType | string | `"Prefix"` |  |
 | ingress.tls | list | `[]` |  |
 | initImage.pullPolicy | string | `"IfNotPresent"` |  |
-| initImage.repository | string | `"ghcr.io/cnoe-io/keycloak-init"` |  |
+| initImage.repository | string | `"ghcr.io/caipe-io/keycloak-init"` |  |
 | initImage.tag | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/mcp-server.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/mcp-server.md
@@ -21,10 +21,10 @@ Deploys one agent's MCP server (Deployment + Service) for CAIPE
 
 ```bash
 # Add and install the chart
-helm install mcp-server oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68
+helm install mcp-server oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade mcp-server oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68
+helm upgrade mcp-server oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install mcp-server oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68 \
+helm install mcp-server oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install mcp-server oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68 \
+helm install mcp-server oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/mcp-server --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/mcp-server --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/openfga-authz-bridge.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/openfga-authz-bridge.md
@@ -21,10 +21,10 @@ Envoy ext_authz bridge that adapts AgentGateway authorization checks to OpenFGA
 
 ```bash
 # Add and install the chart
-helm install openfga-authz-bridge oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68
+helm install openfga-authz-bridge oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade openfga-authz-bridge oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68
+helm upgrade openfga-authz-bridge oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install openfga-authz-bridge oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68 \
+helm install openfga-authz-bridge oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install openfga-authz-bridge oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68 \
+helm install openfga-authz-bridge oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/openfga-authz-bridge --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -67,7 +67,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/openfga-authz-bridge --version 0.5
 | callerToolCheck.enabled | bool | `false` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/openfga-authz-bridge"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/openfga-authz-bridge"` |  |
 | image.tag | string | `""` |  |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/openfga.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/openfga.md
@@ -21,10 +21,10 @@ OpenFGA authorization service for CAIPE relationship-based access control
 
 ```bash
 # Add and install the chart
-helm install openfga oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68
+helm install openfga oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade openfga oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68
+helm upgrade openfga oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install openfga oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68 \
+helm install openfga oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install openfga oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68 \
+helm install openfga oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/openfga --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/openfga --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/scheduler.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/scheduler.md
@@ -21,10 +21,10 @@ A Helm chart for caipe-scheduler - cron schedule registry + k8s CronJob orchestr
 
 ```bash
 # Add and install the chart
-helm install scheduler oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
+helm install scheduler oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade scheduler oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
+helm upgrade scheduler oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install scheduler oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68 \
+helm install scheduler oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install scheduler oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68 \
+helm install scheduler oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/scheduler --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -70,7 +70,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
 | caipe.apiUrl | string | `"http://caipe-ui:3000"` |  |
 | caipe.chatPath | string | `"/api/v1/chat/invoke"` |  |
 | cronRunner.image.pullPolicy | string | `"IfNotPresent"` |  |
-| cronRunner.image.repository | string | `"ghcr.io/cnoe-io/caipe-cron-runner"` |  |
+| cronRunner.image.repository | string | `"ghcr.io/caipe-io/caipe-cron-runner"` |  |
 | cronRunner.image.tag | string | `""` |  |
 | cronRunner.resources.limits.cpu | string | `"100m"` |  |
 | cronRunner.resources.limits.memory | string | `"128Mi"` |  |
@@ -80,7 +80,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/scheduler --version 0.5.68
 | cronRunnerServiceAccount.name | string | `"caipe-cron-runner"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-scheduler"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-scheduler"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | limits.maxMessageChars | int | `2000` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/skill-scanner.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/skill-scanner.md
@@ -24,10 +24,10 @@ cluster-internal (ClusterIP only — no Ingress).
 
 ```bash
 # Add and install the chart
-helm install skill-scanner oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
+helm install skill-scanner oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade skill-scanner oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
+helm upgrade skill-scanner oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68
 ```
 
 ## Customizing Values
@@ -36,15 +36,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install skill-scanner oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68 \
+helm install skill-scanner oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install skill-scanner oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68 \
+helm install skill-scanner oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/skill-scanner --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -63,7 +63,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/skill-scanner --version 0.5.68
 | affinity | object | `{}` | Pod affinity rules |
 | fullnameOverride | string | `""` | Override the full release name |
 | image.pullPolicy | string | `"IfNotPresent"` | Image pull policy |
-| image.repository | string | `"ghcr.io/cnoe-io/skill-scanner"` | Container image repository. Build via build/Dockerfile.skill-scanner and push to your registry; override in the parent values.yaml. |
+| image.repository | string | `"ghcr.io/caipe-io/skill-scanner"` | Container image repository. Build via build/Dockerfile.skill-scanner and push to your registry; override in the parent values.yaml. |
 | image.tag | string | `""` | Image tag. Defaults to the parent chart's appVersion. |
 | imagePullSecrets | list | `[]` | Image pull secrets for private registries |
 | livenessProbe | object | `{"failureThreshold":3,"httpGet":{"path":"/health","port":"http"},"initialDelaySeconds":0,"periodSeconds":20,"timeoutSeconds":3}` | Liveness probe — hits the FastAPI /health endpoint. |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/slack-bot.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/slack-bot.md
@@ -21,10 +21,10 @@ Slack bot integration for AI Platform Engineering using the CAIPE UI BFF
 
 ```bash
 # Add and install the chart
-helm install slack-bot oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
+helm install slack-bot oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade slack-bot oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
+helm upgrade slack-bot oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install slack-bot oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68 \
+helm install slack-bot oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install slack-bot oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68 \
+helm install slack-bot oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/slack-bot --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -64,7 +64,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/slack-bot --version 0.5.68
 | externalSecrets | object | `{"apiVersion":"v1beta1","data":[],"enabled":false,"secretStoreRef":{"kind":"ClusterSecretStore","name":"vault"}}` | External Secrets configuration for sensitive data (Slack tokens, OAuth2 client secret, etc.) |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-slack-bot"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-slack-bot"` |  |
 | image.tag | string | `""` |  |
 | keycloakBot | object | `{"clientSecretFromSecret":{"key":"KC_BOT_CLIENT_SECRET","name":""}}` | Cross-chart binding to the Keycloak bot client_secret used by the Slack bot's RFC 8693 OBO exchange helper. In umbrella installs this usually points at the same Secret/key as oauth2.clientSecretFromSecret. |
 | nameOverride | string | `""` |  |

--- a/docs/docs/installation/helm-charts/ai-platform-engineering/webex-bot.md
+++ b/docs/docs/installation/helm-charts/ai-platform-engineering/webex-bot.md
@@ -21,10 +21,10 @@ Webex bot integration for AI Platform Engineering using the CAIPE UI BFF
 
 ```bash
 # Add and install the chart
-helm install webex-bot oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
+helm install webex-bot oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade webex-bot oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
+helm upgrade webex-bot oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install webex-bot oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68 \
+helm install webex-bot oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install webex-bot oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68 \
+helm install webex-bot oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/webex-bot --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -69,7 +69,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/webex-bot --version 0.5.68
 | externalSecrets.secretStoreRef.name | string | `"vault"` |  |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"Always"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-webex-bot"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-webex-bot"` |  |
 | image.tag | string | `""` |  |
 | keycloakAdmin | object | `{"clientId":"","clientSecretFromSecret":{"key":"KC_PLATFORM_CLIENT_SECRET","name":""}}` | Keycloak Admin API credentials for webex_user_id lookups (typically caipe-platform). |
 | keycloakBot | object | `{"clientSecretFromSecret":{"key":"KC_WEBEX_BOT_CLIENT_SECRET","name":""}}` | Single source of truth: Keycloak chart Secret \{\{release\}\}-keycloak-webex-bot (KC_WEBEX_BOT_CLIENT_SECRET). |

--- a/docs/docs/installation/helm-charts/rag-stack/agent-ontology.md
+++ b/docs/docs/installation/helm-charts/rag-stack/agent-ontology.md
@@ -21,10 +21,10 @@ A Helm chart for Kubernetes
 
 ```bash
 # Add and install the chart
-helm install agent-ontology oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
+helm install agent-ontology oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade agent-ontology oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
+helm upgrade agent-ontology oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install agent-ontology oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68 \
+helm install agent-ontology oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install agent-ontology oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68 \
+helm install agent-ontology oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/agent-ontology --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -68,7 +68,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/agent-ontology --version 0.5.68
 | env | object | `{}` |  |
 | fullnameOverride | string | `"agent-ontology"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-ontology"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-ontology"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingress.annotations | object | `{}` |  |

--- a/docs/docs/installation/helm-charts/rag-stack/index.md
+++ b/docs/docs/installation/helm-charts/rag-stack/index.md
@@ -21,10 +21,10 @@ A complete RAG stack including server, agents, Redis, Neo4j and Milvus
 
 ```bash
 # Add and install the chart
-helm install rag-stack oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
+helm install rag-stack oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade rag-stack oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
+helm upgrade rag-stack oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install rag-stack oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68 \
+helm install rag-stack oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install rag-stack oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68 \
+helm install rag-stack oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/rag-stack --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -63,7 +63,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
 | agent-ontology.enabled | bool | `true` |  |
 | agent-ontology.fullnameOverride | string | `"agent-ontology"` |  |
 | agent-ontology.image.pullPolicy | string | `"Always"` |  |
-| agent-ontology.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-agent-ontology"` |  |
+| agent-ontology.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-agent-ontology"` |  |
 | agent-ontology.image.tag | string | `""` |  |
 | agent-ontology.livenessProbe.failureThreshold | int | `3` |  |
 | agent-ontology.livenessProbe.httpGet.path | string | `"/v1/graph/ontology/agent/status"` |  |
@@ -212,7 +212,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-stack --version 0.5.68
 | rag-server.envFrom | list | `[]` |  |
 | rag-server.fullnameOverride | string | `"rag-server"` |  |
 | rag-server.image.pullPolicy | string | `"Always"` |  |
-| rag-server.image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| rag-server.image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | rag-server.image.tag | string | `""` |  |
 | rag-server.podAnnotations | object | `{}` |  |
 | rag-server.resources.limits.cpu | string | `"500m"` |  |

--- a/docs/docs/installation/helm-charts/rag-stack/rag-ingestors.md
+++ b/docs/docs/installation/helm-charts/rag-stack/rag-ingestors.md
@@ -21,10 +21,10 @@ Configurable ingestors for RAG system - supports AWS, K8s, ArgoCD, Slack, and We
 
 ```bash
 # Add and install the chart
-helm install rag-ingestors oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
+helm install rag-ingestors oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade rag-ingestors oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
+helm upgrade rag-ingestors oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install rag-ingestors oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68 \
+helm install rag-ingestors oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install rag-ingestors oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68 \
+helm install rag-ingestors oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/rag-ingestors --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -65,7 +65,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-ingestors --version 0.5.68
 | defaultResources.requests.ephemeral-storage | string | `"256Mi"` |  |
 | defaultResources.requests.memory | string | `"256Mi"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-ingestors"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-ingestors"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | ingestors | list | `[]` |  |

--- a/docs/docs/installation/helm-charts/rag-stack/rag-redis.md
+++ b/docs/docs/installation/helm-charts/rag-stack/rag-redis.md
@@ -21,10 +21,10 @@ A Helm chart for Kubernetes
 
 ```bash
 # Add and install the chart
-helm install rag-redis oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68
+helm install rag-redis oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade rag-redis oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68
+helm upgrade rag-redis oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install rag-redis oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68 \
+helm install rag-redis oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install rag-redis oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68 \
+helm install rag-redis oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/rag-redis --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/rag-redis --version 0.5.68
 ```
 
 ## Reading the Values Table

--- a/docs/docs/installation/helm-charts/rag-stack/rag-server.md
+++ b/docs/docs/installation/helm-charts/rag-stack/rag-server.md
@@ -21,10 +21,10 @@ RAG server
 
 ```bash
 # Add and install the chart
-helm install rag-server oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
+helm install rag-server oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68
 
 # Upgrade an existing release
-helm upgrade rag-server oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
+helm upgrade rag-server oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68
 ```
 
 ## Customizing Values
@@ -33,15 +33,15 @@ Override default values using `--set` flags or a custom values file:
 
 ```bash
 # Override individual values
-helm install rag-server oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68 \
+helm install rag-server oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68 \
   --set replicaCount=2
 
 # Use a custom values file
-helm install rag-server oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68 \
+helm install rag-server oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68 \
   -f custom-values.yaml
 
 # Show all configurable values
-helm show values oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
+helm show values oci://ghcr.io/caipe-io/charts/rag-server --version 0.5.68
 ```
 
 ## Reading the Values Table
@@ -64,7 +64,7 @@ helm show values oci://ghcr.io/cnoe-io/charts/rag-server --version 0.5.68
 | extraVolumes | list | `[]` |  |
 | fullnameOverride | string | `"rag-server"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"ghcr.io/cnoe-io/caipe-rag-server"` |  |
+| image.repository | string | `"ghcr.io/caipe-io/caipe-rag-server"` |  |
 | image.tag | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |
 | initContainers | list | `[]` |  |

--- a/docs/docs/installation/helm.md
+++ b/docs/docs/installation/helm.md
@@ -17,11 +17,11 @@ Deploy AI Platform Engineering on any Kubernetes cluster using the official Helm
 The chart is published as an OCI artifact:
 
 ```
-oci://ghcr.io/cnoe-io/charts/ai-platform-engineering
+oci://ghcr.io/caipe-io/charts/ai-platform-engineering
 ```
 
 Browse available versions (stable releases only, no RCs):
-👉 **[ghcr.io/cnoe-io/charts/ai-platform-engineering](https://github.com/cnoe-io/ai-platform-engineering/pkgs/container/charts%2Fai-platform-engineering)**
+👉 **[ghcr.io/caipe-io/charts/ai-platform-engineering](https://github.com/caipe-io/ai-platform-engineering/pkgs/container/charts%2Fai-platform-engineering)**
 
 ## Chart structure
 
@@ -56,10 +56,10 @@ Full parameter tables for each chart (auto-generated — regenerate with `make d
 Pull the chart locally to access the bundled example values files:
 
 ```bash
-helm pull oci://ghcr.io/cnoe-io/charts/ai-platform-engineering --version <VERSION> --untar
+helm pull oci://ghcr.io/caipe-io/charts/ai-platform-engineering --version <VERSION> --untar
 ```
 
-Replace `<VERSION>` with the latest stable version from the [registry page](https://github.com/cnoe-io/ai-platform-engineering/pkgs/container/charts%2Fai-platform-engineering).
+Replace `<VERSION>` with the latest stable version from the [registry page](https://github.com/caipe-io/ai-platform-engineering/pkgs/container/charts%2Fai-platform-engineering).
 
 ## Step 2 — Configure secrets
 
@@ -107,20 +107,20 @@ MCP integrations are enabled via Helm tags. Common profiles:
 ```bash
 # Minimal chart install
 helm install ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <VERSION> \
   --values values-secrets.yaml
 
 # With basic MCP integrations
 helm install ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <VERSION> \
   --values values-secrets.yaml \
   --set tags.basic=true
 
 # With External Secrets Operator
 helm install ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <VERSION> \
   --values values-external-secrets.yaml
 ```
@@ -156,7 +156,7 @@ minikube addons enable ingress
 
 # Deploy with ingress
 helm upgrade ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <VERSION> \
   --values values-secrets.yaml \
   --values ai-platform-engineering/values-ingress.yaml.example
@@ -170,7 +170,7 @@ echo "$(minikube ip) dynamic-agents.local" | sudo tee -a /etc/hosts
 ```bash
 # Upgrade to a new version
 helm upgrade ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <NEW_VERSION> \
   --values values-secrets.yaml
 
@@ -188,7 +188,7 @@ helm uninstall ai-platform-engineering
 
 ```bash
 helm install ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <VERSION> \
   --values values-secrets.yaml \
   --set promptConfigType=deep_agent
@@ -217,7 +217,7 @@ dynamic-agents:
 
 ```bash
 helm install ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <VERSION> \
   --values values-secrets.yaml \
   --values values-persistence.yaml
@@ -227,7 +227,7 @@ Or as `--set` flags:
 
 ```bash
 helm install ai-platform-engineering \
-  oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
   --version <VERSION> \
   --values values-secrets.yaml \
   --set tags.caipe-ui=true \

--- a/docs/docs/installation/index.md
+++ b/docs/docs/installation/index.md
@@ -38,14 +38,14 @@ The minimal install (UI + Dynamic Agents + MongoDB) is enough to run chat with c
 
 ```bash
 # Interactive setup script — detects Docker or Kubernetes automatically
-bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)
+bash <(curl -fsSL https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/setup-caipe.sh)
 ```
 
 Or via Helm directly:
 
 ```bash
 helm upgrade --install ai-platform-engineering \
-    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \
+    oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
     --version 0.4.8 -f your-values.yaml
 ```
 

--- a/docs/docs/integrations/cli.md
+++ b/docs/docs/integrations/cli.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 # CAIPE CLI
 
 :::caution Refactor in Progress
-The CLI is under active development. Track progress in [PR #1184](https://github.com/cnoe-io/ai-platform-engineering/pull/1184). Commands, flags, and installation paths may change before the final merge.
+The CLI is under active development. Track progress in [PR #1184](https://github.com/caipe-io/ai-platform-engineering/pull/1184). Commands, flags, and installation paths may change before the final merge.
 :::
 
 
@@ -18,7 +18,7 @@ CAIPE CLI is a TypeScript/Bun CLI that connects to a CAIPE server via the A2A or
 ### Quick install (recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/cli/install.sh | sh
+curl -fsSL https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/cli/install.sh | sh
 ```
 
 Installs the correct binary for your platform (macOS/Linux, arm64/x64) to `/usr/local/bin/caipe`.
@@ -36,7 +36,7 @@ npm install -g caipe
 ### Build from source
 
 ```bash
-git clone https://github.com/cnoe-io/ai-platform-engineering.git
+git clone https://github.com/caipe-io/ai-platform-engineering.git
 cd ai-platform-engineering/cli
 bun install
 npm run compile   # produces dist/caipe (Bun single-file binary)
@@ -129,4 +129,4 @@ Settings are stored in `~/.config/caipe/settings.json`.
 
 ## Source
 
-[`cli/` directory in ai-platform-engineering](https://github.com/cnoe-io/ai-platform-engineering/tree/main/cli)
+[`cli/` directory in ai-platform-engineering](https://github.com/caipe-io/ai-platform-engineering/tree/main/cli)

--- a/docs/docs/knowledge_bases/architecture.md
+++ b/docs/docs/knowledge_bases/architecture.md
@@ -2,7 +2,7 @@
 
 This page provides an overview of the CAIPE RAG system architecture, including core components, data flows, and technology decisions.
 
-For implementation details and configuration, see the [Architecture.md](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/Architecture.md) in the RAG codebase.
+For implementation details and configuration, see the [Architecture.md](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/Architecture.md) in the RAG codebase.
 
 ## System Overview
 
@@ -173,6 +173,6 @@ The system supports multiple embedding providers:
 
 ## Further Reading
 
-- [Server Architecture](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/ARCHITECTURE.md) - Detailed server internals
-- [Ontology Agent README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/agent_ontology/README.md) - Relationship discovery details
-- [Server README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md) - Configuration reference
+- [Server Architecture](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/ARCHITECTURE.md) - Detailed server internals
+- [Ontology Agent README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/agent_ontology/README.md) - Relationship discovery details
+- [Server README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md) - Configuration reference

--- a/docs/docs/knowledge_bases/authentication-overview.md
+++ b/docs/docs/knowledge_bases/authentication-overview.md
@@ -1,6 +1,6 @@
 # Authentication Overview
 
-This page provides a conceptual overview of authentication and authorization in CAIPE RAG. For configuration details and environment variables, see the [Server README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md).
+This page provides a conceptual overview of authentication and authorization in CAIPE RAG. For configuration details and environment variables, see the [Server README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md).
 
 ## Authentication Methods
 
@@ -220,6 +220,6 @@ The first non-empty value is used. If all are empty, defaults to `"unknown"`.
 
 ## Further Reading
 
-- [Server README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md) - Configuration reference with all environment variables
+- [Server README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md) - Configuration reference with all environment variables
 - [Ingestors](ingestors.md) - Ingestor authentication setup
 - [Architecture](architecture.md) - System architecture overview

--- a/docs/docs/knowledge_bases/index.md
+++ b/docs/docs/knowledge_bases/index.md
@@ -59,13 +59,13 @@ The [Ontology Agent](ontology-agent.md) automatically discovers relationships be
 ### Prerequisites
 
 - Docker and Docker Compose
-- Environment variables configured (see [Server README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md))
+- Environment variables configured (see [Server README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md))
 
 ### Start All Services
 
 ```bash
 # Clone the repository
-git clone https://github.com/cnoe-io/ai-platform-engineering.git
+git clone https://github.com/caipe-io/ai-platform-engineering.git
 cd ai-platform-engineering/ai_platform_engineering/knowledge_bases/rag
 
 # Start all services using Docker Compose
@@ -110,5 +110,5 @@ CAIPE RAG includes ingestors for various data sources. See [Ingestors](ingestors
 
 - [Architecture Overview](architecture.md) - Detailed system design and data flows
 - [RAG API Reference](api-reference.md) - REST, graph, ingestion, and MCP route reference
-- [Server README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md) - Configuration and deployment
-- [GitHub Discussion](https://github.com/cnoe-io/ai-platform-engineering/discussions/196) - Unified RAG design discussion
+- [Server README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md) - Configuration and deployment
+- [GitHub Discussion](https://github.com/caipe-io/ai-platform-engineering/discussions/196) - Unified RAG design discussion

--- a/docs/docs/knowledge_bases/ingestors.md
+++ b/docs/docs/knowledge_bases/ingestors.md
@@ -2,7 +2,7 @@
 
 Ingestors are services that pull data from external sources and submit it to the RAG server for indexing. Each ingestor connects to a specific data source, transforms the data into documents or graph entities, and manages its own sync schedule.
 
-For implementation details and creating custom ingestors, see the [Ingestors README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/README.md).
+For implementation details and creating custom ingestors, see the [Ingestors README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/README.md).
 
 ## How Ingestors Work
 
@@ -45,7 +45,7 @@ Discovers and ingests AWS resources across all regions.
 | **Input** | AWS API (via boto3) |
 | **Output** | Graph Entities |
 | **Entity Types** | EC2, S3, RDS, Lambda, EKS, DynamoDB, VPC, IAM, and more |
-| **Documentation** | [AWS README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/aws/README.md) |
+| **Documentation** | [AWS README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/aws/README.md) |
 
 ### Kubernetes
 
@@ -56,7 +56,7 @@ Ingests Kubernetes resources including custom resources.
 | **Input** | Kubernetes API (via kubeconfig) |
 | **Output** | Graph Entities |
 | **Entity Types** | Pods, Deployments, Services, ConfigMaps, Secrets, CRDs |
-| **Documentation** | [Kubernetes README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/k8s/README.md) |
+| **Documentation** | [Kubernetes README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/k8s/README.md) |
 
 ### Backstage
 
@@ -67,7 +67,7 @@ Ingests entities from a Backstage service catalog.
 | **Input** | Backstage Catalog API |
 | **Output** | Graph Entities |
 | **Entity Types** | Components, APIs, Systems, Domains, Groups, Users |
-| **Documentation** | [Backstage README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/backstage/README.md) |
+| **Documentation** | [Backstage README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/backstage/README.md) |
 
 ### ArgoCD
 
@@ -78,7 +78,7 @@ Ingests GitOps resources from ArgoCD.
 | **Input** | ArgoCD API |
 | **Output** | Graph Entities |
 | **Entity Types** | Applications, Projects, Clusters, Repositories, ApplicationSets |
-| **Documentation** | [ArgoCD README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/argocdv3/README.md) |
+| **Documentation** | [ArgoCD README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/argocdv3/README.md) |
 
 ### GitHub
 
@@ -89,7 +89,7 @@ Ingests organizational data from GitHub.
 | **Input** | GitHub API |
 | **Output** | Graph Entities |
 | **Entity Types** | Organizations, Repositories, Teams, Users |
-| **Documentation** | [GitHub README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/github/README.md) |
+| **Documentation** | [GitHub README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/github/README.md) |
 
 ### Confluence
 
@@ -100,7 +100,7 @@ Ingests pages from Confluence spaces with incremental sync support.
 | **Input** | Confluence REST API |
 | **Output** | Documents |
 | **Features** | Incremental sync, space filtering, title-based include/exclude regex patterns |
-| **Documentation** | [Confluence README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/confluence/README.md) |
+| **Documentation** | [Confluence README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/confluence/README.md) |
 
 ### Slack
 
@@ -111,7 +111,7 @@ Ingests conversations from Slack channels.
 | **Input** | Slack API |
 | **Output** | Documents |
 | **Features** | Threads grouped as single documents, channel filtering |
-| **Documentation** | [Slack README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/slack/README.md) |
+| **Documentation** | [Slack README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/slack/README.md) |
 
 ### Webex
 
@@ -122,7 +122,7 @@ Ingests messages from Webex spaces.
 | **Input** | Webex API |
 | **Output** | Documents |
 | **Features** | Space filtering, message threading |
-| **Documentation** | [Webex README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webex/README.md) |
+| **Documentation** | [Webex README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webex/README.md) |
 
 ## Common Configuration
 
@@ -174,10 +174,10 @@ IngestorBuilder()\
     .run()
 ```
 
-See the [Ingestors README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/README.md) for a complete example with job management and error handling.
+See the [Ingestors README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/README.md) for a complete example with job management and error handling.
 
 ## Further Reading
 
-- [Ingestors README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/README.md) - Creating custom ingestors
-- [Common Package](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/common/README.md) - Shared models and utilities
+- [Ingestors README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/ingestors/README.md) - Creating custom ingestors
+- [Common Package](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/common/README.md) - Shared models and utilities
 - [Authentication Overview](authentication-overview.md) - RBAC and security concepts

--- a/docs/docs/knowledge_bases/mcp-tools.md
+++ b/docs/docs/knowledge_bases/mcp-tools.md
@@ -2,7 +2,7 @@
 
 The RAG server exposes MCP (Model Context Protocol) tools that enable AI agents to search, fetch, and explore the knowledge base. These tools provide a standardized interface for LLMs to access organizational knowledge.
 
-For configuration details, see the [Server README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md).
+For configuration details, see the [Server README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/README.md).
 
 ## What is MCP?
 
@@ -242,6 +242,6 @@ MAX_GRAPH_RAW_QUERY_TOKENS=80000  # Max tokens in results
 
 ## Further Reading
 
-- [Server Architecture](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/ARCHITECTURE.md) - MCP implementation details
+- [Server Architecture](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/server/ARCHITECTURE.md) - MCP implementation details
 - [Architecture Overview](architecture.md) - System-level architecture
 - [MCP Specification](https://modelcontextprotocol.io/) - Official MCP documentation

--- a/docs/docs/knowledge_bases/ontology-agent.md
+++ b/docs/docs/knowledge_bases/ontology-agent.md
@@ -2,7 +2,7 @@
 
 The Ontology Agent automatically discovers and validates relationships between entity types in the knowledge graph. Instead of manually defining schemas, the agent uses fuzzy matching and LLM evaluation to identify meaningful relationships.
 
-For configuration, implementation details, and the full architecture, see the [Ontology Agent README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/agent_ontology/README.md).
+For configuration, implementation details, and the full architecture, see the [Ontology Agent README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/agent_ontology/README.md).
 
 ## Why Automatic Ontology Discovery?
 
@@ -146,5 +146,5 @@ Each processing run creates a new version (UUID). This enables:
 
 ## Further Reading
 
-- [Ontology Agent README](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/agent_ontology/README.md) - Configuration and architecture details
+- [Ontology Agent README](https://github.com/caipe-io/ai-platform-engineering/tree/main/ai_platform_engineering/knowledge_bases/rag/agent_ontology/README.md) - Configuration and architecture details
 - [Architecture Overview](architecture.md) - System-level architecture

--- a/docs/docs/repo-ops/releases.md
+++ b/docs/docs/repo-ops/releases.md
@@ -56,7 +56,7 @@ gh workflow run release-finalize.yml \
 
 This workflow:
 - Promotes `x.y.z-rc.N` → `x.y.z`
-- Publishes the Helm chart to `oci://ghcr.io/cnoe-io/charts/ai-platform-engineering`
+- Publishes the Helm chart to `oci://ghcr.io/caipe-io/charts/ai-platform-engineering`
 - Creates a GitHub Release with auto-generated notes
 
 ---

--- a/docs/docs/repo-ops/skills/create-skill.md
+++ b/docs/docs/repo-ops/skills/create-skill.md
@@ -187,5 +187,5 @@ If any are behind: list each file and line that needs updating.
 
 ## See also
 
-- [`.claude/skills/README.md`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.claude/skills/README.md) — full skill index
+- [`.claude/skills/README.md`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.claude/skills/README.md) — full skill index
 - [Claude Code documentation](https://docs.anthropic.com/en/docs/claude-code) — slash commands and skill discovery

--- a/docs/docs/repo-ops/skills/index.md
+++ b/docs/docs/repo-ops/skills/index.md
@@ -24,7 +24,7 @@ Generate a combined release blog post for a new version.
 
 **Inputs:** to-version, from-version (auto-detected from git tags if omitted), optional `values.yaml` for personal impact analysis.
 
-→ [View skill source](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.claude/skills/release-docs/SKILL.md)
+→ [View skill source](https://github.com/caipe-io/ai-platform-engineering/blob/main/.claude/skills/release-docs/SKILL.md)
 
 ---
 
@@ -46,7 +46,7 @@ Audit and sync all documentation surfaces after a release or feature addition.
 | 6 | Sidebar | Doc directory not in `sidebars.ts` |
 | 7 | Navbar label | Version label behind latest tag |
 
-→ [View skill source](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.claude/skills/update-docs/SKILL.md)
+→ [View skill source](https://github.com/caipe-io/ai-platform-engineering/blob/main/.claude/skills/update-docs/SKILL.md)
 
 ---
 
@@ -56,7 +56,7 @@ Run the full end-to-end integration test suite against a running Docker Compose 
 
 **Use when:** validating a feature branch before raising a PR, or after a major refactor.
 
-→ [View skill source](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.claude/skills/integration-testing/SKILL.md)
+→ [View skill source](https://github.com/caipe-io/ai-platform-engineering/blob/main/.claude/skills/integration-testing/SKILL.md)
 
 ---
 
@@ -74,7 +74,7 @@ Run all pre-commit quality gates — lint, Python tests, UI tests — in one com
 ./skills/quality-gates/run_all.sh --fix
 ```
 
-→ [View skill source](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.claude/skills/quality-gates/)
+→ [View skill source](https://github.com/caipe-io/ai-platform-engineering/blob/main/.claude/skills/quality-gates/)
 
 ---
 

--- a/docs/docs/security/rbac/agent-context-hmac.md
+++ b/docs/docs/security/rbac/agent-context-hmac.md
@@ -79,8 +79,8 @@ The dynamic-agents chart `NOTES.txt` warns on `helm install` when gateway MCP ro
 
 ## Related issues
 
-- [#1920](https://github.com/cnoe-io/ai-platform-engineering/issues/1920) — signed agent context for per-agent `tools/call`
-- [#1928](https://github.com/cnoe-io/ai-platform-engineering/issues/1928) — 403 on `tools/call` when HMAC was missing on dynamic-agents in Kubernetes
+- [#1920](https://github.com/caipe-io/ai-platform-engineering/issues/1920) — signed agent context for per-agent `tools/call`
+- [#1928](https://github.com/caipe-io/ai-platform-engineering/issues/1928) — 403 on `tools/call` when HMAC was missing on dynamic-agents in Kubernetes
 
 ## Code references
 

--- a/docs/docs/security/rbac/audit-log-performance.md
+++ b/docs/docs/security/rbac/audit-log-performance.md
@@ -4,7 +4,7 @@
 
 Related UI-wide benchmark results are tracked in [UI Performance Benchmark Results](../../evaluations/ui-performance-benchmark-results.md).
 
-Three improvements shipped together in [#1903](https://github.com/cnoe-io/ai-platform-engineering/issues/1903) / PR #1917:
+Three improvements shipped together in [#1903](https://github.com/caipe-io/ai-platform-engineering/issues/1903) / PR #1917:
 
 1. **Audit service** — MongoDB writes replaced by a lightweight service that owns local/S3 storage
 2. **OpenFGA N+1 fix** — sequential permission checks on `/api/rbac/admin-tab-gates` parallelized with `Promise.all`

--- a/docs/docs/security/rbac/caipe-rbac-migration.md
+++ b/docs/docs/security/rbac/caipe-rbac-migration.md
@@ -18,7 +18,7 @@ The `caipe/rbac` ApplicationSet currently deploys:
 
 ```yaml
 chart_name: ai-platform-engineering
-chart_repo_url: ghcr.io/cnoe-io/pre-release-helm-charts
+chart_repo_url: ghcr.io/caipe-io/pre-release-helm-charts
 chart_version: 0.5.1-rc.25
 namespace: caipe-rbac
 ```
@@ -280,7 +280,7 @@ From the `ai-platform-engineering` repo:
 
 ```bash
 helm template a-caipe-rbac-argoapp \
-  oci://ghcr.io/cnoe-io/pre-release-helm-charts/ai-platform-engineering \
+  oci://ghcr.io/caipe-io/pre-release-helm-charts/ai-platform-engineering \
   --version 0.5.1-rc.25 \
   -n caipe-rbac \
   -f /Users/sraradhy/outshift/platform-apps-deployment/applications/caipe/rbac/a/values.yaml

--- a/docs/docs/security/rbac/helm-install-upgrade.md
+++ b/docs/docs/security/rbac/helm-install-upgrade.md
@@ -292,7 +292,7 @@ openfgaAuthzBridge:
 
 openfga-authz-bridge:
   image:
-    repository: ghcr.io/cnoe-io/openfga-authz-bridge
+    repository: ghcr.io/caipe-io/openfga-authz-bridge
   openfga:
     httpUrl: "http://{{ .Release.Name }}-openfga:8080"
     storeName: caipe-openfga

--- a/docs/docs/security/supply-chain.md
+++ b/docs/docs/security/supply-chain.md
@@ -19,7 +19,7 @@ Every Python dependency across all subpackages (`pyproject.toml` files) must be 
 
 **Why exact pins?** Range specifiers allow the resolver to silently upgrade a package the next time a lock file is regenerated. An exact pin means the version you test is the version that ships.
 
-**Enforcement:** The [`check-pinned-deps`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.github/workflows/check-pinned-deps.yml) CI gate runs `scripts/check_pinned_deps.py` on every PR and `main` push. The job fails if any `pyproject.toml` or `package.json` contains an unpinned dependency.
+**Enforcement:** The [`check-pinned-deps`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.github/workflows/check-pinned-deps.yml) CI gate runs `scripts/check_pinned_deps.py` on every PR and `main` push. The job fails if any `pyproject.toml` or `package.json` contains an unpinned dependency.
 
 ### Node.js / JavaScript
 
@@ -47,11 +47,11 @@ Every Python subpackage with its own `pyproject.toml` ships a committed `uv.lock
 | Bot integrations | `ai_platform_engineering/integrations/<name>_bot/uv.lock` |
 | Shared utilities | `ai_platform_engineering/utils/uv.lock` |
 
-**Enforcement:** The [`uv-lock-check`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.github/workflows/uv-lock-check.yml) CI gate runs `scripts/check_uv_lock_sync.sh` on every PR and `main` push. It re-runs `uv lock --check` across all subpackages and fails if any lock file is out of sync with its `pyproject.toml`.
+**Enforcement:** The [`uv-lock-check`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.github/workflows/uv-lock-check.yml) CI gate runs `scripts/check_uv_lock_sync.sh` on every PR and `main` push. It re-runs `uv lock --check` across all subpackages and fails if any lock file is out of sync with its `pyproject.toml`.
 
 ## Vulnerability Scanning (Grype)
 
-CAIPE uses [Anchore Grype](https://github.com/anchore/grype) for vulnerability scanning, configured via the [`security-scan`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.github/workflows/security-scan.yml) workflow. Scan results are uploaded as SARIF to [GitHub Code Scanning](https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning).
+CAIPE uses [Anchore Grype](https://github.com/anchore/grype) for vulnerability scanning, configured via the [`security-scan`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.github/workflows/security-scan.yml) workflow. Scan results are uploaded as SARIF to [GitHub Code Scanning](https://github.com/caipe-io/ai-platform-engineering/security/code-scanning).
 
 ### Filesystem scan (PRs and main)
 
@@ -70,7 +70,7 @@ Runs on every pull request to `main` and every push to `main`. Scans the full re
 Instead, CAIPE uses **GitHub Code Scanning's PR diff mode** as the blocking gate. When SARIF is uploaded for a PR, GitHub compares the results against the base branch scan. Only alerts that are *new in the PR* surface as a blocking check:
 
 - A PR that introduces a new vulnerable dependency → **new alert → PR blocked**, with a direct link to the CVE and the package name so the author knows exactly what to fix
-- An upstream CVE already present on `main` → **not new → PR not blocked**; the alert remains visible in the [Security tab](https://github.com/cnoe-io/ai-platform-engineering/security/code-scanning) for maintainers to track and upgrade when a patch ships
+- An upstream CVE already present on `main` → **not new → PR not blocked**; the alert remains visible in the [Security tab](https://github.com/caipe-io/ai-platform-engineering/security/code-scanning) for maintainers to track and upgrade when a patch ships
 
 The required check is **`Code scanning results / Grype`** under Settings → Branches → Branch protection rules for `main`.
 
@@ -161,11 +161,11 @@ This is enforced by the Probot DCO app on every PR. Sign-off is added automatica
 
 ### Conventional Commits
 
-The [`conventional_commits`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.github/workflows/conventional_commits.yml) workflow enforces the [Conventional Commits](https://www.conventionalcommits.org/) specification on every PR title and commit message. This provides a structured audit trail and enables automated changelog generation.
+The [`conventional_commits`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.github/workflows/conventional_commits.yml) workflow enforces the [Conventional Commits](https://www.conventionalcommits.org/) specification on every PR title and commit message. This provides a structured audit trail and enables automated changelog generation.
 
 ### No proprietary content
 
-The [`check-proprietary-content`](https://github.com/cnoe-io/ai-platform-engineering/blob/main/.github/workflows/check-proprietary-content.yml) workflow scans every changed file in a PR for patterns associated with proprietary infrastructure (internal domains, email suffixes, internal team names). Any match blocks the PR and posts a comment identifying the exact lines. This prevents accidental leakage of internal tooling references into the open-source repository.
+The [`check-proprietary-content`](https://github.com/caipe-io/ai-platform-engineering/blob/main/.github/workflows/check-proprietary-content.yml) workflow scans every changed file in a PR for patterns associated with proprietary infrastructure (internal domains, email suffixes, internal team names). Any match blocks the PR and posts a comment identifying the exact lines. This prevents accidental leakage of internal tooling references into the open-source repository.
 
 ## Container Image Hardening
 

--- a/docs/docs/ui/customization.md
+++ b/docs/docs/ui/customization.md
@@ -203,7 +203,7 @@ Control which links appear in the application header.
 
 ```bash
 DOCS_URL=https://docs.caipe.example.com
-SOURCE_URL=https://github.com/cnoe-io/ai-platform-engineering
+SOURCE_URL=https://github.com/caipe-io/ai-platform-engineering
 ```
 
 ## Login Page Customization
@@ -283,7 +283,7 @@ Add customization variables to your `docker-compose.yaml`:
 ```yaml
 services:
   caipe-ui:
-    image: ghcr.io/cnoe-io/caipe-ui:latest
+    image: ghcr.io/caipe-io/caipe-ui:latest
     environment:
       - APP_NAME=Grid
       - LOGO_STYLE=white

--- a/docs/docs/ui/skills-live-skills.md
+++ b/docs/docs/ui/skills-live-skills.md
@@ -19,7 +19,7 @@ image.
 
 | Layer            | Location                                                         |
 | ---------------- | ---------------------------------------------------------------- |
-| Packaged default | [`charts/ai-platform-engineering/data/skills/live-skills.md`](https://github.com/cnoe-io/ai-platform-engineering/tree/main/charts/ai-platform-engineering/data/skills/live-skills.md) |
+| Packaged default | [`charts/ai-platform-engineering/data/skills/live-skills.md`](https://github.com/caipe-io/ai-platform-engineering/tree/main/charts/ai-platform-engineering/data/skills/live-skills.md) |
 | Helm ConfigMap   | `skills-live-skills` (key `live-skills.md`)                          |
 | Mounted in pod   | `/app/data/skills-live-skills/live-skills.md` on the `caipe-ui` pod  |
 | Served at        | `GET /api/skills/live-skills` (returns `{ template, source, … }`)  |
@@ -186,7 +186,7 @@ The renderer parses the canonical Markdown's frontmatter once, substitutes
 `{{COMMAND_NAME}}`, `{{DESCRIPTION}}`, `{{BASE_URL}}`, and `{{ARG_REF}}`,
 then re-wraps the body as appropriate for each surface (YAML frontmatter,
 TOML basic strings, or a JSON object). Adding a new agent is one entry in
-[`ui/src/app/api/skills/live-skills/agents.ts`](https://github.com/cnoe-io/ai-platform-engineering/tree/main/ui/src/app/api/skills/live-skills/agents.ts)
+[`ui/src/app/api/skills/live-skills/agents.ts`](https://github.com/caipe-io/ai-platform-engineering/tree/main/ui/src/app/api/skills/live-skills/agents.ts)
 plus a case in `renderForAgent()`.
 
 ### Per-agent launch & invocation guidance
@@ -221,6 +221,6 @@ basic Markdown (bold, inline code, links, fenced code blocks).
 
 ## See also
 
-- Chart-side reference: [`charts/ai-platform-engineering/docs/skills-live-skills.md`](https://github.com/cnoe-io/ai-platform-engineering/tree/main/charts/ai-platform-engineering/docs/skills-live-skills.md)
-- Default template: [`live-skills.md`](https://github.com/cnoe-io/ai-platform-engineering/tree/main/charts/ai-platform-engineering/data/skills/live-skills.md)
-- ConfigMap template: [`templates/skills-live-skills-config.yaml`](https://github.com/cnoe-io/ai-platform-engineering/tree/main/charts/ai-platform-engineering/templates/skills-live-skills-config.yaml)
+- Chart-side reference: [`charts/ai-platform-engineering/docs/skills-live-skills.md`](https://github.com/caipe-io/ai-platform-engineering/tree/main/charts/ai-platform-engineering/docs/skills-live-skills.md)
+- Default template: [`live-skills.md`](https://github.com/caipe-io/ai-platform-engineering/tree/main/charts/ai-platform-engineering/data/skills/live-skills.md)
+- ConfigMap template: [`templates/skills-live-skills-config.yaml`](https://github.com/caipe-io/ai-platform-engineering/tree/main/charts/ai-platform-engineering/templates/skills-live-skills-config.yaml)

--- a/docs/docs/usecases/platform-engineer.md
+++ b/docs/docs/usecases/platform-engineer.md
@@ -48,4 +48,4 @@ docker compose --profile argocd --profile github --profile jira --profile pagerd
 - **devops-engineer**: DevOps-focused setup with ArgoCD, AWS, GitHub, Jira, Komodor, and PagerDuty integrations
 - **caipe-basic**: Minimal setup with the UI, Dynamic Agents runtime, RAG, and a small set of MCP tools
 
-See the [docker-compose.yaml](https://github.com/cnoe-io/ai-platform-engineering/blob/main/docker-compose.yaml) for the available Compose profiles.
+See the [docker-compose.yaml](https://github.com/caipe-io/ai-platform-engineering/blob/main/docker-compose.yaml) for the available Compose profiles.

--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -38,7 +38,7 @@ const CHANNELS = [
     title: 'GitHub Discussions',
     description: 'Ask questions, share ideas, and discuss platform engineering use cases.',
     cta: 'Open a discussion',
-    href: 'https://github.com/cnoe-io/ai-platform-engineering/discussions',
+    href: 'https://github.com/caipe-io/ai-platform-engineering/discussions',
     note: null,
     noteHref: null,
   },
@@ -67,7 +67,7 @@ const CONTRIBUTE = [
     icon: '🌱',
     title: 'Pick a Good First Issue',
     description: 'New to the project? Browse issues tagged for first-time contributors — bite-sized and well-scoped.',
-    href: 'https://github.com/cnoe-io/ai-platform-engineering/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22',
+    href: 'https://github.com/caipe-io/ai-platform-engineering/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22good%20first%20issue%22',
   },
   {
     icon: '🛠️',
@@ -85,7 +85,7 @@ const CONTRIBUTE = [
     icon: '🐛',
     title: 'File Issues',
     description: 'Found a bug or have a feature request? Open a GitHub issue.',
-    href: 'https://github.com/cnoe-io/ai-platform-engineering/issues',
+    href: 'https://github.com/caipe-io/ai-platform-engineering/issues',
   },
   {
     icon: '📖',
@@ -122,7 +122,7 @@ export default function CommunityPage() {
               </Link>
               <Link
                 className={styles.secondaryBtn}
-                href="https://github.com/cnoe-io/ai-platform-engineering"
+                href="https://github.com/caipe-io/ai-platform-engineering"
               >
                 GitHub ↗
               </Link>

--- a/docs/src/pages/features.tsx
+++ b/docs/src/pages/features.tsx
@@ -187,7 +187,7 @@ export default function FeaturesPage() {
               </Link>
               <Link
                 className={styles.secondaryBtn}
-                href="https://github.com/cnoe-io/ai-platform-engineering/issues/new?labels=enhancement&template=feature_request.md"
+                href="https://github.com/caipe-io/ai-platform-engineering/issues/new?labels=enhancement&template=feature_request.md"
               >
                 Submit a Feature Request ↗
               </Link>
@@ -225,12 +225,12 @@ export default function FeaturesPage() {
             <Link className={styles.primaryBtn} to="/docs/installation">
               Installation Guide →
             </Link>
-            <Link className={styles.secondaryBtn} href="https://github.com/cnoe-io/ai-platform-engineering">
+            <Link className={styles.secondaryBtn} href="https://github.com/caipe-io/ai-platform-engineering">
               GitHub ↗
             </Link>
             <Link
               className={styles.secondaryBtn}
-              href="https://github.com/cnoe-io/ai-platform-engineering/issues/new?labels=enhancement&template=feature_request.md"
+              href="https://github.com/caipe-io/ai-platform-engineering/issues/new?labels=enhancement&template=feature_request.md"
             >
               Submit a Feature Request ↗
             </Link>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -5,9 +5,9 @@ import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import styles from './index.module.css';
 
-const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)';
-const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\\n    --version 0.6.0 -f your-values.yaml';
-const GIF_URL = 'https://github.com/cnoe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
+const CURL_CMD = 'bash <(curl -fsSL https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/setup-caipe.sh)';
+const HELM_CMD = 'helm upgrade --install ai-platform-engineering \\\n    oci://ghcr.io/caipe-io/charts/ai-platform-engineering \\\n    --version 0.6.0 -f your-values.yaml';
+const GIF_URL = 'https://github.com/caipe-io/ai-platform-engineering/releases/download/0.4.8/caipe-setup.gif';
 
 function DemoGif() {
   const [open, setOpen] = useState(false);
@@ -180,7 +180,7 @@ const AGENTS = [
 function HeroSection() {
   const [stars, setStars] = useState<string | null>(null);
   useEffect(() => {
-    fetch('https://api.github.com/repos/cnoe-io/ai-platform-engineering')
+    fetch('https://api.github.com/repos/caipe-io/ai-platform-engineering')
       .then((r) => r.json())
       .then((d) => {
         const n = d.stargazers_count;
@@ -217,7 +217,7 @@ function HeroSection() {
               <Link className={styles.heroSecondary} href="https://app.vidcast.io/share/embed/e0033e26-46bf-4298-8c20-0a2fd1746073">
                 Watch a Demo ▶
               </Link>
-              <Link className={styles.heroSecondary} href="https://github.com/cnoe-io/ai-platform-engineering">
+              <Link className={styles.heroSecondary} href="https://github.com/caipe-io/ai-platform-engineering">
                 GitHub ↗
               </Link>
             </div>
@@ -252,7 +252,7 @@ function HeroSection() {
                   <span className={styles.codeComment}># Or via Helm</span>{'\n'}
                   <span className={styles.codePrompt}>$</span>{' '}
                   {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
-                  {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
+                  {'    oci://ghcr.io/caipe-io/charts/ai-platform-engineering \\'}{'\n'}
                   {'    --version 0.6.0 -f your-values.yaml'}
                 </code>
               </pre>
@@ -275,7 +275,7 @@ function HeroSection() {
             <span className={styles.heroStatLabel}>Apache 2.0</span>
           </div>
           <a
-            href="https://github.com/cnoe-io/ai-platform-engineering"
+            href="https://github.com/caipe-io/ai-platform-engineering"
             target="_blank"
             rel="noopener noreferrer"
             className={styles.heroStat}
@@ -403,11 +403,11 @@ function QuickStartSection() {
             <code>
               <span className={styles.codeComment}># Install CAIPE via setup script</span>{'\n'}
               <span className={styles.codePrompt}>$</span>{' '}
-              {'bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)'}{'\n\n'}
+              {'bash <(curl -fsSL https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/setup-caipe.sh)'}{'\n\n'}
               <span className={styles.codeComment}># Or via Helm</span>{'\n'}
               <span className={styles.codePrompt}>$</span>{' '}
               {'helm upgrade --install ai-platform-engineering \\'}{'\n'}
-              {'    oci://ghcr.io/cnoe-io/charts/ai-platform-engineering \\'}{'\n'}
+              {'    oci://ghcr.io/caipe-io/charts/ai-platform-engineering \\'}{'\n'}
               {'    --version 0.6.0 -f your-values.yaml'}
             </code>
           </pre>
@@ -478,7 +478,7 @@ function CtaSection() {
         </Link>
         <Link
           className={styles.heroSecondary}
-          href="https://github.com/cnoe-io/ai-platform-engineering"
+          href="https://github.com/caipe-io/ai-platform-engineering"
         >
           Star on GitHub ↗
         </Link>

--- a/docs/src/pages/roadmap.tsx
+++ b/docs/src/pages/roadmap.tsx
@@ -186,7 +186,7 @@ export default function RoadmapPage() {
                         {(item as any).issueRefs.map((ref: string) => (
                           <a
                             key={ref}
-                            href={`https://github.com/cnoe-io/ai-platform-engineering/issues/${ref.replace('#', '')}`}
+                            href={`https://github.com/caipe-io/ai-platform-engineering/issues/${ref.replace('#', '')}`}
                             target="_blank"
                             rel="noopener noreferrer"
                             className={styles.issueRef}
@@ -216,7 +216,7 @@ export default function RoadmapPage() {
             <div className={styles.heroCtas}>
               <Link
                 className={styles.primaryBtn}
-                href="https://github.com/cnoe-io/ai-platform-engineering/issues/new?template=feature_request.yml"
+                href="https://github.com/caipe-io/ai-platform-engineering/issues/new?template=feature_request.yml"
               >
                 Request a Feature ↗
               </Link>

--- a/scripts/generate-helm-chart-docs.sh
+++ b/scripts/generate-helm-chart-docs.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 SCRIPT_NAME="scripts/generate-helm-chart-docs.sh"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
-OCI_REGISTRY="oci://ghcr.io/cnoe-io/charts/ai-platform-engineering"
+OCI_REGISTRY="oci://ghcr.io/caipe-io/charts/ai-platform-engineering"
 PARENT_CHARTS=("ai-platform-engineering" "rag-stack")
 CHARTS_ROOT="${REPO_ROOT}/charts"
 DOCS_HELM_ROOT="${REPO_ROOT}/docs/docs/installation/helm-charts"
@@ -300,9 +300,9 @@ generate_source_readme() {
   local parent_group
   parent_group=$(parent_group_of "$chart_dir")
 
-  local oci_url="oci://ghcr.io/cnoe-io/charts/${name}"
+  local oci_url="oci://ghcr.io/caipe-io/charts/${name}"
   if is_parent_chart "$chart_dir"; then
-    oci_url="oci://ghcr.io/cnoe-io/charts/${name}"
+    oci_url="oci://ghcr.io/caipe-io/charts/${name}"
   fi
 
   cat > "${chart_dir}/README.md" <<EOF
@@ -398,7 +398,7 @@ generate_docusaurus_page() {
     deps_section=$(generate_dependencies_section "$chart_dir")
   fi
 
-  local oci_url="oci://ghcr.io/cnoe-io/charts/${name}"
+  local oci_url="oci://ghcr.io/caipe-io/charts/${name}"
 
   {
     cat <<EOF

--- a/scripts/validate-helm-image-channel.py
+++ b/scripts/validate-helm-image-channel.py
@@ -2,7 +2,7 @@
 """Validate CAIPE Helm image channel defaults.
 
 Pre-release charts should default maintained CAIPE images to the
-``ghcr.io/cnoe-io/pre-release`` repository namespace. Operators can opt
+``ghcr.io/caipe-io/pre-release`` repository namespace. Operators can opt
 into root published images with ``global.image.channel=release``.
 """
 
@@ -106,14 +106,14 @@ def chart_app_version(chart: Path) -> str:
 def default_image_prefix(chart: Path) -> str:
     app_version = chart_app_version(chart)
     if re.search(r"(?:^|[-.])(dev|rc|hotfix)(?:[-.]|$)", app_version):
-        return "ghcr.io/cnoe-io/pre-release"
-    return "ghcr.io/cnoe-io"
+        return "ghcr.io/caipe-io/pre-release"
+    return "ghcr.io/caipe-io"
 
 
 def opposite_image_prefix(prefix: str) -> str:
-    if prefix == "ghcr.io/cnoe-io":
-        return "ghcr.io/cnoe-io/pre-release"
-    return "ghcr.io/cnoe-io"
+    if prefix == "ghcr.io/caipe-io":
+        return "ghcr.io/caipe-io/pre-release"
+    return "ghcr.io/caipe-io"
 
 
 def rendered_images(manifest: str) -> set[str]:
@@ -208,11 +208,11 @@ def main() -> int:
     )
     missing_release = require_images(
         release_images,
-        "ghcr.io/cnoe-io",
+        "ghcr.io/caipe-io",
         PARENT_EXPECTED_IMAGE_NAMES,
     ) + require_images(
         release_rag_images,
-        "ghcr.io/cnoe-io",
+        "ghcr.io/caipe-io",
         RAG_EXPECTED_IMAGE_NAMES,
     )
     forbidden_default = forbid_images(
@@ -235,11 +235,11 @@ def main() -> int:
     )
     forbidden_release = forbid_images(
         release_images,
-        "ghcr.io/cnoe-io/pre-release",
+        "ghcr.io/caipe-io/pre-release",
         PARENT_EXPECTED_IMAGE_NAMES,
     ) + forbid_images(
         release_rag_images,
-        "ghcr.io/cnoe-io/pre-release",
+        "ghcr.io/caipe-io/pre-release",
         RAG_EXPECTED_IMAGE_NAMES,
     )
 

--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -6,12 +6,12 @@ set -euo pipefail
 #   Roles: kind_cluster, metallb, nginx_ingress, caipe_secrets, caipe_helm,
 #   caipe_mongodb. Benefits: idempotency, inventory-driven multi-env deploys
 #   (demo/devnet/prod from one playbook), Ansible Vault for secrets, CI/CD.
-#   Tracking: https://github.com/cnoe-io/ai-platform-engineering/issues/1115
+#   Tracking: https://github.com/caipe-io/ai-platform-engineering/issues/1115
 # ─────────────────────────────────────────────────────────────────────────────
 
 # ─── Defaults ────────────────────────────────────────────────────────────────
 CAIPE_CHART_VERSION="${CAIPE_CHART_VERSION:-}"
-CAIPE_OCI_REPO="oci://ghcr.io/cnoe-io/charts/ai-platform-engineering"
+CAIPE_OCI_REPO="oci://ghcr.io/caipe-io/charts/ai-platform-engineering"
 LANGFUSE_PORT=3100
 DYNAMIC_AGENTS_PORT=8001
 UI_PORT=3000
@@ -685,7 +685,7 @@ check_prerequisites() {
           esac
           warn ""
           warn "Then re-run:"
-          warn "  bash <(curl -fsSL https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/setup-caipe.sh)"
+          warn "  bash <(curl -fsSL https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/setup-caipe.sh)"
           exit 1
         fi
       fi
@@ -992,7 +992,7 @@ choose_chart_version() {
   if command -v crane &>/dev/null; then
     while IFS= read -r v; do
       [[ -n "$v" ]] && versions+=("$v")
-    done < <(crane ls ghcr.io/cnoe-io/charts/ai-platform-engineering 2>/dev/null | sort -Vr | head -10)
+    done < <(crane ls ghcr.io/caipe-io/charts/ai-platform-engineering 2>/dev/null | sort -Vr | head -10)
   fi
 
   if [[ ${#versions[@]} -eq 0 && -n "$versions_raw" ]]; then
@@ -2994,9 +2994,9 @@ _update_compose_image_tag() {
   _ensure_compose_env_file "$env_file"
   local latest
   if command -v gh &>/dev/null; then
-    latest=$(gh release view --repo cnoe-io/ai-platform-engineering --json tagName -q .tagName)
+    latest=$(gh release view --repo caipe-io/ai-platform-engineering --json tagName -q .tagName)
   elif command -v curl &>/dev/null; then
-    latest=$(curl -sf "https://api.github.com/repos/cnoe-io/ai-platform-engineering/releases/latest" \
+    latest=$(curl -sf "https://api.github.com/repos/caipe-io/ai-platform-engineering/releases/latest" \
       | jq .tag_name)
   else
     err "Either GitHub CLI (gh) or curl is required to fetch the latest CAIPE release"
@@ -8167,7 +8167,7 @@ BANNER
   echo -e "${BLUE}${BOLD}║${NC}                                               ${BLUE}${BOLD}║${NC}"
   echo -e "${BLUE}${BOLD}║${NC}  ${DIM}Multi-Agent System on Kubernetes${NC}             ${BLUE}${BOLD}║${NC}"
   echo -e "${BLUE}${BOLD}║${NC}                                               ${BLUE}${BOLD}║${NC}"
-  echo -e "${BLUE}${BOLD}║${NC}  ${DIM}github.com/cnoe-io/ai-platform-engineering${NC}   ${BLUE}${BOLD}║${NC}"
+  echo -e "${BLUE}${BOLD}║${NC}  ${DIM}github.com/caipe-io/ai-platform-engineering${NC}   ${BLUE}${BOLD}║${NC}"
   echo -e "${BLUE}${BOLD}║${NC}  ${DIM}Powered by cnoe-agent-utils LLMFactory${NC}       ${BLUE}${BOLD}║${NC}"
   echo -e "${BLUE}${BOLD}║${NC}  ${DIM}github.com/cnoe-io/cnoe-agent-utils${NC}          ${BLUE}${BOLD}║${NC}"
   echo -e "${BLUE}${BOLD}╚═══════════════════════════════════════════════╝${NC}"
@@ -8355,7 +8355,7 @@ BANNER
     if [[ ! -f "$_ollama_yaml" ]]; then
       err "deploy/kind/ollama.yaml not found at ${_ollama_yaml}."
       err "When running via 'curl | bash', clone the repo and run setup-caipe.sh directly:"
-      err "  git clone https://github.com/cnoe-io/ai-platform-engineering && cd ai-platform-engineering && bash setup-caipe.sh"
+      err "  git clone https://github.com/caipe-io/ai-platform-engineering && cd ai-platform-engineering && bash setup-caipe.sh"
       exit 1
     fi
     kubectl apply -f "$_ollama_yaml" 2>&1 \

--- a/ui/src/app/api/changelog/route.ts
+++ b/ui/src/app/api/changelog/route.ts
@@ -5,7 +5,7 @@ import path from "path";
 export const dynamic = "force-dynamic";
 
 const CHANGELOG_URL =
-  "https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/CHANGELOG.md";
+  "https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/CHANGELOG.md";
 const STABLE_RELEASE_VERSION_PATTERN = /^\d+\.\d+\.\d+$/;
 const RELEASE_VERSION_PATTERN = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/;
 

--- a/ui/src/app/api/release-notes/__tests__/route.test.ts
+++ b/ui/src/app/api/release-notes/__tests__/route.test.ts
@@ -3,7 +3,7 @@
  */
 import { NextRequest } from "next/server";
 
-const RAW_BASE = "https://raw.githubusercontent.com/cnoe-io/ai-platform-engineering/main/docs/releases";
+const RAW_BASE = "https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/docs/releases";
 
 const LISTING = [
   { name: "README.md", type: "file", download_url: `${RAW_BASE}/README.md` },

--- a/ui/src/app/api/release-notes/route.ts
+++ b/ui/src/app/api/release-notes/route.ts
@@ -4,7 +4,7 @@ import path from "path";
 
 export const dynamic = "force-dynamic";
 
-const GITHUB_OWNER = "cnoe-io";
+const GITHUB_OWNER = "caipe-io";
 const GITHUB_REPO = "ai-platform-engineering";
 const GITHUB_REF = "main";
 const RELEASES_DIR = "docs/releases";

--- a/ui/src/components/release/ReleaseUpgradeDialog.tsx
+++ b/ui/src/components/release/ReleaseUpgradeDialog.tsx
@@ -27,7 +27,7 @@ interface ReleaseUpgradeDialogProps {
   isDismissing?: boolean;
 }
 
-const CHANGELOG_URL = "https://github.com/cnoe-io/ai-platform-engineering/blob/main/CHANGELOG.md";
+const CHANGELOG_URL = "https://github.com/caipe-io/ai-platform-engineering/blob/main/CHANGELOG.md";
 
 function userVisibleSections(sections: ReleaseNote["sections"], isAdmin: boolean): ReleaseNote["sections"] {
   if (isAdmin) return sections;

--- a/ui/src/components/release/__tests__/ReleaseUpgradeDialog.test.tsx
+++ b/ui/src/components/release/__tests__/ReleaseUpgradeDialog.test.tsx
@@ -94,7 +94,7 @@ describe("ReleaseUpgradeDialog", () => {
     expect(screen.getByText("Added Slack and Webex ReBAC migration assistant")).toBeInTheDocument();
     expect(screen.getByRole("link", { name: "View full changelog" })).toHaveAttribute(
       "href",
-      "https://github.com/cnoe-io/ai-platform-engineering/blob/main/CHANGELOG.md",
+      "https://github.com/caipe-io/ai-platform-engineering/blob/main/CHANGELOG.md",
     );
     expect(screen.queryByRole("button", { name: "Open Migration Assistant" })).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Skip until next login" })).toBeInTheDocument();

--- a/ui/src/components/user-menu.tsx
+++ b/ui/src/components/user-menu.tsx
@@ -19,7 +19,7 @@ import Image from "next/image";
 import { NavigationProgressLink } from "@/components/layout/NavigationProgressLink";
 import { useCallback,useEffect,useRef,useState } from "react";
 
-const CHANGELOG_URL = "https://github.com/cnoe-io/ai-platform-engineering/blob/main/CHANGELOG.md";
+const CHANGELOG_URL = "https://github.com/caipe-io/ai-platform-engineering/blob/main/CHANGELOG.md";
 
 export function UserMenu(): React.ReactElement | null {
   const { data: session,status } = useSession();


### PR DESCRIPTION
## Summary
- point Docker Compose, Helm values, release-channel helpers, and ArgoCD examples at `ghcr.io/caipe-io`
- update installer, current documentation, and the site homepage to use the migrated OCI and GitHub namespaces
- preserve historical release notes and archived specifications

## Validation
- `docker compose --env-file .env.example -f docker-compose.yaml config --quiet` with the required first-install profiles
- rendered Compose images contain only `ghcr.io/caipe-io` for CAIPE artifacts
- `docker compose --env-file .env.example -f docker-compose.dev.yaml config --quiet`
- `python3 scripts/validate-helm-image-channel.py`
- `helm lint charts/ai-platform-engineering`
- `helm lint charts/rag-stack`

## Known baseline failures
- `uv run pytest deploy/openfga/bridge/tests/test_helm_values.py -q` has 6 unrelated existing Webex/Keycloak assertion failures after dependencies are fetched; 25 tests pass.