### PR TITLE
docs(community): rebrand community links to CAIPE

### DIFF
--- a/docs/docs/community/index.md
+++ b/docs/docs/community/index.md
@@ -1,6 +1,6 @@
 # CAIPE Community
 
-🚀 [Getting Started](../getting-started/quick-start.md) | 🎥 [Meeting Recordings](https://www.youtube.com/@cnoe-community) | 🏛️ [Governance](https://github.com/caipe-io/governance) | 🗺️ [Roadmap](https://github.com/orgs/cnoe-io/projects/9)
+🚀 [Getting Started](../getting-started/quick-start.md) | 🎥 [Meeting Recordings](https://www.youtube.com/@caipe-io) | 🏛️ [Governance](https://github.com/caipe-io/governance) | 🗺️ [Roadmap](https://github.com/orgs/cnoe-io/projects/9)
 
 ### 🗓️ Weekly Meetings
 

--- a/docs/docs/community/meeting-recordings.md
+++ b/docs/docs/community/meeting-recordings.md
@@ -3,5 +3,5 @@
 
 Stay up to date with our latest meetings, agendas, and demos. Below you'll find recordings and notes for each session.
 
-- Community meeting recordings are posted to the [CAIPE YouTube channel](https://www.youtube.com/@cnoe-community)
+- Community meeting recordings are posted to the [CAIPE YouTube channel](https://www.youtube.com/@caipe-io)
 - Meeting notes are captured in this google doc - https://docs.google.com/document/d/1eRr-5nGVUJACKMjrgNBF_Gpk1Y0zzwEcKa7ILqZKNgc/edit?tab=t.zfdst86q0bhp

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -267,7 +267,7 @@ const config: Config = {
             },
             {
               label: 'Meeting Recordings',
-              href: 'https://www.youtube.com/@cnoe-community',
+              href: 'https://www.youtube.com/@caipe-io',
             },
             {
               label: 'Governance',

--- a/docs/src/pages/community.tsx
+++ b/docs/src/pages/community.tsx
@@ -29,7 +29,7 @@ const CHANNELS = [
     title: 'Meeting Recordings',
     description: 'Catch up on past community meetings and demos.',
     cta: 'Watch recordings',
-    href: 'https://www.youtube.com/@cnoe-community',
+    href: 'https://www.youtube.com/@caipe-io',
     note: null,
     noteHref: null,
   },


### PR DESCRIPTION
## Summary
Main independently completed a broader CNOE-to-CAIPE rebrand of the community docs while this branch was open (issues/discussions links, governance href, Slack wording, footer labels), which superseded most of this PR's original diff.

Rebasing surfaced one remaining spot in each file: the "Meeting Recordings" link still pointed at the old CNOE channel (`https://www.youtube.com/@cnoe-community`) instead of the CAIPE channel (`https://www.youtube.com/@caipe-io`):
- `docs/docusaurus.config.ts` (footer)
- `docs/docs/community/index.md`
- `docs/docs/community/meeting-recordings.md`
- `docs/src/pages/community.tsx`

## Type of Change
- [x] Documentation

## Test plan
- [x] `npx tsc --noEmit` passes on `docs/`
- [ ] Spot-check the rendered `/community` page and footer link
