### PR TITLE
fix(ui): align accent theming and navigation state

### DIFF
--- a/ui/src/components/__tests__/settings-panel.test.tsx
+++ b/ui/src/components/__tests__/settings-panel.test.tsx
@@ -33,6 +33,11 @@ describe("SettingsPanel",() => {
     document.body.removeAttribute("data-font-size");
     document.body.removeAttribute("data-font-family");
     document.documentElement.removeAttribute("data-gradient-theme");
+    document.documentElement.style.removeProperty("--primary");
+    document.documentElement.style.removeProperty("--ring");
+    document.documentElement.style.removeProperty("--gradient-start");
+    document.documentElement.style.removeProperty("--gradient-mid");
+    document.documentElement.style.removeProperty("--gradient-end");
     mockTheme = "dark";
     mockConfig = {
       defaultFontSize: "medium",
@@ -99,6 +104,8 @@ describe("SettingsPanel",() => {
       expect(document.body).toHaveAttribute("data-font-size","x-large");
       expect(document.body).toHaveAttribute("data-font-family","source-sans");
       expect(document.documentElement).toHaveAttribute("data-gradient-theme","sunset");
+      expect(document.documentElement.style.getPropertyValue("--primary")).toBe("30 80% 55%");
+      expect(document.documentElement.style.getPropertyValue("--ring")).toBe("30 80% 55%");
       expect(mockSetTheme).toHaveBeenCalledWith("nord");
     });
   });

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -1736,7 +1736,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
               <div className="text-center py-20">
                 {isLoadingMessages ? (
                   <>
-                    <div className="w-16 h-16 mx-auto mb-6 rounded-2xl bg-gradient-to-br from-primary to-primary/60 flex items-center justify-center">
+                    <div className="w-16 h-16 mx-auto mb-6 rounded-2xl gradient-primary-br flex items-center justify-center">
                       <Loader2 className="h-8 w-8 text-white animate-spin" />
                     </div>
                     <h2 className="text-2xl font-bold mb-2">Loading conversation...</h2>
@@ -1752,6 +1752,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
                       size="w-16 h-16 mx-auto mb-6"
                       iconSize="h-8 w-8"
                       icon={Sparkles}
+                      useGlobalTheme
                     />
                     <h2 className="text-2xl font-bold mb-4">Welcome to {getConfig('appName')}</h2>
                     <p className="text-muted-foreground mb-3">
@@ -1763,6 +1764,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
                         rounded="rounded-lg"
                         size="w-8 h-8"
                         iconSize="h-4 w-4"
+                        useGlobalTheme
                       />
                       <span className="text-lg font-semibold">
                         {agentName || "your agent"}

--- a/ui/src/components/dynamic-agents/AgentAvatar.tsx
+++ b/ui/src/components/dynamic-agents/AgentAvatar.tsx
@@ -37,6 +37,8 @@ export interface AgentAvatarProps {
   gradientTheme?: string | null;
   /** Override custom theme config (used when agent is null, e.g. editor live preview) */
   customThemeConfig?: CustomThemeConfig | null;
+  /** Use the user's global accent for application-level avatar treatments. */
+  useGlobalTheme?: boolean;
   /** Border radius — exact Tailwind class (e.g. "rounded-full", "rounded-xl") */
   rounded?: string;
   /** Container size — exact Tailwind classes (e.g. "w-9 h-9") */
@@ -57,6 +59,7 @@ export function AgentAvatar({
   agent,
   gradientTheme: gradientThemeOverride,
   customThemeConfig: customThemeConfigOverride,
+  useGlobalTheme = false,
   rounded = "rounded-xl",
   size = "w-9 h-9",
   iconSize = "h-4 w-4",
@@ -82,10 +85,12 @@ export function AgentAvatar({
   const resolvedGradientTheme = gradientThemeOverride ?? agent?.ui?.gradient_theme ?? agent?.gradient_theme ?? null;
   const resolvedCustomThemeConfig = customThemeConfigOverride ?? agent?.ui?.custom_theme_config ?? agent?.custom_theme_config ?? null;
 
-  const gradientStyle = resolvedGradientTheme
+  const gradientStyle = !useGlobalTheme && resolvedGradientTheme
     ? getGradientStyle(resolvedGradientTheme, resolvedCustomThemeConfig)
     : null;
-  const iconColor = resolvedGradientTheme
+  const iconColor = useGlobalTheme
+    ? "white"
+    : resolvedGradientTheme
     ? (getAccentColor(resolvedGradientTheme, resolvedCustomThemeConfig) || "white")
     : null;
 
@@ -109,9 +114,11 @@ export function AgentAvatar({
         "flex items-center justify-center shrink-0",
         rounded,
         size,
-        isDefault
-          ? "bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600"
-          : "shadow-sm",
+        useGlobalTheme
+          ? "gradient-primary-br text-white shadow-sm"
+          : isDefault
+            ? "bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600"
+            : "shadow-sm",
         isStreaming && "animate-pulse",
         className,
       )}

--- a/ui/src/components/layout/ApplicationNavigation.tsx
+++ b/ui/src/components/layout/ApplicationNavigation.tsx
@@ -201,13 +201,21 @@ function ApplicationNavigationContents({
   const [expansionPreference,setExpansionPreference] = React.useState<{
     activeArea: string | null;
     expandedArea: string | null;
-  }>({ activeArea: null,expandedArea: null });
+    userInitiated: boolean;
+  }>({ activeArea: null,expandedArea: null,userInitiated: false });
   const routeExpandedArea = activeHasSectionNavigation ? activeArea : null;
   const hasUserExpansionPreference =
-    expansionPreference.activeArea === activeArea;
+    expansionPreference.userInitiated
+      && expansionPreference.activeArea === activeArea;
   const expandedArea = hasUserExpansionPreference
     ? expansionPreference.expandedArea
     : routeExpandedArea;
+
+  React.useEffect(() => {
+    setExpansionPreference((current) => current.activeArea === activeArea
+      ? current
+      : { activeArea,expandedArea: routeExpandedArea,userInitiated: false });
+  }, [activeArea,routeExpandedArea]);
 
   const items = [
     { key: "home",href: "/",label: "Home",icon: Home },
@@ -480,6 +488,7 @@ function ApplicationNavigationContents({
             setExpansionPreference({
               activeArea,
               expandedArea: contextExpanded ? null : item.key,
+              userInitiated: true,
             });
           };
           const control = item.disabled ? (

--- a/ui/src/components/layout/ApplicationSectionNavigation.tsx
+++ b/ui/src/components/layout/ApplicationSectionNavigation.tsx
@@ -87,12 +87,15 @@ function AdminApplicationNavigation(): React.ReactElement | null {
   const visibleDestinations = categories.flatMap(
     (category) => category.destinations,
   );
+  const onAdminRoute = pathname?.startsWith("/admin") ?? false;
   const requestedDestination = findAdminDestinationByPath(pathname);
-  const activeDestination = requestedDestination && visibleDestinations.some(
+  const activeDestination = onAdminRoute && requestedDestination && visibleDestinations.some(
     (destination) => destination.id === requestedDestination.id,
   )
     ? requestedDestination
-    : visibleDestinations[0];
+    : onAdminRoute
+      ? visibleDestinations[0]
+      : undefined;
 
   return categories.length > 0 ? (
     <AdminNavigation

--- a/ui/src/components/layout/WorkspaceNavigation.tsx
+++ b/ui/src/components/layout/WorkspaceNavigation.tsx
@@ -386,7 +386,7 @@ export function WorkspaceNavigationList({
                               "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                               density === "descriptive" ? "min-h-14" : "min-h-12",
                               active
-                                ? "bg-muted/50 font-medium text-foreground"
+                                ? "workspace-navigation-active font-medium text-foreground"
                                 : "hover:bg-muted/60 hover:text-foreground",
                             )}
                             onClick={() => {
@@ -676,10 +676,10 @@ export function WorkspaceHierarchicalNavigationList({
               aria-controls={destinationsId}
               aria-expanded={expanded}
               className={cn(
-                "group flex min-h-11 w-full items-center gap-3 rounded-xl px-2.5 py-2 text-left outline-none transition-colors",
+                "group flex min-h-11 w-full items-center gap-3 rounded-xl border border-transparent px-2.5 py-2 text-left outline-none transition-colors",
                 "focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                 active
-                  ? "bg-muted/60 font-medium text-foreground"
+                  ? "workspace-navigation-active font-medium text-foreground"
                   : expanded
                     ? "text-foreground"
                     : "text-muted-foreground hover:bg-muted/60 hover:text-foreground",
@@ -706,7 +706,7 @@ export function WorkspaceHierarchicalNavigationList({
                 aria-hidden="true"
                 className={cn(
                   "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground transition-colors",
-                  active && "bg-primary/10 text-primary",
+                  active && "gradient-primary-br text-white shadow-sm",
                   !active && "group-hover:bg-background group-hover:text-foreground",
                 )}
               >

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -636,6 +636,26 @@ describe('AppHeader — application chrome', () => {
       expect(knowledgePanel).not.toHaveClass('transition-[grid-template-rows,opacity]')
     })
 
+    it('collapses section navigation when navigation moves to a page without sections', () => {
+      mockStorageMode = 'mongodb'
+      mockIsAdmin = true
+      mockPathname = '/admin/people/users'
+
+      const { rerender } = render(<AdminNavigationFixture />)
+
+      expect(applicationButton('Admin')).toHaveAttribute('aria-expanded', 'true')
+
+      mockPathname = '/chat'
+      rerender(<></>)
+
+      expect(applicationButton('Admin')).toHaveAttribute('aria-expanded', 'false')
+
+      mockPathname = '/'
+      rerender(<></>)
+
+      expect(applicationButton('Admin')).toHaveAttribute('aria-expanded', 'false')
+    })
+
     it('keeps Admin expanded while its registered destination changes', () => {
       mockStorageMode = 'mongodb'
       mockIsAdmin = true
@@ -734,8 +754,10 @@ describe('AppHeader — application chrome', () => {
       const resourcesPanel = document.getElementById(
         resources.getAttribute('aria-controls')!,
       )
+      const people = screen.getByRole('button', { name: 'People group' })
 
       expect(resourcesPanel).not.toHaveClass('transition-[grid-template-rows,opacity]')
+      expect(people).toHaveClass('workspace-navigation-active')
       fireEvent.click(resources)
       expect(resourcesPanel).toHaveClass('transition-[grid-template-rows,opacity]')
 

--- a/ui/src/lib/appearance-preferences.ts
+++ b/ui/src/lib/appearance-preferences.ts
@@ -67,6 +67,13 @@ function isOption<Value extends string>(
   return typeof value === "string" && options.some((option) => option.id === value);
 }
 
+function hslComponents(color: string): string | null {
+  const match = color.match(
+    /^hsl\(\s*([-+]?\d*\.?\d+)\s*[, ]\s*([-+]?\d*\.?\d+)%\s*[, /]\s*([-+]?\d*\.?\d+)%/i,
+  );
+  return match ? `${match[1]} ${match[2]}% ${match[3]}%` : null;
+}
+
 export function getDefaultAppearancePreferences(): AppearancePreferences {
   const configuredTheme = getConfig("defaultTheme");
   return {
@@ -159,9 +166,23 @@ export function applyFontSize(value: FontSize): void {
 export function applyGradientTheme(value: GradientTheme): void {
   const selected = gradientThemes.find((theme) => theme.id === value);
   if (!selected) return;
-  document.documentElement.style.setProperty("--gradient-from",selected.from);
-  document.documentElement.style.setProperty("--gradient-to",selected.to);
-  document.documentElement.setAttribute("data-gradient-theme",value);
+  const root = document.documentElement;
+  root.style.setProperty("--gradient-from",selected.from);
+  root.style.setProperty("--gradient-to",selected.to);
+
+  // Primary controls are part of the selected accent system, so buttons,
+  // focus rings, selections, and active settings choices use the same hue.
+  const from = hslComponents(selected.from);
+  const to = hslComponents(selected.to);
+  if (from) {
+    root.style.setProperty("--primary",from);
+    root.style.setProperty("--ring",from);
+    root.style.setProperty("--gradient-start",from);
+    root.style.setProperty("--gradient-mid",from);
+  }
+  if (to) root.style.setProperty("--gradient-end",to);
+
+  root.setAttribute("data-gradient-theme",value);
   localStorage.setItem(STORAGE_KEYS.gradientTheme,value);
 }
 


### PR DESCRIPTION
# Description

Make the selected accent gradient drive shared primary controls, focus rings, selections, and gradient borders across the UI. Apply the global accent to the chat welcome treatment and active navigation hierarchy, while preserving semantic status colors.

Reset application and Admin navigation disclosure state when the route leaves a section so only the current page's navigation remains expanded and selected.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

For chart changes, you can test temporary versions before merging:
- **Base repo contributors:** Create a branch starting with `prebuild/` for automatic prebuilds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Temporary charts are published to `ghcr.io/caipe-io/charts` with PR-specific versions
- Cleanup happens automatically when the PR closes or label is removed

## Testing

- Focused Jest suites: 68 tests passed
- ESLint passed for all changed files
- Webpack production compilation passed; the full build reaches existing Next.js route-export type errors outside this change

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass
