### PR TITLE
fix(skills): make hub-projected skills visible to non-admin callers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.14"
+version = "1.0.0-dev.15"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/app/api/skills/__tests__/runnable-gate.test.ts
+++ b/ui/src/app/api/skills/__tests__/runnable-gate.test.ts
@@ -201,6 +201,35 @@ describe("filterSkillsByOpenFga", () => {
     );
   });
 
+  it("keeps hub-projected skills visible for signed-in readers without per-skill tuples", async () => {
+    // hub_skills is a live cache (hub-crawl.ts) never routed through
+    // /api/skills/configs, so it never gets the per-object OpenFGA tuple
+    // that flow grants on create — hub skills must be treated like
+    // `default` here or every one of them fails closed.
+    const check = jest.fn(async () => ({ allowed: false }));
+    const filtered = await filterSkillsByOpenFga(
+      [
+        { ...baseSkill, id: "hub-1", source: "hub", name: "Hub skill" },
+        { ...baseSkill, id: "team-private", source: "agent_skills", name: "Team private" },
+      ],
+      {
+        subject: "user:alice-sub",
+        mode: "read",
+        check,
+      }
+    );
+
+    expect(filtered.map((skill) => skill.id)).toEqual(["hub-1"]);
+    expect(check).toHaveBeenCalledWith({
+      user: "user:alice-sub",
+      relation: "can_read",
+      object: "skill:team-private",
+    });
+    expect(check).not.toHaveBeenCalledWith(
+      expect.objectContaining({ object: "skill:hub-1" }),
+    );
+  });
+
   it("requires can_use when content is being loaded for runtime consumers", async () => {
     const filtered = await filterSkillsByOpenFga(
       [{ ...baseSkill, id: "hub-h1-runnable" }],
@@ -232,6 +261,30 @@ describe("filterSkillsByOpenFga", () => {
     );
 
     expect(filtered.map((skill) => skill.id)).toEqual(["builtin-safe"]);
+    expect(checks).toEqual([
+      "user:alice-sub can_use organization:caipe",
+      "user:alice-sub can_use skill:team-private",
+    ]);
+  });
+
+  it("keeps hub-projected skills visible in use mode for users with baseline org access", async () => {
+    const checks: string[] = [];
+    const filtered = await filterSkillsByOpenFga(
+      [
+        { ...baseSkill, id: "hub-1", source: "hub", name: "Hub skill" },
+        { ...baseSkill, id: "team-private", source: "agent_skills", name: "Team private" },
+      ],
+      {
+        subject: "user:alice-sub",
+        mode: "use",
+        check: async (tuple) => {
+          checks.push(`${tuple.user} ${tuple.relation} ${tuple.object}`);
+          return { allowed: tuple.object === "organization:caipe" };
+        },
+      }
+    );
+
+    expect(filtered.map((skill) => skill.id)).toEqual(["hub-1"]);
     expect(checks).toEqual([
       "user:alice-sub can_use organization:caipe",
       "user:alice-sub can_use skill:team-private",
@@ -279,6 +332,10 @@ describe("filterSkillsByOpenFga", () => {
 
     expect(checkedObjects).toEqual([
       "can_use skill:local-skill",
+      // Hub skills are a shared-catalog source (see the "hub-projected
+      // skills" tests above), so they hit the baseline org check first,
+      // same as `default`.
+      "can_use organization:caipe",
       "can_use skill:hub-hub1-skill2",
     ]);
   });

--- a/ui/src/app/api/skills/route.ts
+++ b/ui/src/app/api/skills/route.ts
@@ -307,8 +307,17 @@ export async function filterSkillsByOpenFga(
 
   const decisions = await Promise.all(
     skills.map(async (skill) => {
-      if (options.mode === "read" && skill.source === "default") return skill;
-      if (options.mode === "use" && skill.source === "default" && await hasBaselineUseAccess()) {
+      // Hub-projected skills are a live cache (see hub-crawl.ts), never
+      // created through /api/skills/configs, so they never get the
+      // per-object OpenFGA tuple that flow grants on create. Without this
+      // carve-out every hub skill fails the per-skill check below and is
+      // silently stripped for any non-admin caller. Treat them like
+      // `default` (built-in templates): a shared, admin-managed catalog
+      // with no per-object ACL, not a per-user-owned resource.
+      const isSharedCatalogSource =
+        skill.source === "default" || skill.source === "hub";
+      if (options.mode === "read" && isSharedCatalogSource) return skill;
+      if (options.mode === "use" && isSharedCatalogSource && await hasBaselineUseAccess()) {
         return skill;
       }
       try {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev14"
+version = "1.0.0.dev15"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- `hub_skills` (Skill Hub crawls) are a live cache, projected into the catalog on every `GET /api/skills` request — they never go through `POST /api/skills/configs`, the only path that grants the per-object OpenFGA `can_read`/`can_use` tuple via `reconcileSkillTeamShares()`.
- `filterSkillsByOpenFga()` already carved out `source === "default"` (built-in templates) from the per-skill tuple check, treating them as a shared, admin-managed catalog with no per-object ACL. Hub skills never got the same treatment, so every hub-crawled skill failed its per-skill OpenFGA check and was silently stripped from the response for any non-admin caller — a hub with 18 successfully crawled skills rendered zero of them in the gallery, on every scope/source filter, with no error surfaced anywhere.
- Extends the existing `default` carve-out to also cover `source === "hub"`.

## Test plan
- [x] `npx jest src/app/api/skills/__tests__/runnable-gate.test.ts` — 26/26 passing, including two new tests mirroring the existing `default`-source coverage for `read` and `use` mode, plus an updated pre-existing test whose expectation changed as an intended consequence of this fix.
- [x] Verified live: crawled `anthropics/skills` (18 skills) on a test deployment, confirmed they were completely absent from the Skills Gallery pre-fix, and confirmed they appear correctly post-fix.
