### PR TITLE
feat(rag): show collection id in the collections detail pane

### DIFF
--- a/ui/src/components/rag/RagCollectionsView.tsx
+++ b/ui/src/components/rag/RagCollectionsView.tsx
@@ -676,6 +676,14 @@ export function RagCollectionsView() {
                       className="h-10 max-w-xl text-lg font-semibold"
                     />
                   </CardTitle>
+                  {!isCreating && selected && (
+                    <p className="pl-8 text-xs text-muted-foreground">
+                      id:{" "}
+                      <code className="rounded bg-muted px-1 py-0.5">
+                        {selected._id}
+                      </code>
+                    </p>
+                  )}
                   <CardDescription>
                     {isCreating
                       ? "Private by default. You are the Owner and the only person who can search this collection until you add teams below."

--- a/ui/src/components/rag/__tests__/RagCollectionsView.test.tsx
+++ b/ui/src/components/rag/__tests__/RagCollectionsView.test.tsx
@@ -266,6 +266,27 @@ describe("RagCollectionsView", () => {
     );
   });
 
+  it("shows the collection id next to its name, like the agent editor does", async () => {
+    render(<RagCollectionsView />);
+
+    expect(
+      await screen.findByDisplayValue("Primary collection"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/^id:/)).toBeInTheDocument();
+    expect(screen.getByText("primary-collection")).toBeInTheDocument();
+  });
+
+  it("does not show an id for an unsaved, in-progress collection draft", async () => {
+    render(<RagCollectionsView />);
+
+    fireEvent.click(
+      await screen.findByRole("button", { name: "New Collection" }),
+    );
+
+    expect(screen.getByTestId("new-collection-draft")).toBeInTheDocument();
+    expect(screen.queryByText(/^id:/)).not.toBeInTheDocument();
+  });
+
   it("opens new collection as a full inline editor", async () => {
     render(<RagCollectionsView />);
 


### PR DESCRIPTION
## Summary

- The Collections UI (Knowledge Bases -> Collections) only ever showed a collection's display name. There was no way to see its stable `_id` (the value needed for API calls, or for scoping something like a search-tool `collection_id` filter) without going through devtools or the API directly.
- Adds a small read-only `id: <code>...</code>` line under the name field in the collection detail pane, shown only for an existing, saved collection (not while creating a new, unsaved draft) — mirroring the existing "id:" treatment already used in the dynamic agent editor.

## Test plan

- [x] `npm test -- RagCollectionsView` — all existing tests still pass; added two new tests: id is shown for a selected existing collection, and id is not shown for an in-progress unsaved draft.
- [x] `npx eslint` on the changed files — clean.