### PR TITLE
feat(dynamic-agents): tag LiteLLM requests by agent

### DIFF
--- a/ai_platform_engineering/dynamic_agents/README.md
+++ b/ai_platform_engineering/dynamic_agents/README.md
@@ -106,6 +106,8 @@ ANTHROPIC_API_KEY=your-api-key
 # LITELLM_REQUEST_TAGS_ENABLED=true
 # LITELLM_ENVIRONMENT=production
 # LITELLM_APPLICATION=agent-platform
+# Leave LITELLM_REQUEST_TAGS_ENABLED unset or false when LiteLLM is not used.
+# In that mode no LiteLLM headers or custom HTTP transport are added.
 
 # For Azure OpenAI:
 # AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
@@ -159,7 +161,7 @@ The API documentation is available at:
 | `DYNAMIC_AGENTS_COLLECTION` | Agents collection name | `dynamic_agents` |
 | `MCP_SERVERS_COLLECTION` | MCP servers collection name | `mcp_servers` |
 | `AGENT_RUNTIME_TTL_SECONDS` | Cache TTL for agent runtimes | `3600` |
-| `LITELLM_REQUEST_TAGS_ENABLED` | Add environment, application, agent ID, and agent name tags to OpenAI-compatible LiteLLM requests | `false` |
+| `LITELLM_REQUEST_TAGS_ENABLED` | Add environment, application, agent ID, and agent name tags to OpenAI-compatible LiteLLM requests. Leave disabled for non-LiteLLM providers. | `false` |
 | `LITELLM_ENVIRONMENT` | Environment value used when LiteLLM request tags are enabled | unset |
 | `LITELLM_APPLICATION` | Application value used when LiteLLM request tags are enabled | unset |
 | `CORS_ORIGINS` | Allowed CORS origins | `["*"]` |

--- a/ai_platform_engineering/dynamic_agents/README.md
+++ b/ai_platform_engineering/dynamic_agents/README.md
@@ -102,6 +102,11 @@ ANTHROPIC_API_KEY=your-api-key
 # For OpenAI:
 # OPENAI_API_KEY=your-api-key
 
+# For an OpenAI-compatible LiteLLM gateway (optional request correlation):
+# LITELLM_REQUEST_TAGS_ENABLED=true
+# LITELLM_ENVIRONMENT=production
+# LITELLM_APPLICATION=agent-platform
+
 # For Azure OpenAI:
 # AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
 # AZURE_OPENAI_API_KEY=your-api-key
@@ -154,6 +159,9 @@ The API documentation is available at:
 | `DYNAMIC_AGENTS_COLLECTION` | Agents collection name | `dynamic_agents` |
 | `MCP_SERVERS_COLLECTION` | MCP servers collection name | `mcp_servers` |
 | `AGENT_RUNTIME_TTL_SECONDS` | Cache TTL for agent runtimes | `3600` |
+| `LITELLM_REQUEST_TAGS_ENABLED` | Add environment, application, agent ID, and agent name tags to OpenAI-compatible LiteLLM requests | `false` |
+| `LITELLM_ENVIRONMENT` | Environment value used when LiteLLM request tags are enabled | unset |
+| `LITELLM_APPLICATION` | Application value used when LiteLLM request tags are enabled | unset |
 | `CORS_ORIGINS` | Allowed CORS origins | `["*"]` |
 
 ### Models Configuration

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -981,7 +981,12 @@ class AgentRuntime:
             f"[llm] Instantiating LLM for agent '{self.config.name}': "
             f"provider={self.config.model.provider}, model={self.config.model.id}"
         )
-        llm = get_llm(self.config.model.provider, self.config.model.id)
+        llm = get_llm(
+            self.config.model.provider,
+            self.config.model.id,
+            agent_id=self.config.id,
+            agent_name=self.config.name,
+        )
         logger.info(f"[llm] LLM instantiated for agent '{self.config.name}': type={type(llm).__name__}")
 
         # ─────────────────────────────────────────────────────────────────
@@ -1437,7 +1442,12 @@ class AgentRuntime:
             subagent_prompt = subagent_config.system_prompt
 
             # Instantiate subagent LLM (uses its own configured model)
-            subagent_llm = get_llm(subagent_config.model.provider, subagent_config.model.id)
+            subagent_llm = get_llm(
+                subagent_config.model.provider,
+                subagent_config.model.id,
+                agent_id=subagent_config.id,
+                agent_name=subagent_config.name,
+            )
 
             # Create SubAgent dict in deepagents format
             # Use agent_id as the name - this ensures namespace[0] from LangGraph

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/llm_clients.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/llm_clients.py
@@ -46,17 +46,26 @@ def _cached_bedrock_clients(region: str) -> tuple[Any, Any]:
     return _create_bedrock_clients(region)
 
 
-def _create_httpx_client(endpoint: str) -> Any:
+def _create_httpx_client(
+    endpoint: str,
+    headers: tuple[tuple[str, str], ...] = (),
+) -> Any:
     import httpx
 
