### PR TITLE
feat(aws-mcp): support EKS workload identity

### DIFF
--- a/ai_platform_engineering/mcp/aws/README.md
+++ b/ai_platform_engineering/mcp/aws/README.md
@@ -19,12 +19,21 @@ AWS MCP Server that exposes `aws_cli_execute` and `eks_kubectl_execute` as
 | `MCP_PORT` | `8000` | Bind port (HTTP/SSE mode) |
 | `AWS_ACCOUNT_LIST` | — | Comma-separated `name:account_id` pairs for cross-account profiles |
 | `CROSS_ACCOUNT_ROLE_NAME` | `caipe-read-only` | IAM role to assume in each account |
+| `AWS_CREDENTIAL_SOURCE` | auto | Optional AWS CLI credential source override: `Environment`, `EcsContainer`, or `Ec2InstanceMetadata` |
 | `AWS_CLI_MAX_EXECUTION_TIME` | `30` | Timeout (seconds) for AWS CLI commands |
 | `KUBECTL_MAX_EXECUTION_TIME` | `45` | Timeout (seconds) for kubectl commands |
 | `AWS_CLI_MAX_OUTPUT_SIZE` | `20000` | Maximum output size (bytes) before truncation |
 | `RESTRICT_KUBECTL_SECRETS` | `true` | Block `kubectl get/describe secret(s)` |
 | `RESTRICT_KUBECTL_PROXY` | `true` | Block `kubectl proxy` |
 | `RESTRICT_KUBECTL_EXEC` | `false` | Block `kubectl exec` |
+
+### Workload identity
+
+The server automatically uses `EcsContainer` when EKS Pod Identity injects a
+container credential endpoint. When IRSA injects both `AWS_ROLE_ARN` and
+`AWS_WEB_IDENTITY_TOKEN_FILE`, the server creates a web-identity source profile
+and chains each cross-account profile through it. Static environment credentials
+remain supported as a local-development fallback, but are not required on EKS.
 
 ## Running locally
 

--- a/ai_platform_engineering/mcp/aws/server.py
+++ b/ai_platform_engineering/mcp/aws/server.py
@@ -69,10 +69,50 @@ _kubectl_semaphore: asyncio.Semaphore
 
 logger = logging.getLogger(__name__)
 
+_SUPPORTED_CREDENTIAL_SOURCES = {
+    "Environment",
+    "EcsContainer",
+    "Ec2InstanceMetadata",
+}
+
 
 # ---------------------------------------------------------------------------
 # AWS profile setup
 # ---------------------------------------------------------------------------
+
+def _credential_source() -> str:
+    """Return the AWS CLI credential source for assume-role profiles.
+
+    EKS Pod Identity exposes credentials through the standard container
+    credential endpoint, which the AWS CLI names ``EcsContainer``.  Preserve
+    ``Environment`` as the fallback for local development and legacy installs.
+    Operators may explicitly select any AWS CLI-supported source through
+    ``AWS_CREDENTIAL_SOURCE``.
+    """
+    configured = os.getenv("AWS_CREDENTIAL_SOURCE", "").strip()
+    if configured:
+        if configured not in _SUPPORTED_CREDENTIAL_SOURCES:
+            supported = ", ".join(sorted(_SUPPORTED_CREDENTIAL_SOURCES))
+            raise ValueError(
+                f"Unsupported AWS_CREDENTIAL_SOURCE '{configured}'. "
+                f"Expected one of: {supported}."
+            )
+        return configured
+
+    if os.getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") or os.getenv(
+        "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"
+    ):
+        return "EcsContainer"
+
+    return "Environment"
+
+
+def _single_line_env(name: str) -> str:
+    """Read a config value while preventing AWS config-file injection."""
+    value = os.getenv(name, "").strip()
+    if "\n" in value or "\r" in value:
+        raise ValueError(f"{name} must be a single-line value.")
+    return value
 
 def _setup_aws_profiles() -> list[dict]:
     """Read AWS_ACCOUNT_LIST and write ~/.aws/config with assume-role profiles."""
@@ -99,17 +139,41 @@ def _setup_aws_profiles() -> list[dict]:
     os.makedirs(aws_config_dir, exist_ok=True)
 
     sections = ["# AUTO-GENERATED PROFILES FROM AWS_ACCOUNT_LIST\n"]
-    for acc in accounts:
+    web_identity_role = _single_line_env("AWS_ROLE_ARN")
+    web_identity_token_file = _single_line_env("AWS_WEB_IDENTITY_TOKEN_FILE")
+    use_web_identity = bool(web_identity_role and web_identity_token_file)
+
+    if use_web_identity:
         sections.append(
+            "[profile mcp-workload-identity]\n"
+            f"role_arn = {web_identity_role}\n"
+            f"web_identity_token_file = {web_identity_token_file}\n"
+            "role_session_name = mcp-aws\n"
+        )
+    else:
+        credential_source = _credential_source()
+
+    for acc in accounts:
+        profile = (
             f"[profile {acc['name']}]\n"
             f"role_arn = arn:aws:iam::{acc['id']}:role/{cross_account_role}\n"
-            f"credential_source = Environment\n"
         )
