### PR TITLE
docs(homepage): refresh hero messaging

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -46,7 +46,8 @@
   justify-content: center;
   align-items: center;
   text-align: center;
-  max-width: 760px;
+  width: 100%;
+  max-width: 1100px;
   margin: 0 auto;
 }
 
@@ -75,6 +76,7 @@
   color: #fff;
   overflow-wrap: anywhere;
   text-wrap: balance;
+  white-space: nowrap;
 }
 
 .heroAccent {
@@ -82,6 +84,10 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
+}
+
+.heroLine {
+  display: block;
 }
 
 .heroSubtitle {
@@ -684,6 +690,7 @@
   }
   
   .heroButtons { justify-content: center; }
+  .heroTitle { white-space: normal; }
   .heroSubtitle { margin: 0 auto 1rem; }
 }
 
@@ -694,6 +701,7 @@
   .heroTitle { font-size: clamp(2rem, 10vw, 2.6rem) !important; }
   .heroSubtitle { font-size: 0.98rem; }
   .heroPronunciation { margin-bottom: 1.25rem; }
+  .heroLine { display: inline; }
   .heroButtons, .ctaButtons {
     flex-direction: column;
     align-items: stretch;
@@ -755,7 +763,7 @@
 .installWidget {
   margin-top: 2rem;
   width: 100%;
-  max-width: 100%;
+  max-width: 980px;
   background: #0b1120;
   border: 1px solid rgba(148, 163, 184, 0.15);
   border-radius: 10px;
@@ -795,6 +803,7 @@
   display: flex;
   align-items: center;
   gap: 0.75rem;
+  min-height: 5.5rem;
   padding: 0.9rem 1.1rem;
   width: 100%;
   background: none;
@@ -820,8 +829,8 @@
 
 .installPre {
   margin: 0;
-  white-space: pre-wrap;
-  word-break: break-all;
+  white-space: pre;
+  overflow-x: auto;
   flex: 1;
   min-width: 0;
 }
@@ -829,6 +838,7 @@
 .installPre code {
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 0.8rem;
+  line-height: 1.5;
   color: #e2e8f0;
 }
 

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -196,15 +196,22 @@ function HeroSection() {
           {/* Left: copy + CTAs */}
           <div className={styles.heroLeft}>
             <Heading as="h1" className={styles.heroTitle}>
-              Hosted open source AI agents for{' '}
-              <span className={styles.heroAccent}>platform engineering</span>
+              Open Source AI Platform for{' '}
+              <span className={styles.heroAccent}>All</span>
             </Heading>
             <p className={styles.heroSubtitle}>
-              All-in-one, self-hostable AI agents with security built in, for
-              enterprise or personal.
+              <span className={styles.heroLine}>
+                Build, govern, and operate secure AI agents and agentic workflows
+              </span>{' '}
+              <span className={styles.heroLine}>for enterprises and individuals</span>
             </p>
             <p className={styles.heroPronunciation}>
-              💡 Pronounced like <strong>cape</strong> 🦸 — just as a cape empowers a superhero, CAIPE empowers teams with 🤖 agentic AI automation.
+              <span className={styles.heroLine}>
+                💡 Pronounced like <strong>cape</strong> 🦸 — just as a cape empowers a superhero,
+              </span>{' '}
+              <span className={styles.heroLine}>
+                CAIPE empowers teams with 🤖 agentic AI automation.
+              </span>
             </p>
             <div className={styles.heroButtons}>
               <Link className={styles.heroPrimary} to="/docs/getting-started/quick-start">
@@ -457,7 +464,7 @@ export default function Home() {
   return (
     <Layout
       title={siteConfig.title}
-      description="Hosted open source AI agents for platform engineering. All-in-one, self-hostable, with security built in, for enterprise or personal."
+      description="Open Source AI Platform for All. Build, govern, and operate secure AI agents and agentic workflows for enterprises and individuals."
     >
       <main>
         <HeroSection />


### PR DESCRIPTION
# Description

Refresh the Docusaurus homepage hero with inclusive open-source AI platform messaging. Keep the headline and supporting copy readable across screen sizes, and stabilize the install widget dimensions when switching between the curl and Helm tabs.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

For chart changes, you can test temporary versions before merging:
- **Base repo contributors:** Create a branch starting with `prebuild/` for automatic prebuilds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Temporary charts are published to `ghcr.io/caipe-io/charts` with PR-specific versions
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Validation

- `npm run typecheck`
- `npm run build`
- `git diff --check`