-    client = httpx.Client(timeout=httpx.Timeout(300.0, connect=60.0))
+    client = httpx.Client(
+        timeout=httpx.Timeout(300.0, connect=60.0),
+        headers=dict(headers),
+    )
     logger.info("Created httpx client (endpoint=%s, shared=%s)", endpoint, SHARE_CLIENTS)
     return client
 
 
-@lru_cache(maxsize=4)
-def _cached_httpx_client(endpoint: str) -> Any:
-    return _create_httpx_client(endpoint)
+@lru_cache(maxsize=128)
+def _cached_httpx_client(
+    endpoint: str,
+    headers: tuple[tuple[str, str], ...] = (),
+) -> Any:
+    return _create_httpx_client(endpoint, headers)
 
 
 def _get_bedrock_clients(region: str | None = None) -> tuple[Any, Any]:
@@ -67,11 +76,14 @@ def _get_bedrock_clients(region: str | None = None) -> tuple[Any, Any]:
     return _create_bedrock_clients(region)
 
 
-def _get_httpx_client(endpoint: str) -> Any:
-    """Get httpx.Client for OpenAI/Azure. Cached by endpoint when sharing enabled."""
+def _get_httpx_client(
+    endpoint: str,
+    headers: tuple[tuple[str, str], ...] = (),
+) -> Any:
+    """Get an HTTP client, cached by endpoint and immutable default headers."""
     if SHARE_CLIENTS:
-        return _cached_httpx_client(endpoint)
-    return _create_httpx_client(endpoint)
+        return _cached_httpx_client(endpoint, headers)
+    return _create_httpx_client(endpoint, headers)
 
 
 # ─────────────────────────────────────────────────────────────────────────────