+        if use_web_identity:
+            profile += "source_profile = mcp-workload-identity\n"
+        else:
+            profile += f"credential_source = {credential_source}\n"
+        sections.append(profile)
 
     with open(os.path.join(aws_config_dir, "config"), "w") as fh:
         fh.write("\n".join(sections))
 
-    logger.info("Generated AWS profiles for %d accounts: %s", len(accounts), [a["name"] for a in accounts])
+    source_type = "WebIdentity" if use_web_identity else credential_source
+    logger.info(
+        "Generated AWS profiles for %d accounts using %s: %s",
+        len(accounts),
+        source_type,
+        [a["name"] for a in accounts],
+    )
     return accounts
 
 

--- a/ai_platform_engineering/mcp/aws/tests/test_aws_profiles.py
+++ b/ai_platform_engineering/mcp/aws/tests/test_aws_profiles.py
@@ -1,0 +1,90 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SERVER_PATH = Path(__file__).parents[1] / "server.py"
+
+
+def _load_server():
+    spec = importlib.util.spec_from_file_location("mcp_aws_server", SERVER_PATH)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def server(monkeypatch, tmp_path):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AWS_ACCOUNT_LIST", "dev:111111111111,prod:222222222222")
+    monkeypatch.delenv("AWS_CREDENTIAL_SOURCE", raising=False)
+    monkeypatch.delenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", raising=False)
+    monkeypatch.delenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", raising=False)
+    monkeypatch.delenv("AWS_ROLE_ARN", raising=False)
+    monkeypatch.delenv("AWS_WEB_IDENTITY_TOKEN_FILE", raising=False)
+    return _load_server()
+
+
+def _config(tmp_path):
+    return (tmp_path / ".aws" / "config").read_text()
+
+
+def test_profiles_default_to_environment_credentials(server, tmp_path):
+    server._setup_aws_profiles()
+
+    config = _config(tmp_path)
+    assert config.count("credential_source = Environment") == 2
+
+
+def test_profiles_auto_detect_eks_pod_identity(server, monkeypatch, tmp_path):
+    monkeypatch.setenv(
+        "AWS_CONTAINER_CREDENTIALS_FULL_URI",
+        "http://169.254.170.23/v1/credentials",
+    )
+
+    server._setup_aws_profiles()
+
+    config = _config(tmp_path)
+    assert config.count("credential_source = EcsContainer") == 2
+    assert "AWS_ACCESS_KEY_ID" not in config
+
+
+def test_profiles_chain_through_irsa_web_identity(server, monkeypatch, tmp_path):
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::111111111111:role/mcp-aws")
+    monkeypatch.setenv(
+        "AWS_WEB_IDENTITY_TOKEN_FILE",
+        "/var/run/secrets/eks.amazonaws.com/serviceaccount/token",
+    )
+
+    server._setup_aws_profiles()
+
+    config = _config(tmp_path)
+    assert "[profile mcp-workload-identity]" in config
+    assert "web_identity_token_file = /var/run/secrets/eks.amazonaws.com/serviceaccount/token" in config
+    assert config.count("source_profile = mcp-workload-identity") == 2
+    assert "credential_source" not in config
+
+
+def test_explicit_credential_source_override(server, monkeypatch, tmp_path):
+    monkeypatch.setenv("AWS_CREDENTIAL_SOURCE", "Ec2InstanceMetadata")
+
+    server._setup_aws_profiles()
+
+    assert _config(tmp_path).count("credential_source = Ec2InstanceMetadata") == 2
+
+
+def test_invalid_credential_source_is_rejected(server, monkeypatch):
+    monkeypatch.setenv("AWS_CREDENTIAL_SOURCE", "ArbitraryProvider")
+
+    with pytest.raises(ValueError, match="Unsupported AWS_CREDENTIAL_SOURCE"):
+        server._setup_aws_profiles()
+
+
+def test_web_identity_values_must_be_single_line(server, monkeypatch):
+    monkeypatch.setenv("AWS_ROLE_ARN", "arn:aws:iam::111111111111:role/mcp-aws\n[profile injected]")
+    monkeypatch.setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/token")
+
+    with pytest.raises(ValueError, match="AWS_ROLE_ARN must be a single-line"):
+        server._setup_aws_profiles()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.13"
+version = "1.0.0-dev.14"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev13"
+version = "1.0.0.dev14"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- detect EKS Pod Identity and use `credential_source = EcsContainer` for cross-account profiles
- support IRSA through a generated source profile
- retain explicit environment credentials as a local/legacy fallback
- validate credential configuration values before writing AWS config

## Validation
- `uv run --with pytest pytest -q tests/test_aws_profiles.py` (6 passed)
- `uvx ruff check server.py tests/test_aws_profiles.py`
- `git diff --check`

Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>