### PR TITLE
fix(ci): remove retag-unchanged, always build fresh on tag push

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -293,7 +293,7 @@ jobs:
           if [[ "$IS_CHART_ONLY" == "true" ]]; then
             echo "- ⏭️ Image builds **skipped** (chart-only change)" >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "- 🔄 Image builds triggered (changed images rebuilt, unchanged retagged)" >> "$GITHUB_STEP_SUMMARY"
+            echo "- 🔄 Image builds triggered (all components rebuilt fresh)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: 📊 Existing auto-tag summary

--- a/.github/workflows/ci-audit-service.yml
+++ b/.github/workflows/ci-audit-service.yml
@@ -62,10 +62,29 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged a stale image instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             audit_service:
               - 'ai_platform_engineering/audit_service/**'

--- a/.github/workflows/ci-audit-service.yml
+++ b/.github/workflows/ci-audit-service.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       force_build:
-        description: 'Force a fresh build instead of retagging.'
+        description: 'Force a fresh build instead of relying on change detection.'
         required: false
         type: boolean
         default: false
@@ -36,7 +36,6 @@ jobs:
       (github.event_name == 'workflow_dispatch')
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
-      should_retag: ${{ steps.set-outputs.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
     steps:
       - name: Checkout repository
@@ -62,29 +61,10 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged a stale image instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             audit_service:
               - 'ai_platform_engineering/audit_service/**'
@@ -99,45 +79,21 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
         run: |
           SHOULD_BUILD="false"
-          SHOULD_RETAG="false"
 
           if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
-            {
-              echo "should_build=false"
-              echo "should_retag=false"
-            } >> "$GITHUB_OUTPUT"
+            echo "should_build=false" >> "$GITHUB_OUTPUT"
             exit 0
-          fi
-
-          if [[ "$TAG_VERSION" =~ -(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            IS_PRERELEASE="true"
-            PRERELEASE_NUM="${BASH_REMATCH[2]}"
-          else
-            IS_PRERELEASE="false"
-            PRERELEASE_NUM=0
           fi
 
           if [ "$FORCE_BUILD" == "true" ]; then
             SHOULD_BUILD="true"
-            SHOULD_RETAG="false"
           elif [ -n "$TAG_VERSION" ]; then
-            if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
-              if [ "$AUDIT_SERVICE_CHANGED" == "true" ]; then
-                SHOULD_BUILD="true"
-              else
-                SHOULD_RETAG="true"
-              fi
-            else
-              SHOULD_BUILD="true"
-            fi
+            SHOULD_BUILD="true"
           elif [ "$AUDIT_SERVICE_CHANGED" == "true" ] || [ "$EVENT_NAME" == "workflow_dispatch" ]; then
             SHOULD_BUILD="true"
           fi
 
-          {
-            echo "should_build=$SHOULD_BUILD"
-            echo "should_retag=$SHOULD_RETAG"
-          } >> "$GITHUB_OUTPUT"
+          echo "should_build=$SHOULD_BUILD" >> "$GITHUB_OUTPUT"
 
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
@@ -282,113 +238,11 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/caipe-audit-service
-      DOCKERFILE: build/Dockerfile.audit-service
-    steps:
-      - name: Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1 # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: Log in to registry
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_ACTOR: ${{ github.actor }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$GH_ACTOR" --password-stdin
-
-      - name: Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-            SOURCE_TAG=""
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
-                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
-                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
-                  SOURCE_TAG="$CANDIDATE"
-                  break
-                fi
-              done
-            fi
-            if [[ -z "$SOURCE_TAG" ]]; then
-              SOURCE_TAG="${BASE_VERSION}"
-            fi
-          else
-            SOURCE_TAG="latest"
-          fi
-
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1 && crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TAG_VERSION}"; then
-            echo "needs_build=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "needs_build=true" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-
-      # Known gap: this fallback still cross-builds arm64 under QEMU rather
-      # than a native runner (unlike build-and-push above). It only runs when
-      # the source image for retagging is missing — rare — so it hasn't been
-      # split per-platform. Apply the same native-runner + digest-merge
-      # treatment here if this path ever times out/OOMs.
-      - name: Build and Push fallback image
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          push: true
-          tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-changes.outputs.tag_version }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          provenance: false
-          sbom: false
-
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -400,14 +254,12 @@ jobs:
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
           BUILD_RESULT: ${{ needs.build-and-push.result }}
           MERGE_RESULT: ${{ needs.merge-manifests.result }}
-          RETAG_RESULT: ${{ needs.retag-unchanged.result }}
           REPOSITORY: ${{ github.repository }}
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
           if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
-          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-autonomous-agents.yml
+++ b/.github/workflows/ci-autonomous-agents.yml
@@ -25,7 +25,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
-      should_retag: ${{ steps.set-outputs.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
     steps:
       - name: Checkout repository
@@ -40,29 +39,10 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged a stale image instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             autonomous_agents:
               - 'ai_platform_engineering/autonomous_agents/**'
@@ -75,47 +55,25 @@ jobs:
           TAG_VERSION: ${{ steps.version.outputs.tag_version }}
         run: |
           SHOULD_BUILD="false"
-          SHOULD_RETAG="false"
           TAG_VERSION="${{ env.TAG_VERSION }}"
 
           # Chart-only tag: skip image builds entirely
           if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
             echo "📊 Chart-only tag: skipping image builds"
             echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "should_retag=false" >> $GITHUB_OUTPUT
             exit 0
           fi
 
-          # Determine pre-release type and number
-          if [[ "$TAG_VERSION" =~ -(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            IS_PRERELEASE="true"
-            PRERELEASE_NUM="${BASH_REMATCH[2]}"
-          else
-            IS_PRERELEASE="false"
-            PRERELEASE_NUM=0
-          fi
-
           if [ -n "$TAG_VERSION" ]; then
-            if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
-              if [ "$AUTONOMOUS_AGENTS_CHANGED" == "true" ]; then
-                SHOULD_BUILD="true"
-                echo "🔨 Pre-release tag with changes: building"
-              else
-                SHOULD_RETAG="true"
-                echo "🏷️ Pre-release tag without changes: retagging"
-              fi
-            else
-              SHOULD_BUILD="true"
-              echo "🚀 Build all: first pre-release or final release"
-            fi
+            SHOULD_BUILD="true"
+            echo "🏷️ Tag push: building fresh"
           elif [ "$AUTONOMOUS_AGENTS_CHANGED" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             SHOULD_BUILD="true"
             echo "📦 Files changed or manual trigger: building"
           fi
 
           echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
-          echo "should_retag=$SHOULD_RETAG" >> $GITHUB_OUTPUT
-          echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG"
+          echo "Outputs: build=$SHOULD_BUILD"
 
   build-and-push:
     runs-on: ubuntu-latest
@@ -174,123 +132,12 @@ jobs:
           provenance: false
           sbom: false
 
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/caipe-autonomous-agents
-      DOCKERFILE: build/Dockerfile.autonomous-agents
-
-    steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1  # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: 📦 Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: 🔐 Log in to registry
-        env:
-          GH_ACTOR: ${{ github.actor }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$GH_ACTOR" --password-stdin
-
-      - name: 🔍 Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-
-          echo "🏷️ Processing autonomous-agents..."
-
-          # Determine source tag (previous version)
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              PREV_NUM=$((SUFFIX_NUM - 1))
-              SOURCE_TAG="${BASE_VERSION}-${SUFFIX_TYPE}.${PREV_NUM}"
-            else
-              SOURCE_TAG="${BASE_VERSION}"
-            fi
-          else
-            SOURCE_TAG="latest"
-          fi
-
-          TARGET_TAG="${TAG_VERSION}"
-
-          echo "  Source: ${SOURCE_TAG}"
-          echo "  Target: ${TARGET_TAG}"
-
-          # Check if source image exists
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            echo "  ✅ Source image exists, retagging..."
-            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TARGET_TAG}"; then
-              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-            else
-              echo "  ⚠️ Retag failed unexpectedly, will build instead"
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "  ⚠️ Source image ${SOURCE_TAG} not found (may still be building)"
-            echo "  📦 Will build fresh instead of using stale fallback"
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Fallback build if retag not possible
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-      - name: 🔨 Build and Push (fallback)
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: ai_platform_engineering/autonomous_agents
-          file: ${{ env.DOCKERFILE }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-changes.outputs.tag_version }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          provenance: false
-          sbom: false
-
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, retag-unchanged]
+    needs: [determine-changes, build-and-push]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -301,7 +148,6 @@ jobs:
           BUILD_RESULT: ${{ needs.build-and-push.result }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPOSITORY: ${{ github.repository }}
-          RETAG_RESULT: ${{ needs.retag-unchanged.result }}
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
           WORKFLOW_NAME: ${{ github.workflow }}
         run: |
@@ -309,9 +155,8 @@ jobs:
 
           # Consider skipped as success (job conditions not met)
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-autonomous-agents.yml
+++ b/.github/workflows/ci-autonomous-agents.yml
@@ -40,10 +40,29 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged a stale image instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             autonomous_agents:
               - 'ai_platform_engineering/autonomous_agents/**'

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -50,10 +50,29 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ github.token }}
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged a stale image instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             ui:
               - 'ui/**'

--- a/.github/workflows/ci-caipe-ui.yml
+++ b/.github/workflows/ci-caipe-ui.yml
@@ -16,7 +16,7 @@ on:
         required: false
         type: string
       force_build:
-        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        description: 'Force a fresh build of all components (bypass change-detection). Use for coordinated releases.'
         required: false
         type: boolean
         default: false
@@ -34,7 +34,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
-      should_retag: ${{ steps.set-outputs.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
     steps:
       - name: Checkout repository
@@ -50,29 +49,10 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ github.token }}
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged a stale image instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             ui:
               - 'ui/**'
@@ -86,50 +66,27 @@ jobs:
           FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
-          SHOULD_RETAG="false"
 
           # Chart-only tag: skip image builds entirely
           if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
             echo "📊 Chart-only tag: skipping image builds"
             echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "should_retag=false" >> $GITHUB_OUTPUT
             exit 0
-          fi
-
-          # Determine pre-release type and number
-          if [[ "$TAG_VERSION" =~ -(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            IS_PRERELEASE="true"
-            PRERELEASE_NUM="${BASH_REMATCH[2]}"
-          else
-            IS_PRERELEASE="false"
-            PRERELEASE_NUM=0
           fi
 
           if [ "$FORCE_BUILD" == "true" ]; then
             SHOULD_BUILD="true"
-            SHOULD_RETAG="false"
             echo "🔁 force_build requested: building fresh regardless of changes"
           elif [ -n "$TAG_VERSION" ]; then
-            if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
-              if [ "$UI_CHANGED" == "true" ]; then
-                SHOULD_BUILD="true"
-                echo "🔨 Pre-release tag with UI changes: building"
-              else
-                SHOULD_RETAG="true"
-                echo "🏷️ Pre-release tag without UI changes: retagging"
-              fi
-            else
-              SHOULD_BUILD="true"
-              echo "🚀 Build all: first pre-release or final release"
-            fi
+            SHOULD_BUILD="true"
+            echo "🏷️ Tag push: building fresh"
           elif [ "$UI_CHANGED" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             SHOULD_BUILD="true"
             echo "📦 UI files changed or manual trigger: building"
           fi
 
           echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
-          echo "should_retag=$SHOULD_RETAG" >> $GITHUB_OUTPUT
-          echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG"
+          echo "Outputs: build=$SHOULD_BUILD"
 
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
@@ -307,177 +264,12 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/caipe-ui
-      DOCKERFILE: build/Dockerfile.caipe-ui
-
-    steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1  # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-packages: write
-
-      - name: 📦 Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: 🔐 Log in to registry
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_ACTOR: ${{ github.actor }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$GH_ACTOR" --password-stdin
-
-      - name: 🔍 Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-          echo "🏷️ Processing caipe-ui..."
-
-          # Determine source tag (previous version). Walk back from N-1 to the
-          # latest rc/hotfix that actually has a published image, so a component
-          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
-          # retags from the most recent real image (rc.8) instead of a phantom
-          # rc.9. Falls back to the base version, then to a fresh build.
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-
-            SOURCE_TAG=""
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
-                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
-                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
-                  SOURCE_TAG="$CANDIDATE"
-                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
-                  break
-                fi
-              done
-            fi
-            if [[ -z "$SOURCE_TAG" ]]; then
-              SOURCE_TAG="${BASE_VERSION}"
-            fi
-          else
-            SOURCE_TAG="latest"
-          fi
-
-          echo "  Source: ${SOURCE_TAG}"
-          echo "  Target: ${TAG_VERSION}"
-
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            echo "  ✅ Source image exists, retagging..."
-            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TAG_VERSION}"; then
-              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-            else
-              echo "  ⚠️ Retag failed unexpectedly, will build instead"
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "  ⚠️ Source image ${SOURCE_TAG} not found"
-            echo "  📦 Will build fresh instead"
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Fallback build if retag not possible
-      - name: Free disk space
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        run: |
-          echo "Disk usage before cleanup:"
-          df -h
-          sudo apt-get remove -y '^ghc-*' || true
-          sudo apt-get remove -y '^dotnet-*' || true
-          sudo apt-get remove -y '^llvm-*' || true
-          sudo apt-get remove -y 'php*' || true
-          sudo apt-get remove -y azure-cli google-cloud-cli hhvm google-chrome-stable firefox powershell mono-devel || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          docker system prune -af --volumes || true
-          echo "Disk usage after cleanup:"
-          df -h
-
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-        with:
-          persist-credentials: false
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-      # Known gap: this fallback still cross-builds arm64 under QEMU rather
-      # than a native runner (unlike build-and-push above). It only runs when
-      # the source image for retagging is missing — rare — so it hasn't been
-      # split per-platform. Apply the same native-runner + digest-merge
-      # treatment here if this path ever times out/OOMs.
-      - name: 🔨 Build and Push (fallback)
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          target: runner
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-changes.outputs.tag_version }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          build-args: |
-            CAIPE_URL=http://caipe-supervisor:8000
-            BUILDKIT_INLINE_CACHE=1
-            IMAGE_TAG=${{ needs.determine-changes.outputs.tag_version || github.sha }}
-            GIT_COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
-          provenance: false
-          sbom: false
-
   # Notify release-finalize workflow when this CI completes
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -499,19 +291,16 @@ jobs:
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
           BUILD_PUSH_RESULT: ${{ needs.build-and-push.result }}
           MERGE_RESULT: ${{ needs.merge-manifests.result }}
-          RETAG_UNCHANGED_RESULT: ${{ needs.retag-unchanged.result }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_WORKFLOW: ${{ github.workflow }}
         run: |
           BUILD_RESULT="$BUILD_PUSH_RESULT"
           MERGE_RESULT_VAL="$MERGE_RESULT"
-          RETAG_RESULT="$RETAG_UNCHANGED_RESULT"
 
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
           if [[ "$MERGE_RESULT_VAL" == "skipped" ]]; then MERGE_RESULT_VAL="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT_VAL" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT_VAL" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -58,10 +58,29 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged a stale image instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             dynamic_agents:
               - 'ai_platform_engineering/dynamic_agents/**'

--- a/.github/workflows/ci-dynamic-agents.yml
+++ b/.github/workflows/ci-dynamic-agents.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       force_build:
-        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        description: 'Force a fresh build of all components (bypass change-detection). Use for coordinated releases.'
         required: false
         type: boolean
         default: false
@@ -32,7 +32,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
-      should_retag: ${{ steps.set-outputs.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
     steps:
       - name: Checkout repository
@@ -58,29 +57,10 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged a stale image instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             dynamic_agents:
               - 'ai_platform_engineering/dynamic_agents/**'
@@ -93,51 +73,28 @@ jobs:
           FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
-          SHOULD_RETAG="false"
           TAG_VERSION="${{ env.TAG_VERSION }}"
 
           # Chart-only tag: skip image builds entirely
           if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
             echo "📊 Chart-only tag: skipping image builds"
             echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "should_retag=false" >> $GITHUB_OUTPUT
             exit 0
-          fi
-
-          # Determine pre-release type and number
-          if [[ "$TAG_VERSION" =~ -(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            IS_PRERELEASE="true"
-            PRERELEASE_NUM="${BASH_REMATCH[2]}"
-          else
-            IS_PRERELEASE="false"
-            PRERELEASE_NUM=0
           fi
 
           if [ "$FORCE_BUILD" == "true" ]; then
             SHOULD_BUILD="true"
-            SHOULD_RETAG="false"
             echo "🔁 force_build requested: building fresh regardless of changes"
           elif [ -n "$TAG_VERSION" ]; then
-            if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
-              if [ "$DYNAMIC_AGENTS_CHANGED" == "true" ]; then
-                SHOULD_BUILD="true"
-                echo "🔨 Pre-release tag with changes: building"
-              else
-                SHOULD_RETAG="true"
-                echo "🏷️ Pre-release tag without changes: retagging"
-              fi
-            else
-              SHOULD_BUILD="true"
-              echo "🚀 Build all: first pre-release or final release"
-            fi
+            SHOULD_BUILD="true"
+            echo "🏷️ Tag push: building fresh"
           elif [ "$DYNAMIC_AGENTS_CHANGED" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             SHOULD_BUILD="true"
             echo "📦 Files changed or manual trigger: building"
           fi
 
           echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
-          echo "should_retag=$SHOULD_RETAG" >> $GITHUB_OUTPUT
-          echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG"
+          echo "Outputs: build=$SHOULD_BUILD"
 
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
@@ -295,150 +252,12 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/caipe-dynamic-agents
-      DOCKERFILE: ai_platform_engineering/dynamic_agents/build/Dockerfile
-
-    steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1  # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-packages: write
-
-      - name: 📦 Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: 🔐 Log in to registry
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GH_ACTOR: ${{ github.actor }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$GH_ACTOR" --password-stdin
-
-      - name: 🔍 Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-
-          echo "🏷️ Processing dynamic-agents..."
-
-          # Determine source tag (previous version). Walk back from N-1 to the
-          # latest rc/hotfix that actually has a published image, so a component
-          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
-          # retags from the most recent real image (rc.8) instead of a phantom
-          # rc.9. Falls back to the base version, then to a fresh build.
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-
-            SOURCE_TAG=""
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
-                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
-                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
-                  SOURCE_TAG="$CANDIDATE"
-                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
-                  break
-                fi
-              done
-            fi
-            if [[ -z "$SOURCE_TAG" ]]; then
-              SOURCE_TAG="${BASE_VERSION}"
-            fi
-          else
-            SOURCE_TAG="latest"
-          fi
-
-          TARGET_TAG="${TAG_VERSION}"
-
-          echo "  Source: ${SOURCE_TAG}"
-          echo "  Target: ${TARGET_TAG}"
-
-          # Check if source image exists
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            echo "  ✅ Source image exists, retagging..."
-            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TARGET_TAG}"; then
-              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-            else
-              echo "  ⚠️ Retag failed unexpectedly, will build instead"
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "  ⚠️ Source image ${SOURCE_TAG} not found (may still be building)"
-            echo "  📦 Will build fresh instead of using stale fallback"
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Fallback build if retag not possible
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-      # Known gap: this fallback still cross-builds arm64 under QEMU rather
-      # than a native runner (unlike build-and-push above). It only runs when
-      # the source image for retagging is missing — rare — so it hasn't been
-      # split per-platform. Apply the same native-runner + digest-merge
-      # treatment here if this path ever times out/OOMs.
-      - name: 🔨 Build and Push (fallback)
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: ai_platform_engineering/dynamic_agents
-          file: ${{ env.DOCKERFILE }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-changes.outputs.tag_version }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          provenance: false
-          sbom: false
-
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -460,21 +279,18 @@ jobs:
           TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
           BUILD_PUSH_RESULT: ${{ needs.build-and-push.result }}
           MERGE_RESULT: ${{ needs.merge-manifests.result }}
-          RETAG_UNCHANGED_RESULT: ${{ needs.retag-unchanged.result }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_WORKFLOW: ${{ github.workflow }}
         run: |
           # Determine overall conclusion
           BUILD_RESULT="$BUILD_PUSH_RESULT"
           MERGE_RESULT_VAL="$MERGE_RESULT"
-          RETAG_RESULT="$RETAG_UNCHANGED_RESULT"
 
           # Consider skipped as success (job conditions not met)
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
           if [[ "$MERGE_RESULT_VAL" == "skipped" ]]; then MERGE_RESULT_VAL="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT_VAL" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT_VAL" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-mcp-servers.yml
+++ b/.github/workflows/ci-mcp-servers.yml
@@ -105,10 +105,29 @@ jobs:
             });
             core.setOutput('filters', filters);
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged stale images instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths (MCP)
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: ${{ steps.generate-filters.outputs.filters }}
 
       - name: Set matrix based on changes (MCP)

--- a/.github/workflows/ci-mcp-servers.yml
+++ b/.github/workflows/ci-mcp-servers.yml
@@ -12,12 +12,12 @@ on:
   workflow_dispatch:
     inputs:
       build_all:
-        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        description: 'Force a fresh build of all components (bypass change-detection). Use for coordinated releases.'
         required: false
         default: false
         type: boolean
       tag_version:
-        description: 'Version tag to apply (e.g., 0.3.0-dev.5). If provided, unchanged agents will be retagged from previous version.'
+        description: 'Version tag to apply (e.g., 0.3.0-dev.5).'
         required: false
         type: string
 
@@ -56,9 +56,7 @@ jobs:
       (github.event_name == 'workflow_dispatch')
     outputs:
       agents_to_build: ${{ steps.set-matrix.outputs.agents_to_build }}
-      agents_to_retag: ${{ steps.set-matrix.outputs.agents_to_retag }}
       should_build: ${{ steps.set-matrix.outputs.should_build }}
-      should_retag: ${{ steps.set-matrix.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
     env:
       ALL_AGENTS: ${{ needs.load-config.outputs.all_agents }}
@@ -105,29 +103,10 @@ jobs:
             });
             core.setOutput('filters', filters);
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged stale images instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths (MCP)
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: ${{ steps.generate-filters.outputs.filters }}
 
       - name: Set matrix based on changes (MCP)
@@ -148,44 +127,25 @@ jobs:
             if (/-chart\.\d+$/.test(tagVersion)) {
               console.log("📊 Chart-only tag: skipping image builds");
               core.setOutput('agents_to_build', '[]');
-              core.setOutput('agents_to_retag', '[]');
               core.setOutput('should_build', 'false');
-              core.setOutput('should_retag', 'false');
               return;
             }
 
-            const preReleaseMatch = tagVersion ? tagVersion.match(/-(dev|rc|hotfix)\.(\d+)$/) : null;
-            const isPreRelease = !!preReleaseMatch;
-            const preReleaseNum = preReleaseMatch ? parseInt(preReleaseMatch[2]) : 0;
             const isSharedChanged = filterOutputs.shared_config === 'true' ||
                                    filterOutputs.shared_dockerfile === 'true';
 
-            // Build all if: manual, shared changed, first pre-release (N==1), or final release
-            const shouldForceBuildAll = manualBuildAll || isSharedChanged ||
-              (tagVersion && !isPreRelease) ||
-              (isPreRelease && preReleaseNum === 1);
-
             let agentsToBuild;
-            let agentsToRetag = [];
-
-            if (shouldForceBuildAll) {
-              console.log("🚀 Build all: " + (manualBuildAll ? "manual" : isSharedChanged ? "shared changed" : "first pre-release or final release"));
+            if (manualBuildAll || isSharedChanged || tagVersion) {
+              console.log("🚀 Build all: " + (manualBuildAll ? "manual" : isSharedChanged ? "shared changed" : "tag push"));
               agentsToBuild = allAgents;
-            } else if (isPreRelease && preReleaseNum > 1) {
-              console.log(`🏷️ Pre-release N>1 (${tagVersion}): build changed / retag unchanged`);
-              agentsToBuild = allAgents.filter(a => filterOutputs[a] === 'true');
-              agentsToRetag = allAgents.filter(a => filterOutputs[a] !== 'true');
             } else {
               console.log("🔍 Standard PR: building only changed agents");
               agentsToBuild = allAgents.filter(a => filterOutputs[a] === 'true');
             }
 
             core.setOutput('agents_to_build', JSON.stringify(agentsToBuild));
-            core.setOutput('agents_to_retag', JSON.stringify(agentsToRetag));
             core.setOutput('should_build', String(agentsToBuild.length > 0));
-            core.setOutput('should_retag', String(agentsToRetag.length > 0 && !!tagVersion));
             console.log(`Agents to build: ${agentsToBuild.join(', ') || 'none'}`);
-            console.log(`Agents to retag: ${agentsToRetag.join(', ') || 'none'}`);
 
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
@@ -351,154 +311,12 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  # Retag unchanged agents from previous version when tag_version is provided
-  # If source image doesn't exist (still building), falls back to full build
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: determine-agents
-    if: needs.determine-agents.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    strategy:
-      matrix:
-        agent: ${{ fromJson(needs.determine-agents.outputs.agents_to_retag) }}
-      fail-fast: false
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/mcp-${{ matrix.agent }}
-
-    steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1  # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_MCP_APP_ID }}
-          private-key: ${{ secrets.CI_MCP_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-packages: write
-
-      - name: 📦 Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: 🔐 Log in to registry
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REGISTRY_USER: ${{ github.actor }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$REGISTRY_USER" --password-stdin
-
-      - name: 🔍 Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-agents.outputs.tag_version }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-          echo "🏷️ Processing mcp-${{ matrix.agent }}..."
-
-          # Determine source tag (previous version). Walk back from N-1 to the
-          # latest rc/hotfix that actually has a published image, so a component
-          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
-          # retags from the most recent real image (rc.8) instead of a phantom
-          # rc.9. Falls back to the base version, then to a fresh build.
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-
-            SOURCE_TAG=""
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
-                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
-                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
-                  SOURCE_TAG="$CANDIDATE"
-                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
-                  break
-                fi
-              done
-            fi
-            if [[ -z "$SOURCE_TAG" ]]; then
-              SOURCE_TAG="${BASE_VERSION}"
-            fi
-          else
-            SOURCE_TAG="latest"
-          fi
-
-          echo "  Source: ${SOURCE_TAG}"
-          echo "  Target: ${TAG_VERSION}"
-
-          # Check if source image exists
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            echo "  ✅ Source image exists, retagging..."
-            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TAG_VERSION}"; then
-              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-            else
-              echo "  ⚠️ Retag failed unexpectedly, will build instead"
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "  ⚠️ Source image ${SOURCE_TAG} not found (may still be building)"
-            echo "  📦 Will build fresh instead of using stale fallback"
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Fallback build if retag not possible
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-
-      # Known gap: this fallback still cross-builds arm64 under QEMU rather
-      # than a native runner (unlike build-and-push above). It only runs when
-      # the source image for retagging is missing — rare — so it hasn't been
-      # split per-platform. Apply the same native-runner + digest-merge
-      # treatment here if this path ever times out/OOMs.
-      - name: 🔨 Build and Push (fallback)
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          file: build/agents/Dockerfile.mcp
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-agents.outputs.tag_version }}
-          build-args: |
-            AGENT_NAME=${{ matrix.agent }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-agents, build-and-push, merge-manifests, retag-unchanged]
+    needs: [determine-agents, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-agents.outputs.tag_version != '' &&
@@ -523,14 +341,12 @@ jobs:
           # Determine overall conclusion
           BUILD_RESULT="${{ needs.build-and-push.result }}"
           MERGE_RESULT="${{ needs.merge-manifests.result }}"
-          RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           # Consider skipped as success (job conditions not met)
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
           if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-rag.yml
+++ b/.github/workflows/ci-rag.yml
@@ -83,10 +83,29 @@ jobs:
           # app secrets. They only need read access for tag detection.
           token: ${{ steps.app-token.outputs.token || github.token }}
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged a stale image instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             shared:
               - 'ai_platform_engineering/knowledge_bases/rag/common/**'

--- a/.github/workflows/ci-rag.yml
+++ b/.github/workflows/ci-rag.yml
@@ -1,4 +1,3 @@
-# assisted-by claude code claude-sonnet-4-6
 name: "[CI] CAIPE RAG Build and Push"
 description: "Build and push CAIPE RAG Docker image"
 
@@ -16,7 +15,7 @@ on:
         required: false
         type: string
       force_build:
-        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        description: 'Force a fresh build of all components (bypass change-detection). Use for coordinated releases.'
         required: false
         type: boolean
         default: false
@@ -51,11 +50,9 @@ jobs:
     needs: load-config
     outputs:
       should_build: ${{ steps.set-matrix.outputs.should_build }}
-      should_retag: ${{ steps.set-matrix.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
       build_matrix: ${{ steps.set-matrix.outputs.build_matrix }}
       build_groups: ${{ steps.set-matrix.outputs.build_groups }}
-      retag_matrix: ${{ steps.set-matrix.outputs.retag_matrix }}
     steps:
       - name: 🔑 Generate GitHub App token
         id: app-token
@@ -83,29 +80,10 @@ jobs:
           # app secrets. They only need read access for tag detection.
           token: ${{ steps.app-token.outputs.token || github.token }}
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged a stale image instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             shared:
               - 'ai_platform_engineering/knowledge_bases/rag/common/**'
@@ -121,10 +99,8 @@ jobs:
 
       # Build only the components whose own sources (or the shared `common/`
       # library) changed, instead of rebuilding all three on any rag/** edit.
-      # First pre-release / final release / manual dispatch / force_build still
-      # build everything; on incremental pre-releases unchanged components are
-      # retagged from the previous version.
-      - name: Compute build & retag matrices
+      # Tag pushes, manual dispatch, and force_build still build everything.
+      - name: Compute build matrix
         id: set-matrix
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
@@ -183,45 +159,28 @@ jobs:
             const changedSet = sharedChanged ? allComponents : changed;
 
             let buildComponents = [];
-            let retagComponents = [];
             if (/-chart\.\d+$/.test(tag)) {
               console.log('📊 Chart-only tag: skipping image builds');
+            } else if (forceBuild) {
+              buildComponents = allComponents;
+              console.log('🔁 force_build requested: building all');
+            } else if (tag) {
+              buildComponents = allComponents;
+              console.log('🏷️ Tag push: building all');
+            } else if (event === 'workflow_dispatch') {
+              buildComponents = allComponents;
+              console.log('🔧 Manual trigger: building all');
             } else {
-              const pre = tag.match(/-(dev|rc|hotfix)\.(\d+)$/);
-              const preNum = pre ? parseInt(pre[2], 10) : 0;
-
-              if (forceBuild) {
-                // Coordinated release / manual override: build every component fresh.
-                buildComponents = allComponents;
-                console.log('🔁 force_build requested: building all');
-              } else if (tag) {
-                if (pre && preNum > 1) {
-                  // Incremental pre-release: build changed components, retag the rest.
-                  buildComponents = changedSet;
-                  retagComponents = allComponents.filter(c => !changedSet.includes(c));
-                  console.log(`🔨 Incremental pre-release: build [${buildComponents}], retag [${retagComponents}]`);
-                } else {
-                  // First pre-release or final release: build everything.
-                  buildComponents = allComponents;
-                  console.log('🚀 First pre-release or final release: building all');
-                }
-              } else if (event === 'workflow_dispatch') {
-                buildComponents = allComponents;
-                console.log('🔧 Manual trigger: building all');
-              } else {
-                // PR / push without a tag: build only changed components.
-                buildComponents = changedSet;
-                console.log(`📦 Changed components: [${buildComponents}]`);
-              }
+              // PR / push without a tag: build only changed components.
+              buildComponents = changedSet;
+              console.log(`📦 Changed components: [${buildComponents}]`);
             }
 
             const buildMatrix = expandPlatforms(buildComponents);
             const buildGroups = expand(buildComponents);
             core.setOutput('build_matrix', JSON.stringify({ include: buildMatrix }));
             core.setOutput('build_groups', JSON.stringify({ include: buildGroups }));
-            core.setOutput('retag_matrix', JSON.stringify({ include: expand(retagComponents) }));
             core.setOutput('should_build', String(buildGroups.length > 0));
-            core.setOutput('should_retag', String(retagComponents.length > 0));
 
   # Build each component/variant natively per-platform (no QEMU emulation) and
   # push by digest only. merge-manifests (below) then stitches the per-arch
@@ -432,205 +391,12 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  # Retag unchanged rag components from previous version when tag_version is provided
-  # If source image doesn't exist (still building), falls back to full build
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: [determine-changes, load-config]
-    if: needs.determine-changes.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    strategy:
-      matrix: ${{ fromJson(needs.determine-changes.outputs.retag_matrix) }}
-      fail-fast: false
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/caipe-rag-${{ matrix.component }}
-      DOCKERFILE: ai_platform_engineering/knowledge_bases/rag/build/Dockerfile.${{ matrix.component }}
-
-    steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1  # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-packages: write
-
-      - name: 📦 Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: 🔐 Log in to registry
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          GHCR_ACTOR: ${{ github.actor }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$GHCR_ACTOR" --password-stdin
-
-      - name: 🔍 Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
-          VARIANT: ${{ matrix.variant }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-
-          # Determine variant suffix for tags
-          if [[ "$VARIANT" != "default" ]]; then
-            VARIANT_SUFFIX="-${VARIANT}"
-          else
-            VARIANT_SUFFIX=""
-          fi
-
-          echo "🏷️ Processing rag-${{ matrix.component }}${VARIANT_SUFFIX}..."
-
-          # Determine source tag (previous version). Walk back from N-1 to the
-          # latest rc/hotfix that actually has a published image, so a component
-          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
-          # retags from the most recent real image (rc.8) instead of a phantom
-          # rc.9. Falls back to the base version, then to a fresh build.
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-
-            SOURCE_TAG=""
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
-                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}${VARIANT_SUFFIX}"
-                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
-                  SOURCE_TAG="$CANDIDATE"
-                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
-                  break
-                fi
-              done
-            fi
-            if [[ -z "$SOURCE_TAG" ]]; then
-              SOURCE_TAG="${BASE_VERSION}${VARIANT_SUFFIX}"
-            fi
-          else
-            SOURCE_TAG="latest${VARIANT_SUFFIX}"
-          fi
-
-          TARGET_TAG="${TAG_VERSION}${VARIANT_SUFFIX}"
-
-          echo "  Source: ${SOURCE_TAG}"
-          echo "  Target: ${TARGET_TAG}"
-
-          # Check if source image exists
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            echo "  ✅ Source image exists, retagging..."
-            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TARGET_TAG}"; then
-              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-            else
-              echo "  ⚠️ Retag failed unexpectedly, will build instead"
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "  ⚠️ Source image ${SOURCE_TAG} not found (may still be building)"
-            echo "  📦 Will build fresh instead of using stale fallback"
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Fallback build if retag not possible
-      - name: Free disk space
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        run: |
-          echo "Disk usage before cleanup:"
-          df -h
-
-          # Remove unnecessary packages and files
-          sudo apt-get remove -y '^ghc-*' || true
-          sudo apt-get remove -y '^dotnet-*' || true
-          sudo apt-get remove -y '^llvm-*' || true
-          sudo apt-get remove -y 'php*' || true
-          sudo apt-get remove -y azure-cli google-cloud-cli hhvm google-chrome-stable firefox powershell mono-devel || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-
-          # Remove large directories
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-
-          # Clean Docker system
-          docker system prune -af --volumes || true
-
-          echo "Disk usage after cleanup:"
-          df -h
-
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-      - name: Clean up before build
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        run: |
-          echo "Cleaning up Docker system before build..."
-          docker system prune -f --volumes || true
-          echo "Current disk usage:"
-          df -h
-
-      # Known gap: this fallback still cross-builds arm64 under QEMU rather
-      # than using a native runner (unlike build-and-push above). It only
-      # runs when the source image for retagging is missing — rare in
-      # practice — so it hasn't been split per-platform. If this path starts
-      # timing out/OOMing the same way build-and-push did, apply the same
-      # native-runner + digest-merge treatment here.
-      - name: 🔨 Build and Push (fallback)
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: ai_platform_engineering/knowledge_bases/rag
-          file: ${{ env.DOCKERFILE }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-changes.outputs.tag_version }}${{ matrix.variant != 'default' && format('-{0}', matrix.variant) || '' }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: ${{ matrix.component != 'server' && 'type=gha,mode=min' || '' }}
-          build-args: |
-            VARIANT=${{ matrix.variant }}
-            BUILDKIT_INLINE_CACHE=1
-          provenance: false
-          sbom: false
-
   # Notify release-finalize workflow when this CI completes (for final release builds only)
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -655,14 +421,12 @@ jobs:
           # Determine overall conclusion
           BUILD_RESULT="${{ needs.build-and-push.result }}"
           MERGE_RESULT="${{ needs.merge-manifests.result }}"
-          RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           # Consider skipped as success (job conditions not met)
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
           if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -75,10 +75,29 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged a stale image instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             scanner:
               - 'build/Dockerfile.skill-scanner'

--- a/.github/workflows/ci-skill-scanner.yml
+++ b/.github/workflows/ci-skill-scanner.yml
@@ -31,7 +31,7 @@ on:
         required: false
         type: string
       force_build:
-        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        description: 'Force a fresh build of all components (bypass change-detection). Use for coordinated releases.'
         required: false
         type: boolean
         default: false
@@ -48,7 +48,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
-      should_retag: ${{ steps.set-outputs.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
       scanner_version: ${{ steps.scanner_version.outputs.scanner_version }}
     steps:
@@ -75,29 +74,10 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged a stale image instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             scanner:
               - 'build/Dockerfile.skill-scanner'
@@ -125,51 +105,28 @@ jobs:
           FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
-          SHOULD_RETAG="false"
           TAG_VERSION="${{ env.TAG_VERSION }}"
 
           # Chart-only tag: skip image builds entirely (mirrors ci-caipe-ui.yml)
           if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
             echo "📊 Chart-only tag: skipping image builds"
             echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "should_retag=false" >> $GITHUB_OUTPUT
             exit 0
-          fi
-
-          # Determine pre-release type and number
-          if [[ "$TAG_VERSION" =~ -(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            IS_PRERELEASE="true"
-            PRERELEASE_NUM="${BASH_REMATCH[2]}"
-          else
-            IS_PRERELEASE="false"
-            PRERELEASE_NUM=0
           fi
 
           if [ "$FORCE_BUILD" == "true" ]; then
             SHOULD_BUILD="true"
-            SHOULD_RETAG="false"
             echo "🔁 force_build requested: building fresh regardless of changes"
           elif [ -n "$TAG_VERSION" ]; then
-            if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
-              if [ "$SCANNER_CHANGED" == "true" ]; then
-                SHOULD_BUILD="true"
-                echo "🔨 Pre-release tag with scanner changes: building"
-              else
-                SHOULD_RETAG="true"
-                echo "🏷️ Pre-release tag without scanner changes: retagging"
-              fi
-            else
-              SHOULD_BUILD="true"
-              echo "🚀 Build all: first pre-release or final release"
-            fi
+            SHOULD_BUILD="true"
+            echo "🏷️ Tag push: building fresh"
           elif [ "$SCANNER_CHANGED" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             SHOULD_BUILD="true"
             echo "📦 Scanner files changed or manual trigger: building"
           fi
 
           echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
-          echo "should_retag=$SHOULD_RETAG" >> $GITHUB_OUTPUT
-          echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG"
+          echo "Outputs: build=$SHOULD_BUILD"
 
   # Build natively per-platform (no QEMU) and push by digest only;
   # merge-manifests combines the per-arch digests into the final tagged
@@ -354,168 +311,6 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/skill-scanner
-      DOCKERFILE: build/Dockerfile.skill-scanner
-
-    steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1  # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-packages: write
-
-      - name: 📦 Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: 🔐 Log in to registry
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REGISTRY_USER: ${{ github.actor }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$REGISTRY_USER" --password-stdin
-
-      - name: 🔍 Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-          echo "🏷️ Processing skill-scanner..."
-
-          # Determine source tag (previous version). Walk back from N-1 to the
-          # latest rc/hotfix that actually has a published image, so a component
-          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
-          # retags from the most recent real image (rc.8) instead of a phantom
-          # rc.9. Falls back to the base version, then to a fresh build.
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-
-            SOURCE_TAG=""
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
-                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
-                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
-                  SOURCE_TAG="$CANDIDATE"
-                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
-                  break
-                fi
-              done
-            fi
-            if [[ -z "$SOURCE_TAG" ]]; then
-              SOURCE_TAG="${BASE_VERSION}"
-            fi
-          else
-            SOURCE_TAG="latest"
-          fi
-
-          echo "  Source: ${SOURCE_TAG}"
-          echo "  Target: ${TAG_VERSION}"
-
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            echo "  ✅ Source image exists, retagging..."
-            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TAG_VERSION}"; then
-              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-            else
-              echo "  ⚠️ Retag failed unexpectedly, will build instead"
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "  ⚠️ Source image ${SOURCE_TAG} not found"
-            echo "  📦 Will build fresh instead"
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Fallback build if retag not possible
-      - name: Free disk space
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        run: |
-          echo "Disk usage before cleanup:"
-          df -h
-          sudo apt-get remove -y '^ghc-*' || true
-          sudo apt-get remove -y '^dotnet-*' || true
-          sudo apt-get remove -y '^llvm-*' || true
-          sudo apt-get remove -y 'php*' || true
-          sudo apt-get remove -y azure-cli google-cloud-cli hhvm google-chrome-stable firefox powershell mono-devel || true
-          sudo apt-get autoremove -y
-          sudo apt-get clean
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /usr/local/lib/android
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
-          docker system prune -af --volumes || true
-          echo "Disk usage after cleanup:"
-          df -h
-
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-      # Known gap: this fallback still cross-builds arm64 under QEMU rather
-      # than a native runner (unlike build-and-push above). It only runs when
-      # the source image for retagging is missing — rare — so it hasn't been
-      # split per-platform. Apply the same native-runner + digest-merge
-      # treatment here if this path ever times out/OOMs.
-      - name: 🔨 Build and Push (fallback)
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-changes.outputs.tag_version }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=min
-          build-args: |
-            SKILL_SCANNER_VERSION=${{ needs.determine-changes.outputs.scanner_version }}
-            BUILDKIT_INLINE_CACHE=1
-            IMAGE_TAG=${{ needs.determine-changes.outputs.tag_version || github.sha }}
-            GIT_COMMIT=${{ github.sha }}
-            BUILD_DATE=${{ github.event.head_commit.timestamp }}
-          provenance: false
-          sbom: false
-
   # Notify release-finalize workflow when this CI completes. Mirrors
   # ci-caipe-ui.yml's notify-release; the matching gating entry lives in
   # release-finalize.yml's REQUIRED_WORKFLOWS list.
@@ -523,7 +318,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -547,13 +342,11 @@ jobs:
         run: |
           BUILD_RESULT="${{ needs.build-and-push.result }}"
           MERGE_RESULT="${{ needs.merge-manifests.result }}"
-          RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
           if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -62,10 +62,29 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged a stale image instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             slack_bot:
               - 'ai_platform_engineering/integrations/slack_bot/**'

--- a/.github/workflows/ci-slack-bot.yml
+++ b/.github/workflows/ci-slack-bot.yml
@@ -15,7 +15,7 @@ on:
         required: false
         type: string
       force_build:
-        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        description: 'Force a fresh build of all components (bypass change-detection). Use for coordinated releases.'
         required: false
         type: boolean
         default: false
@@ -36,7 +36,6 @@ jobs:
       (github.event_name == 'workflow_dispatch')
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
-      should_retag: ${{ steps.set-outputs.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
     steps:
       - name: Checkout repository
@@ -62,29 +61,10 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ steps.app-token.outputs.token || github.token }}
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged a stale image instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             slack_bot:
               - 'ai_platform_engineering/integrations/slack_bot/**'
@@ -97,51 +77,28 @@ jobs:
           FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
-          SHOULD_RETAG="false"
           TAG_VERSION="${{ env.TAG_VERSION }}"
 
           # Chart-only tag: skip image builds entirely
           if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
             echo "📊 Chart-only tag: skipping image builds"
             echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "should_retag=false" >> $GITHUB_OUTPUT
             exit 0
-          fi
-
-          # Determine pre-release type and number
-          if [[ "$TAG_VERSION" =~ -(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            IS_PRERELEASE="true"
-            PRERELEASE_NUM="${BASH_REMATCH[2]}"
-          else
-            IS_PRERELEASE="false"
-            PRERELEASE_NUM=0
           fi
 
           if [ "$FORCE_BUILD" == "true" ]; then
             SHOULD_BUILD="true"
-            SHOULD_RETAG="false"
             echo "🔁 force_build requested: building fresh regardless of changes"
           elif [ -n "$TAG_VERSION" ]; then
-            if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
-              if [ "$SLACK_BOT_CHANGED" == "true" ]; then
-                SHOULD_BUILD="true"
-                echo "🔨 Pre-release tag with slack bot changes: building"
-              else
-                SHOULD_RETAG="true"
-                echo "🏷️ Pre-release tag without slack bot changes: retagging"
-              fi
-            else
-              SHOULD_BUILD="true"
-              echo "🚀 Build all: first pre-release or final release"
-            fi
+            SHOULD_BUILD="true"
+            echo "🏷️ Tag push: building fresh"
           elif [ "$SLACK_BOT_CHANGED" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             SHOULD_BUILD="true"
             echo "📦 Slack bot files changed or manual trigger: building"
           fi
 
           echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
-          echo "should_retag=$SHOULD_RETAG" >> $GITHUB_OUTPUT
-          echo "Outputs: build=$SHOULD_BUILD, retag=$SHOULD_RETAG"
+          echo "Outputs: build=$SHOULD_BUILD"
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -321,144 +278,12 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/caipe-slack-bot
-      DOCKERFILE: build/Dockerfile.slack-bot
-
-    steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1  # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_BUILD_APP_ID }}
-          private-key: ${{ secrets.CI_BUILD_APP_PRIVATE_KEY }}
-          owner: ${{ github.repository_owner }}
-          repositories: ${{ github.event.repository.name }}
-          permission-packages: write
-
-      - name: 📦 Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: 🔐 Log in to registry
-        env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
-          REGISTRY_USER: ${{ github.actor }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$REGISTRY_USER" --password-stdin
-
-      - name: 🔍 Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-          echo "🏷️ Processing slack-bot..."
-
-          # Determine source tag (previous version). Walk back from N-1 to the
-          # latest rc/hotfix that actually has a published image, so a component
-          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
-          # retags from the most recent real image (rc.8) instead of a phantom
-          # rc.9. Falls back to the base version, then to a fresh build.
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-
-            SOURCE_TAG=""
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
-                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
-                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
-                  SOURCE_TAG="$CANDIDATE"
-                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
-                  break
-                fi
-              done
-            fi
-            if [[ -z "$SOURCE_TAG" ]]; then
-              SOURCE_TAG="${BASE_VERSION}"
-            fi
-          else
-            SOURCE_TAG="latest"
-          fi
-
-          echo "  Source: ${SOURCE_TAG}"
-          echo "  Target: ${TAG_VERSION}"
-
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            echo "  ✅ Source image exists, retagging..."
-            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TAG_VERSION}"; then
-              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-            else
-              echo "  ⚠️ Retag failed unexpectedly, will build instead"
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "  ⚠️ Source image ${SOURCE_TAG} not found"
-            echo "  📦 Will build fresh instead"
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          fi
-
-      # Fallback build if retag not possible
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-      # Known gap: this fallback still cross-builds arm64 under QEMU rather
-      # than a native runner (unlike build-and-push above). It only runs when
-      # the source image for retagging is missing — rare — so it hasn't been
-      # split per-platform. Apply the same native-runner + digest-merge
-      # treatment here if this path ever times out/OOMs.
-      - name: 🔨 Build and Push (fallback)
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-changes.outputs.tag_version }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   # Notify release-finalize workflow when this CI completes
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write  # Required for repository_dispatch via gh api
-    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -482,13 +307,11 @@ jobs:
         run: |
           BUILD_RESULT="${{ needs.build-and-push.result }}"
           MERGE_RESULT="${{ needs.merge-manifests.result }}"
-          RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
           if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/ci-webex-bot.yml
+++ b/.github/workflows/ci-webex-bot.yml
@@ -53,10 +53,29 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: 🔎 Determine diff base for tag-push change detection
+        id: diffbase
+        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
+        run: |
+          set -euo pipefail
+          # dorny/paths-filter defaults `base` to the repo's default branch
+          # (main). The tagged commit is already on main, so diffing
+          # tag-vs-main is a near-empty no-op — every tag push reported
+          # "no changes" and silently retagged a stale image instead of
+          # rebuilding. Diff against the previous tag instead.
+          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
+          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
+          if [ -n "$BASE_TAG" ]; then
+            echo "📍 Diffing against previous tag: $BASE_TAG"
+          else
+            echo "⚠️ No previous tag found; leaving paths-filter base unset"
+          fi
+
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
+          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             webex_bot:
               - '.github/workflows/ci-webex-bot.yml'

--- a/.github/workflows/ci-webex-bot.yml
+++ b/.github/workflows/ci-webex-bot.yml
@@ -17,7 +17,7 @@ on:
         required: false
         type: string
       force_build:
-        description: 'Force a fresh build of all components (bypass change-detection/retag). Use for coordinated releases.'
+        description: 'Force a fresh build of all components (bypass change-detection). Use for coordinated releases.'
         required: false
         type: boolean
         default: false
@@ -38,7 +38,6 @@ jobs:
       (github.event_name == 'workflow_dispatch')
     outputs:
       should_build: ${{ steps.set-outputs.outputs.should_build }}
-      should_retag: ${{ steps.set-outputs.outputs.should_retag }}
       tag_version: ${{ steps.version.outputs.tag_version }}
     steps:
       - name: Checkout repository
@@ -53,29 +52,10 @@ jobs:
           manual_tag: ${{ inputs.tag_version }}
           token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: 🔎 Determine diff base for tag-push change detection
-        id: diffbase
-        if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/') }}
-        run: |
-          set -euo pipefail
-          # dorny/paths-filter defaults `base` to the repo's default branch
-          # (main). The tagged commit is already on main, so diffing
-          # tag-vs-main is a near-empty no-op — every tag push reported
-          # "no changes" and silently retagged a stale image instead of
-          # rebuilding. Diff against the previous tag instead.
-          BASE_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || true)
-          echo "base=$BASE_TAG" >> "$GITHUB_OUTPUT"
-          if [ -n "$BASE_TAG" ]; then
-            echo "📍 Diffing against previous tag: $BASE_TAG"
-          else
-            echo "⚠️ No previous tag found; leaving paths-filter base unset"
-          fi
-
       - name: Detect changed paths
         id: filter
         uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4
         with:
-          base: ${{ steps.diffbase.outputs.base }}
           filters: |
             webex_bot:
               - '.github/workflows/ci-webex-bot.yml'
@@ -92,48 +72,26 @@ jobs:
           FORCE_BUILD: ${{ inputs.force_build }}
         run: |
           SHOULD_BUILD="false"
-          SHOULD_RETAG="false"
           TAG_VERSION="${{ env.TAG_VERSION }}"
 
           if [[ "$TAG_VERSION" =~ -chart\.[0-9]+$ ]]; then
             echo "📊 Chart-only tag: skipping image builds"
             echo "should_build=false" >> $GITHUB_OUTPUT
-            echo "should_retag=false" >> $GITHUB_OUTPUT
             exit 0
-          fi
-
-          if [[ "$TAG_VERSION" =~ -(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            IS_PRERELEASE="true"
-            PRERELEASE_NUM="${BASH_REMATCH[2]}"
-          else
-            IS_PRERELEASE="false"
-            PRERELEASE_NUM=0
           fi
 
           if [ "$FORCE_BUILD" == "true" ]; then
             SHOULD_BUILD="true"
-            SHOULD_RETAG="false"
             echo "🔁 force_build requested: building fresh regardless of changes"
           elif [ -n "$TAG_VERSION" ]; then
-            if [ "$IS_PRERELEASE" == "true" ] && [ "$PRERELEASE_NUM" -gt 1 ]; then
-              if [ "$WEBEX_BOT_CHANGED" == "true" ]; then
-                SHOULD_BUILD="true"
-                echo "🔨 Pre-release tag with webex bot changes: building"
-              else
-                SHOULD_RETAG="true"
-                echo "🏷️ Pre-release tag without webex bot changes: retagging"
-              fi
-            else
-              SHOULD_BUILD="true"
-              echo "🚀 Build all: first pre-release or final release"
-            fi
+            SHOULD_BUILD="true"
+            echo "🏷️ Tag push: building fresh"
           elif [ "$WEBEX_BOT_CHANGED" == "true" ] || [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
             SHOULD_BUILD="true"
             echo "📦 Webex bot files changed or manual trigger: building"
           fi
 
           echo "should_build=$SHOULD_BUILD" >> $GITHUB_OUTPUT
-          echo "should_retag=$SHOULD_RETAG" >> $GITHUB_OUTPUT
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -303,132 +261,11 @@ jobs:
         run: |
           docker buildx imagetools inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}
 
-  retag-unchanged:
-    runs-on: ubuntu-latest
-    needs: determine-changes
-    if: needs.determine-changes.outputs.should_retag == 'true'
-    permissions:
-      contents: read
-      packages: write
-
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository_owner }}/caipe-webex-bot
-      DOCKERFILE: build/Dockerfile.webex-bot
-
-    steps:
-      - name: 🔒 Harden runner
-        uses: step-security/harden-runner@e14015d583714f6e62063499dc959a02595150a1  # v2.21.1
-        with:
-          egress-policy: audit
-
-      - name: 📦 Install crane
-        run: |
-          VERSION="v0.20.2"
-          curl -sL "https://github.com/google/go-containerregistry/releases/download/${VERSION}/go-containerregistry_Linux_x86_64.tar.gz" | tar xz crane
-          sudo mv crane /usr/local/bin/
-
-      - name: 🔐 Log in to registry
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REGISTRY_USER: ${{ github.actor }}
-        run: |
-          echo "$GH_TOKEN" | crane auth login ghcr.io -u "$REGISTRY_USER" --password-stdin
-
-      - name: 🔍 Check source image and retag or build
-        id: retag-or-build
-        env:
-          TAG_VERSION: ${{ needs.determine-changes.outputs.tag_version }}
-        run: |
-          FULL_IMAGE="${REGISTRY}/${IMAGE_NAME}"
-          echo "🏷️ Processing webex-bot..."
-
-          # Determine source tag (previous version). Walk back from N-1 to the
-          # latest rc/hotfix that actually has a published image, so a component
-          # that was skipped for an intermediate tag (e.g. rc.9 missing) still
-          # retags from the most recent real image (rc.8) instead of a phantom
-          # rc.9. Falls back to the base version, then to a fresh build.
-          if [[ "$TAG_VERSION" =~ ^(.+)-(dev|rc|hotfix)\.([0-9]+)$ ]]; then
-            BASE_VERSION="${BASH_REMATCH[1]}"
-            SUFFIX_TYPE="${BASH_REMATCH[2]}"
-            SUFFIX_NUM="${BASH_REMATCH[3]}"
-
-            SOURCE_TAG=""
-            if [[ "$SUFFIX_NUM" -gt 1 ]]; then
-              for ((p=SUFFIX_NUM-1; p>=1; p--)); do
-                CANDIDATE="${BASE_VERSION}-${SUFFIX_TYPE}.${p}"
-                if crane manifest "${FULL_IMAGE}:${CANDIDATE}" >/dev/null 2>&1; then
-                  SOURCE_TAG="$CANDIDATE"
-                  echo "  ↩️  Latest existing source: ${SOURCE_TAG}"
-                  break
-                fi
-              done
-            fi
-            if [[ -z "$SOURCE_TAG" ]]; then
-              SOURCE_TAG="${BASE_VERSION}"
-            fi
-          else
-            SOURCE_TAG="latest"
-          fi
-
-          echo "  Source: ${SOURCE_TAG}"
-          echo "  Target: ${TAG_VERSION}"
-
-          if crane manifest "${FULL_IMAGE}:${SOURCE_TAG}" >/dev/null 2>&1; then
-            echo "  ✅ Source image exists, retagging..."
-            if crane tag "${FULL_IMAGE}:${SOURCE_TAG}" "${TAG_VERSION}"; then
-              echo "  ✅ Successfully retagged from ${SOURCE_TAG}"
-              echo "needs_build=false" >> $GITHUB_OUTPUT
-            else
-              echo "  ⚠️ Retag failed unexpectedly, will build instead"
-              echo "needs_build=true" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "  ⚠️ Source image ${SOURCE_TAG} not found (may still be building)"
-            echo "  📦 Will build fresh instead of using stale fallback"
-            echo "needs_build=true" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Checkout repository
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
-      - name: Set up Docker Buildx
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
-      - name: Log in to GitHub Container Registry
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Set up QEMU
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/setup-qemu-action@1f40c72289eff860ee54a304f1438e3cff362e0a # v4
-      # Known gap: this fallback still cross-builds arm64 under QEMU rather
-      # than a native runner (unlike build-and-push above). It only runs when
-      # the source image for retagging is missing — rare — so it hasn't been
-      # split per-platform. Apply the same native-runner + digest-merge
-      # treatment here if this path ever times out/OOMs.
-      - name: 🔨 Build and Push (fallback)
-        if: steps.retag-or-build.outputs.needs_build == 'true'
-        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
-        with:
-          context: .
-          file: ${{ env.DOCKERFILE }}
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ needs.determine-changes.outputs.tag_version }}
-          platforms: linux/amd64,linux/arm64
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-
   notify-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
-    needs: [determine-changes, build-and-push, merge-manifests, retag-unchanged]
+    needs: [determine-changes, build-and-push, merge-manifests]
     if: |
       always() &&
       needs.determine-changes.outputs.tag_version != '' &&
@@ -442,13 +279,11 @@ jobs:
         run: |
           BUILD_RESULT="${{ needs.build-and-push.result }}"
           MERGE_RESULT="${{ needs.merge-manifests.result }}"
-          RETAG_RESULT="${{ needs.retag-unchanged.result }}"
 
           if [[ "$BUILD_RESULT" == "skipped" ]]; then BUILD_RESULT="success"; fi
           if [[ "$MERGE_RESULT" == "skipped" ]]; then MERGE_RESULT="success"; fi
-          if [[ "$RETAG_RESULT" == "skipped" ]]; then RETAG_RESULT="success"; fi
 
-          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" && "$RETAG_RESULT" == "success" ]]; then
+          if [[ "$BUILD_RESULT" == "success" && "$MERGE_RESULT" == "success" ]]; then
             CONCLUSION="success"
           else
             CONCLUSION="failure"

--- a/.github/workflows/release-prerelease.yml
+++ b/.github/workflows/release-prerelease.yml
@@ -21,9 +21,8 @@ description: "Create an rc/hotfix tag on a release/* branch and trigger a coordi
 #   5. Explicitly dispatches ci-helm.yml with force_build=true so the Helm
 #      chart is published even when no chart files changed in this commit.
 #
-# To force-rebuild every container image fresh (bypass retag for unchanged
-# components), run each ci-*.yml individually via workflow_dispatch with
-# force_build=true after this workflow has created the tag.
+# The push-tag event already rebuilds every container image fresh (tag
+# pushes are never skipped or retagged from a prior version).
 
 on:
   workflow_dispatch:
@@ -266,10 +265,6 @@ jobs:
           - \`ci-mcp-sub-agent\`
           - \`ci-rag\`
           - \`ci-helm\` (also dispatched explicitly with \`force_build=true\`)
-
-          > To force-rebuild every image fresh (bypass retag for unchanged components),
-          > run each \`ci-*.yml\` manually via **workflow_dispatch** with
-          > \`force_build=true\` and \`tag_version=${RC_TAG}\` after this workflow completes.
           EOF
 
   dispatch-helm:

--- a/docs/docs/development/advanced/ci-infrastructure.md
+++ b/docs/docs/development/advanced/ci-infrastructure.md
@@ -88,7 +88,7 @@ different version; they do not select a different package tree.
 | `auto-tag.yml` | Creates development, release-candidate, hotfix, and chart-only tags |
 | `prebuild-*.yml` | Builds temporary PR images in canonical packages |
 | `prebuild-helm.yml` | Publishes temporary chart versions in canonical chart packages |
-| `ci-*.yml` | Builds or retags versioned images after a Git tag |
+| `ci-*.yml` | Builds versioned images after a Git tag |
 | `ci-helm.yml` | Publishes versioned charts after a Git tag |
 | `release-manual.yml` | Creates the final release tag and draft GitHub Release |
 | `release-finalize.yml` | Publishes the release after required artifact workflows complete |

--- a/docs/docs/development/ci-cd-and-releases.md
+++ b/docs/docs/development/ci-cd-and-releases.md
@@ -100,9 +100,7 @@ The main image workflows are tag-driven:
 
 Each workflow resolves the tag through `.github/actions/determine-release-tag/action.yml`.
 
-For prerelease tags with `N > 1`, workflows build only changed images and retag unchanged images from the previous tag. If the source image for retagging does not exist, the workflow falls back to a fresh build.
-
-For first prerelease tags and final release tags, workflows build all relevant images.
+Every tag push builds all relevant images fresh, regardless of prerelease number or which paths changed.
 
 Development, release-candidate, hotfix, final, and prebuild tags all publish to the same image package. Deployments change only the tag, not the image repository.
 
@@ -217,8 +215,6 @@ When ready to publish the fixed version, run the final release flow with the int
 If a PR version bump fails with a branch update comment, merge the latest target branch into the PR branch and push again.
 
 If a prebuild does not publish immediately after the version bump workflow commits, wait for the next PR workflow run. Prebuild publishing intentionally skips when a new version-bump commit was just pushed.
-
-If an image workflow retags an older image unexpectedly, check whether the changed paths matched that image's path filters. For prerelease `N > 1`, unchanged image paths are retagged by design.
 
 If Docker builds do not run for a chart-only tag, that is expected. `-chart.M` tags publish Helm updates only.
 


### PR DESCRIPTION
## Summary

`dorny/paths-filter` defaults `base` to the repo's default branch (`main`) when unset. On a tag push, the tagged commit is already on `main`, so diffing tag-vs-main is a near-empty no-op — every prerelease/hotfix tag push reported "no changes" and silently retagged the previous tag's stale image via `crane` instead of rebuilding.

Confirmed live: `ci-webex-bot.yml` retagged `1.0.0-rc.4` from `1.0.0-rc.3` despite 14 files (+534/-174) changing under `ai_platform_engineering/integrations/webex_bot/**` between those tags, and `ci-caipe-ui.yml` did the same despite 130 files changing under `ui/**`. Same pattern found in `ci-audit-service.yml`, `ci-autonomous-agents.yml`, `ci-dynamic-agents.yml`, `ci-mcp-servers.yml`, `ci-rag.yml`, `ci-skill-scanner.yml`, and `ci-slack-bot.yml`. `ci-scheduler.yml` uses paths-filter too but only for PR-triggered builds (tag pushes always build unconditionally there), so it's unaffected. `ci-helm.yml` has no retag logic either.

## Fix

Rather than patch the diff base so paths-filter reports the right thing on tag pushes, this removes the retag-unchanged mechanism entirely:

- Every tag push now builds every component fresh — no more "build changed / retag unchanged from the previous version" branching. This removes the whole bug class instead of one instance of it (a future change to the tag-vs-base logic, an edge case in the "walk back to the latest published rc" fallback, etc. can't reintroduce a stale-image bug if there's no retag path left).
- Removed the `retag-unchanged` job (crane install/auth, source-image lookup, fallback build) from all 9 affected workflows.
- Removed the `should_retag` / `agents_to_retag` / `retag_matrix` outputs and the prerelease-number branching that fed them. `should_build` is now `true` unconditionally on any tag push (after the chart-only-tag skip), and still gates correctly on changed paths for PR-triggered builds (PR diffs use the correct base — the target branch — so they're not subject to the tag-vs-main bug).
- Dropped `retag-unchanged` from each `notify-release` job's `needs` and conclusion-computation logic.
- Updated stale doc/comment text in `auto-tag.yml`, `release-prerelease.yml`, and `docs/docs/development/{ci-cd-and-releases,advanced/ci-infrastructure}.md` that described the now-removed retag behavior.

`SHOULD_BUILD` is `false` in exactly two cases now, neither diff-dependent on a tag push: chart-only tags (`-chart.N`, a string match, not a diff) and PRs that don't touch a component's paths (correct base, unaffected by this bug).

## Test plan

- [ ] Cut a new prerelease tag after merging and confirm every affected workflow builds fresh (no `retag-unchanged` job appears in the run at all)
- [ ] Confirm a chart-only tag still skips image builds as before
- [ ] Confirm PR builds still only build components whose paths changed