@@ -120,7 +132,44 @@ def _resolve_llm_defaults(provider: str | None, model_id: str | None) -> tuple[s
     return resolved_provider, resolved_model
 
 
-def get_llm(provider: str, model_id: str) -> BaseChatModel:
+def _tag_value(value: str) -> str:
+    """Return an ASCII, comma-safe value for a LiteLLM request tag."""
+    cleaned = "".join(
+        char if char.isascii() and (char.isalnum() or char in "._:@/-") else "-"
+        for char in value.strip()
+    )
+    while "--" in cleaned:
+        cleaned = cleaned.replace("--", "-")
+    return cleaned.strip("-")[:128]
+
+
+def _litellm_request_headers(
+    agent_id: str | None,
+    agent_name: str | None,
+) -> tuple[tuple[str, str], ...]:
+    """Build opt-in LiteLLM tags that correlate spend logs to an agent."""
+    if os.getenv("LITELLM_REQUEST_TAGS_ENABLED", "false").lower() != "true":
+        return ()
+
+    tag_values = (
+        ("environment", os.getenv("LITELLM_ENVIRONMENT")),
+        ("application", os.getenv("LITELLM_APPLICATION")),
+        ("agent_id", agent_id),
+        ("agent_name", agent_name),
+    )
+    tags = [f"{key}:{cleaned}" for key, value in tag_values if value and (cleaned := _tag_value(value))]
+    if not tags:
+        return ()
+    return (("x-litellm-tags", ",".join(tags)),)
+
+
+def get_llm(
+    provider: str,
+    model_id: str,
+    *,
+    agent_id: str | None = None,
+    agent_name: str | None = None,
+) -> BaseChatModel:
     """Get a LangChain chat model for the given provider and model.
 
     Injects shared transport clients (boto3/httpx) when LLM_CLIENT_SHARING=true,
@@ -142,8 +191,13 @@ def get_llm(provider: str, model_id: str) -> BaseChatModel:
     if resolved_model is not None:
         kwargs["model"] = resolved_model
 
-    if SHARE_CLIENTS:
-        p = resolved_provider.lower().replace("-", "_")
+    p = resolved_provider.lower().replace("-", "_")
+    request_headers = _litellm_request_headers(agent_id, agent_name)
+
+    if p == "openai" and request_headers:
+        endpoint = os.getenv("OPENAI_ENDPOINT", "https://api.openai.com/v1")
+        kwargs["http_client"] = _get_httpx_client(endpoint, request_headers)
+    elif SHARE_CLIENTS:
         if "bedrock" in p or "aws" in p:
             rt, ctrl = _get_bedrock_clients()
             kwargs["client"] = rt

--- a/ai_platform_engineering/dynamic_agents/tests/test_llm_clients_fallback.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_llm_clients_fallback.py
@@ -196,3 +196,75 @@ def test_resolve_helper_returns_none_for_empty_model_id():
 
     provider, model = llm_clients._resolve_llm_defaults("aws-bedrock", "claude-x")
     assert model == "claude-x"
+
+
+def test_litellm_request_headers_are_opt_in(monkeypatch):
+    monkeypatch.delenv("LITELLM_REQUEST_TAGS_ENABLED", raising=False)
+
+    assert llm_clients._litellm_request_headers("agent-example", "Example Agent") == ()
+
+
+def test_litellm_request_headers_include_sanitized_agent_identity(monkeypatch):
+    monkeypatch.setenv("LITELLM_REQUEST_TAGS_ENABLED", "true")
+    monkeypatch.setenv("LITELLM_ENVIRONMENT", "production")
+    monkeypatch.setenv("LITELLM_APPLICATION", "agent-platform")
+
+    headers = llm_clients._litellm_request_headers(
+        "agent/example,one",
+        "Example Agent\nOne",
+    )
+
+    assert headers == (
+        (
+            "x-litellm-tags",
+            "environment:production,application:agent-platform,"
+            "agent_id:agent/example-one,agent_name:Example-Agent-One",
+        ),
+    )
+
+
+def test_get_llm_adds_per_agent_tags_to_openai_transport(monkeypatch):
+    captured = {}
+
+    class _Factory:
+        def __init__(self, provider):
+            captured["provider"] = provider
+
+        def get_llm(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return "llm"
+
+    tagged_client = object()
+
+    def _client(endpoint, headers=()):
+        captured["endpoint"] = endpoint
+        captured["headers"] = headers
+        return tagged_client
+
+    monkeypatch.setattr("cnoe_agent_utils.LLMFactory", _Factory, raising=False)
+    monkeypatch.setattr(llm_clients, "_get_httpx_client", _client)
+    monkeypatch.setenv("OPENAI_ENDPOINT", "https://gateway.example.test/v1")
+    monkeypatch.setenv("LITELLM_REQUEST_TAGS_ENABLED", "true")
+    monkeypatch.setenv("LITELLM_ENVIRONMENT", "production")
+    monkeypatch.setenv("LITELLM_APPLICATION", "agent-platform")
+
+    result = llm_clients.get_llm(
+        "openai",
+        "example-model",
+        agent_id="agent-example",
+        agent_name="Example Agent",
+    )
+
+    assert result == "llm"
+    assert captured["endpoint"] == "https://gateway.example.test/v1"
+    assert captured["headers"] == (
+        (
+            "x-litellm-tags",
+            "environment:production,application:agent-platform,"
+            "agent_id:agent-example,agent_name:Example-Agent",
+        ),
+    )
+    assert captured["kwargs"] == {
+        "model": "example-model",
+        "http_client": tagged_client,
+    }

--- a/ai_platform_engineering/dynamic_agents/tests/test_llm_clients_fallback.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_llm_clients_fallback.py
@@ -204,6 +204,38 @@ def test_litellm_request_headers_are_opt_in(monkeypatch):
     assert llm_clients._litellm_request_headers("agent-example", "Example Agent") == ()
 
 
+def test_get_llm_does_not_change_transport_when_litellm_tags_disabled(monkeypatch):
+    captured = {}
+
+    class _Factory:
+        def __init__(self, provider):
+            captured["provider"] = provider
+
+        def get_llm(self, **kwargs):
+            captured["kwargs"] = kwargs
+            return "llm"
+
+    def _unexpected_client(*args, **kwargs):
+        pytest.fail("LiteLLM transport must not be created when request tags are disabled")
+
+    monkeypatch.setattr("cnoe_agent_utils.LLMFactory", _Factory, raising=False)
+    monkeypatch.setattr(llm_clients, "_get_httpx_client", _unexpected_client)
+    monkeypatch.setenv("LITELLM_REQUEST_TAGS_ENABLED", "false")
+
+    result = llm_clients.get_llm(
+        "openai",
+        "example-model",
+        agent_id="agent-example",
+        agent_name="Example Agent",
+    )
+
+    assert result == "llm"
+    assert captured == {
+        "provider": "openai",
+        "kwargs": {"model": "example-model"},
+    }
+
+
 def test_litellm_request_headers_include_sanitized_agent_identity(monkeypatch):
     monkeypatch.setenv("LITELLM_REQUEST_TAGS_ENABLED", "true")
     monkeypatch.setenv("LITELLM_ENVIRONMENT", "production")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.13"
+version = "1.0.0-dev.14"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev13"
+version = "1.0.0.dev14"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Add opt-in LiteLLM request correlation for dynamic agents using the standard x-litellm-tags header.

When enabled, every OpenAI-compatible request carries:

- environment:<value>
- application:<value>
- agent_id:<dynamic-agent-id>
- agent_name:<sanitized-agent-name>

Primary agents and subagents are tagged independently. The LiteLLM virtual-key owner remains the Internal User, while the actual request user remains available for End User attribution.

Validated against the production LiteLLM gateway with dedicated Grid and TOME keys; request tags appeared in spend logs alongside the expected key aliases.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass

Focused validation:

- Ruff checks passed
- Focused tests: 12 passed
- Full dynamic-agent suite: 409 passed and 3 skipped, with two unrelated failures in test_mongo_credential_sources_self_heal.py and test_runtime_reader_contract.py