### PR TITLE
feat(rag): file datasource re-upload + document count fix

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -2252,6 +2252,86 @@ def _validate_local_file_batch(files: list[tuple[str, bytes]]) -> None:
     raise HTTPException(status_code=413, detail=f"Upload exceeds the {max_local_file_total_upload_bytes} byte batch limit")
 
 
+def _bound_local_file_chunk_params(chunk_size: int, chunk_overlap: int) -> tuple[int, int]:
+  bounded_chunk_size = max(100, min(chunk_size, 100000))
+  bounded_chunk_overlap = max(0, min(chunk_overlap, 10000, bounded_chunk_size - 1))
+  return bounded_chunk_size, bounded_chunk_overlap
+
+
+async def _ingest_local_file_uploads(
+  *,
+  job_id: str,
+  datasource_id: str,
+  uploads: list[tuple[UploadFile, str, bytes, str, str]],
+  description: str,
+  fresh_until: int,
+  chunk_size: int,
+  chunk_overlap: int,
+  user: UserContext,
+  success_message: str,
+  failure_message: str,
+) -> None:
+  """Build documents from validated uploads, ingest them, and finalize the job."""
+  now = int(time.time())
+  documents = []
+  for upload_file, filename, content, text, document_type in uploads:
+    document_metadata = {
+      "document_id": f"{datasource_id}__{hashlib.sha256(filename.encode()).hexdigest()[:8]}",
+      "datasource_id": datasource_id,
+      "ingestor_id": LOCAL_FILE_INGESTOR_ID,
+      "title": filename,
+      "description": description or "",
+      "is_structured_entity": False,
+      "document_type": document_type,
+      "document_ingested_at": now,
+      "fresh_until": fresh_until,
+      "metadata": {
+        "source": filename,
+        "filename": filename,
+        "content_type": upload_file.content_type,
+        "byte_size": len(content),
+      },
+    }
+    documents.append(Document(page_content=text, metadata=document_metadata))
+    logger.info(
+      "local_file_upload accepted filename=%s content_type=%s bytes=%d document_type=%s datasource_id=%s user=%s",
+      filename,
+      upload_file.content_type,
+      len(content),
+      document_type,
+      datasource_id,
+      user.email,
+    )
+
+  try:
+    await ingestor.ingest_documents(
+      ingestor_id=LOCAL_FILE_INGESTOR_ID,
+      datasource_id=datasource_id,
+      job_id=job_id,
+      documents=documents,
+      fresh_until=fresh_until,
+      chunk_overlap=chunk_overlap,
+      chunk_size=chunk_size,
+    )
+    await jobmanager.increment_document_count(job_id, len(documents))
+    await jobmanager.upsert_job(
+      job_id,
+      status=JobStatus.COMPLETED,
+      message=success_message,
+      total=len(uploads),
+      datasource_id=datasource_id,
+    )
+  except Exception as exc:
+    await jobmanager.increment_failure(job_id, message=str(exc))
+    await jobmanager.upsert_job(
+      job_id,
+      status=JobStatus.FAILED,
+      message=failure_message,
+      datasource_id=datasource_id,
+    )
+    raise
+
+
 @app.post("/v1/ingest/local-file", status_code=status.HTTP_202_ACCEPTED)
 async def ingest_local_file(
   request: Request,
@@ -2331,8 +2411,7 @@ async def ingest_local_file(
   if not success:
     raise HTTPException(status_code=500, detail="Failed to create job")
 
-  bounded_chunk_size = max(100, min(chunk_size, 100000))
-  bounded_chunk_overlap = max(0, min(chunk_overlap, 10000, bounded_chunk_size - 1))
+  bounded_chunk_size, bounded_chunk_overlap = _bound_local_file_chunk_params(chunk_size, chunk_overlap)
   now = int(time.time())
   first_filename = uploads[0][1]
   datasource_name = first_filename if len(uploads) == 1 else f"{first_filename} + {len(uploads) - 1} files"
@@ -2374,67 +2453,140 @@ async def ingest_local_file(
   await metadata_storage.store_datasource_info(datasource_info)
 
   fresh_until = get_fresh_until(datasource_info.reload_interval)
-  documents = []
-  for upload_file, filename, content, text, document_type in uploads:
-    document_metadata = {
-      "document_id": f"{datasource_id}__{hashlib.sha256(filename.encode()).hexdigest()[:8]}",
-      "datasource_id": datasource_id,
-      "ingestor_id": LOCAL_FILE_INGESTOR_ID,
-      "title": filename,
-      "description": description or "",
-      "is_structured_entity": False,
-      "document_type": document_type,
-      "document_ingested_at": now,
-      "fresh_until": fresh_until,
-      "metadata": {
-        "source": filename,
-        "filename": filename,
-        "content_type": upload_file.content_type,
-        "byte_size": len(content),
-      },
-    }
-    documents.append(Document(page_content=text, metadata=document_metadata))
-    logger.info(
-      "local_file_upload accepted filename=%s content_type=%s bytes=%d document_type=%s datasource_id=%s user=%s",
-      filename,
-      upload_file.content_type,
-      len(content),
-      document_type,
-      datasource_id,
-      user.email,
-    )
-
-  try:
-    await ingestor.ingest_documents(
-      ingestor_id=LOCAL_FILE_INGESTOR_ID,
-      datasource_id=datasource_id,
-      job_id=job_id,
-      documents=documents,
-      fresh_until=fresh_until,
-      chunk_overlap=bounded_chunk_overlap,
-      chunk_size=bounded_chunk_size,
-    )
-    await jobmanager.upsert_job(
-      job_id,
-      status=JobStatus.COMPLETED,
-      message="Uploaded file ingested successfully" if len(uploads) == 1 else f"Uploaded {len(uploads)} files ingested successfully",
-      total=len(uploads),
-      datasource_id=datasource_id,
-    )
-  except Exception as exc:
-    await jobmanager.increment_failure(job_id, message=str(exc))
-    await jobmanager.upsert_job(
-      job_id,
-      status=JobStatus.FAILED,
-      message="Uploaded file ingestion failed",
-      datasource_id=datasource_id,
-    )
-    raise
+  await _ingest_local_file_uploads(
+    job_id=job_id,
+    datasource_id=datasource_id,
+    uploads=uploads,
+    description=description,
+    fresh_until=fresh_until,
+    chunk_size=bounded_chunk_size,
+    chunk_overlap=bounded_chunk_overlap,
+    user=user,
+    success_message="Uploaded file ingested successfully" if len(uploads) == 1 else f"Uploaded {len(uploads)} files ingested successfully",
+    failure_message="Uploaded file ingestion failed",
+  )
 
   return {
     "datasource_id": datasource_id,
     "job_id": job_id,
     "message": "Local file ingested successfully" if len(uploads) == 1 else "Local files ingested successfully",
+  }
+
+
+@app.post("/v1/ingest/local-file/reupload", status_code=status.HTTP_202_ACCEPTED)
+async def reupload_local_file(
+  datasource_id: str = Form(...),
+  files: List[UploadFile] = File(..., alias="file"),
+  chunk_size: Optional[int] = Form(None),
+  chunk_overlap: Optional[int] = Form(None),
+  user: UserContext = Depends(require_authenticated_user),
+):
+  """Replace the content of an existing local-file data source with a new upload."""
+  if not metadata_storage or not jobmanager or not ingestor or not vector_db:
+    raise HTTPException(status_code=500, detail="Server not initialized")
+  if graph_rag_enabled and not data_graph_db:
+    raise HTTPException(status_code=500, detail="Server not initialized")
+
+  existing = await metadata_storage.get_datasource_info(datasource_id)
+  if not existing:
+    raise HTTPException(status_code=404, detail="Datasource not found")
+  if existing.source_type != "local_file":
+    raise HTTPException(status_code=400, detail="Only file datasources support re-upload")
+
+  await check_datasource_management_access(user, datasource_id)
+
+  uploads: list[tuple[UploadFile, str, bytes, str, str]] = []
+  for upload_file in files:
+    content = await upload_file.read()
+    try:
+      filename = _validate_local_file_upload(upload_file, content)
+      text, document_type = _extract_local_file_text(filename, upload_file.content_type, content)
+    except HTTPException as exc:
+      safe_filename = _safe_upload_filename(upload_file.filename)
+      logger.warning(
+        "local_file_reupload rejected filename=%s content_type=%s bytes=%d status=%d detail=%s user=%s",
+        safe_filename,
+        upload_file.content_type,
+        len(content),
+        exc.status_code,
+        exc.detail,
+        user.email,
+      )
+      raise
+    uploads.append((upload_file, filename, content, text, document_type))
+
+  _validate_local_file_batch([(filename, content) for _, filename, content, _, _ in uploads])
+  total_bytes = sum(len(content) for _, _, content, _, _ in uploads)
+
+  jobs = await jobmanager.get_jobs_by_datasource(datasource_id)
+  if jobs and any(job.status == JobStatus.IN_PROGRESS for job in jobs):
+    raise HTTPException(status_code=400, detail="Cannot re-upload while an ingestion job is in progress.")
+
+  for job in jobs or []:
+    await jobmanager.delete_job(job.job_id)
+  await vector_db.adelete(expr=f"datasource_id == {VectorDBQueryService._quote_string(datasource_id)}")
+  if graph_rag_enabled and data_graph_db:
+    await data_graph_db.remove_entity(None, {DATASOURCE_ID_KEY: datasource_id})
+
+  bounded_chunk_size, bounded_chunk_overlap = _bound_local_file_chunk_params(
+    chunk_size if chunk_size is not None else (existing.default_chunk_size or 10000),
+    chunk_overlap if chunk_overlap is not None else (existing.default_chunk_overlap or 2000),
+  )
+
+  job_id = str(uuid.uuid4())
+  success = await jobmanager.upsert_job(
+    job_id,
+    status=JobStatus.IN_PROGRESS,
+    message="Re-uploading file..." if len(uploads) == 1 else f"Re-uploading {len(uploads)} files...",
+    total=len(uploads),
+    datasource_id=datasource_id,
+  )
+  if not success:
+    raise HTTPException(status_code=500, detail="Failed to create job")
+
+  now = int(time.time())
+  first_filename = uploads[0][1]
+  datasource_name = first_filename if len(uploads) == 1 else f"{first_filename} + {len(uploads) - 1} files"
+  file_metadata = [
+    {
+      "filename": filename,
+      "content_type": upload_file.content_type,
+      "document_type": document_type,
+      "byte_size": len(content),
+    }
+    for upload_file, filename, content, _, document_type in uploads
+  ]
+  existing.name = datasource_name
+  existing.default_chunk_size = bounded_chunk_size
+  existing.default_chunk_overlap = bounded_chunk_overlap
+  existing.last_updated = now
+  existing.metadata = {
+    **(existing.metadata or {}),
+    "filename": first_filename,
+    "file_count": len(uploads),
+    "total_byte_size": total_bytes,
+    "files": file_metadata,
+  }
+  await metadata_storage.store_datasource_info(existing)
+
+  fresh_until = get_fresh_until(existing.reload_interval)
+  await _ingest_local_file_uploads(
+    job_id=job_id,
+    datasource_id=datasource_id,
+    uploads=uploads,
+    description=existing.description,
+    fresh_until=fresh_until,
+    chunk_size=bounded_chunk_size,
+    chunk_overlap=bounded_chunk_overlap,
+    user=user,
+    success_message="Re-uploaded file ingested successfully" if len(uploads) == 1 else f"Re-uploaded {len(uploads)} files ingested successfully",
+    failure_message="Re-uploaded file ingestion failed",
+  )
+
+  return {
+    "datasource_id": datasource_id,
+    "job_id": job_id,
+    "message": "Local file re-uploaded successfully" if len(uploads) == 1 else "Local files re-uploaded successfully",
   }
 
 

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -2522,8 +2522,6 @@ async def reupload_local_file(
   if jobs and any(job.status == JobStatus.IN_PROGRESS for job in jobs):
     raise HTTPException(status_code=400, detail="Cannot re-upload while an ingestion job is in progress.")
 
-  for job in jobs or []:
-    await jobmanager.delete_job(job.job_id)
   await vector_db.adelete(expr=f"datasource_id == {VectorDBQueryService._quote_string(datasource_id)}")
   if graph_rag_enabled and data_graph_db:
     await data_graph_db.remove_entity(None, {DATASOURCE_ID_KEY: datasource_id})

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_local_file_reupload.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_local_file_reupload.py
@@ -1,0 +1,152 @@
+"""Tests for POST /v1/ingest/local-file/reupload.
+
+Re-upload replaces the content of an existing local-file data source in
+place: old vector/job/graph state is purged and a new ingestion job is run
+under the same datasource_id, preserving other datasource settings.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from common.job_manager import JobInfo, JobStatus
+from common.models.rag import DataSourceInfo
+from common.models.rbac import Role, UserContext
+from server import restapi
+from server.rbac import require_authenticated_user
+
+
+def _user(role: str = Role.ADMIN, subject: str = "primary-sub") -> UserContext:
+    return UserContext(
+        subject=subject,
+        email="primary@example.com",
+        role=role,
+        is_authenticated=True,
+        groups=[],
+    )
+
+
+def _datasource(source_type: str = "local_file") -> DataSourceInfo:
+    return DataSourceInfo(
+        datasource_id="primary-ds",
+        ingestor_id=restapi.LOCAL_FILE_INGESTOR_ID,
+        name="old.md",
+        source_type=source_type,
+        last_updated=0,
+        default_chunk_size=10000,
+        default_chunk_overlap=2000,
+    )
+
+
+def _job(job_id: str = "job-1", status: JobStatus = JobStatus.COMPLETED) -> JobInfo:
+    return JobInfo(job_id=job_id, status=status, created_at=0, datasource_id="primary-ds")
+
+
+def _allow():
+    async def _ok(*args, **kwargs):
+        return None
+
+    return _ok
+
+
+def _deny(status_code: int = 403, detail: str = "Access denied for this datasource"):
+    async def _raise(*args, **kwargs):
+        raise HTTPException(status_code=status_code, detail=detail)
+
+    return _raise
+
+
+@pytest.fixture
+def client() -> TestClient:
+    return TestClient(restapi.app, raise_server_exceptions=False)
+
+
+@pytest.fixture(autouse=True)
+def _wire(monkeypatch: pytest.MonkeyPatch):
+    restapi.app.dependency_overrides[require_authenticated_user] = lambda: _user()
+    jm = AsyncMock()
+    jm.get_jobs_by_datasource.return_value = []
+    jm.upsert_job.return_value = True
+    ms = AsyncMock()
+    ms.get_datasource_info.return_value = _datasource()
+    ing = AsyncMock()
+    vdb = AsyncMock()
+    monkeypatch.setattr(restapi, "jobmanager", jm, raising=False)
+    monkeypatch.setattr(restapi, "metadata_storage", ms, raising=False)
+    monkeypatch.setattr(restapi, "ingestor", ing, raising=False)
+    monkeypatch.setattr(restapi, "vector_db", vdb, raising=False)
+    monkeypatch.setattr(restapi, "graph_rag_enabled", False, raising=False)
+    monkeypatch.setattr(restapi, "check_datasource_management_access", _allow(), raising=False)
+    yield {"jobmanager": jm, "metadata_storage": ms, "ingestor": ing, "vector_db": vdb}
+    restapi.app.dependency_overrides.clear()
+
+
+def _reupload(client: TestClient, datasource_id: str = "primary-ds", filename: str = "new.md", content: bytes = b"# new content"):
+    return client.post(
+        "/v1/ingest/local-file/reupload",
+        data={"datasource_id": datasource_id},
+        files={"file": (filename, content, "text/markdown")},
+    )
+
+
+def test_reupload_404_when_datasource_missing(client: TestClient, _wire):
+    _wire["metadata_storage"].get_datasource_info.return_value = None
+
+    response = _reupload(client)
+
+    assert response.status_code == 404
+
+
+def test_reupload_400_when_not_local_file_source(client: TestClient, _wire):
+    _wire["metadata_storage"].get_datasource_info.return_value = _datasource(source_type="confluence")
+
+    response = _reupload(client)
+
+    assert response.status_code == 400
+
+
+def test_reupload_403_when_access_denied(client: TestClient, monkeypatch: pytest.MonkeyPatch, _wire):
+    monkeypatch.setattr(restapi, "check_datasource_management_access", _deny(), raising=False)
+
+    response = _reupload(client)
+
+    assert response.status_code == 403
+    _wire["vector_db"].adelete.assert_not_awaited()
+
+
+def test_reupload_400_when_job_in_progress(client: TestClient, _wire):
+    _wire["jobmanager"].get_jobs_by_datasource.return_value = [_job(status=JobStatus.IN_PROGRESS)]
+
+    response = _reupload(client)
+
+    assert response.status_code == 400
+    _wire["vector_db"].adelete.assert_not_awaited()
+
+
+def test_reupload_happy_path_purges_old_content_and_ingests_new_file(client: TestClient, _wire):
+    _wire["jobmanager"].get_jobs_by_datasource.return_value = [_job()]
+
+    response = _reupload(client, filename="new.md", content=b"# brand new")
+
+    assert response.status_code == 202
+    body = response.json()
+    assert body["datasource_id"] == "primary-ds"
+    assert "job_id" in body
+
+    _wire["jobmanager"].delete_job.assert_awaited_once_with("job-1")
+    _wire["vector_db"].adelete.assert_awaited_once()
+    _wire["ingestor"].ingest_documents.assert_awaited_once()
+    _, ingest_kwargs = _wire["ingestor"].ingest_documents.call_args
+    assert ingest_kwargs["datasource_id"] == "primary-ds"
+    assert len(ingest_kwargs["documents"]) == 1
+    assert ingest_kwargs["documents"][0].page_content == "# brand new"
+
+    _wire["jobmanager"].increment_document_count.assert_awaited_once_with(body["job_id"], 1)
+
+    stored = _wire["metadata_storage"].store_datasource_info.call_args[0][0]
+    assert stored.datasource_id == "primary-ds"
+    assert stored.name == "new.md"

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_local_file_reupload.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_local_file_reupload.py
@@ -137,7 +137,7 @@ def test_reupload_happy_path_purges_old_content_and_ingests_new_file(client: Tes
     assert body["datasource_id"] == "primary-ds"
     assert "job_id" in body
 
-    _wire["jobmanager"].delete_job.assert_awaited_once_with("job-1")
+    _wire["jobmanager"].delete_job.assert_not_awaited()
     _wire["vector_db"].adelete.assert_awaited_once()
     _wire["ingestor"].ingest_documents.assert_awaited_once()
     _, ingest_kwargs = _wire["ingestor"].ingest_documents.call_args
@@ -150,3 +150,25 @@ def test_reupload_happy_path_purges_old_content_and_ingests_new_file(client: Tes
     stored = _wire["metadata_storage"].store_datasource_info.call_args[0][0]
     assert stored.datasource_id == "primary-ds"
     assert stored.name == "new.md"
+
+
+def test_reupload_preserves_job_history_across_multiple_reuploads(client: TestClient, _wire):
+    """Each re-upload should add a new job rather than deleting prior ones (matches the
+    reload pattern in queue_datasource_reload/create_reload_job for other source types)."""
+    _wire["jobmanager"].get_jobs_by_datasource.return_value = [_job(job_id="job-1")]
+
+    first = _reupload(client, filename="second.md", content=b"# second")
+    assert first.status_code == 202
+
+    _wire["jobmanager"].get_jobs_by_datasource.return_value = [
+        _job(job_id="job-1"),
+        _job(job_id=first.json()["job_id"]),
+    ]
+
+    second = _reupload(client, filename="third.md", content=b"# third")
+    assert second.status_code == 202
+
+    _wire["jobmanager"].delete_job.assert_not_awaited()
+    new_job_ids = {call.args[0] for call in _wire["jobmanager"].upsert_job.call_args_list}
+    assert new_job_ids == {first.json()["job_id"], second.json()["job_id"]}
+    assert first.json()["job_id"] != second.json()["job_id"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.18"
+version = "1.0.0-dev.19"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/components/rag/FileUploadDropzone.tsx
+++ b/ui/src/components/rag/FileUploadDropzone.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { useRef } from "react";
+import { FileText, Upload, X } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  formatUploadFileSize,
+  type FileUploadSelectionLimits,
+} from "./file-upload-selection";
+
+interface FileUploadDropzoneProps {
+  selectedFiles: File[];
+  limits: FileUploadSelectionLimits;
+  onFilesSelected: (files: File[]) => void;
+  onRemoveFile: (index: number) => void;
+}
+
+/**
+ * The drag-and-drop file picker + selected-file list, shared by every upload
+ * surface (initial ingest, re-upload, ...) so they look and behave
+ * identically.
+ */
+export function FileUploadDropzone({
+  selectedFiles,
+  limits,
+  onFilesSelected,
+  onRemoveFile,
+}: FileUploadDropzoneProps) {
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  return (
+    <div className="mb-4">
+      <label className="block text-sm font-medium text-muted-foreground mb-2">
+        Files
+      </label>
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept=".md,.markdown,.pdf,.txt,text/markdown,text/plain,application/pdf"
+        multiple
+        className="sr-only"
+        aria-label="Choose files to ingest"
+        onChange={(event) => {
+          onFilesSelected(Array.from(event.currentTarget.files ?? []));
+          event.currentTarget.value = "";
+        }}
+      />
+      <div
+        className="rounded-lg border-2 border-dashed border-border bg-muted/20 px-4 py-5 transition-colors hover:border-primary/50 hover:bg-muted/30"
+        onDragOver={(event) => event.preventDefault()}
+        onDrop={(event) => {
+          event.preventDefault();
+          onFilesSelected(Array.from(event.dataTransfer.files));
+        }}
+      >
+        <div className="flex flex-col items-center justify-center gap-3 text-center sm:flex-row sm:text-left">
+          <div className="rounded-full bg-primary/10 p-2.5 text-primary">
+            <Upload className="h-5 w-5" />
+          </div>
+          <div className="flex-1">
+            <p className="text-sm font-medium text-foreground">
+              Drop files here or choose them from your computer
+            </p>
+            <p className="mt-0.5 text-xs text-muted-foreground">
+              PDF, Markdown, and plain text. Up to{" "}
+              {limits.max_files_per_upload} files,{" "}
+              {limits.max_file_size_mb} MiB each, and{" "}
+              {limits.max_total_upload_size_mb} MiB total.
+            </p>
+          </div>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => fileInputRef.current?.click()}
+            className="shrink-0 gap-2"
+          >
+            <Upload className="h-4 w-4" />
+            Choose files
+          </Button>
+        </div>
+      </div>
+
+      {selectedFiles.length > 0 && (
+        <div className="mt-3 space-y-2" aria-live="polite">
+          <p className="text-xs font-medium text-muted-foreground">
+            {selectedFiles.length}{" "}
+            {selectedFiles.length === 1 ? "file" : "files"} selected
+          </p>
+          <div className="max-h-36 space-y-1.5 overflow-y-auto">
+            {selectedFiles.map((file, index) => (
+              <div
+                key={`${file.name}-${file.lastModified}-${index}`}
+                className="flex items-center gap-2 rounded-md border border-border/60 bg-background px-3 py-2"
+              >
+                <FileText className="h-4 w-4 shrink-0 text-primary" />
+                <span
+                  className="min-w-0 flex-1 truncate text-sm"
+                  title={file.name}
+                >
+                  {file.name}
+                </span>
+                <span className="shrink-0 text-xs text-muted-foreground">
+                  {formatUploadFileSize(file.size)}
+                </span>
+                <button
+                  type="button"
+                  onClick={() => onRemoveFile(index)}
+                  className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+                  aria-label={`Remove ${file.name}`}
+                >
+                  <X className="h-3.5 w-3.5" />
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui/src/components/rag/IngestView.tsx
+++ b/ui/src/components/rag/IngestView.tsx
@@ -61,7 +61,6 @@ import {
   Settings,
   StopCircle,
   Trash2,
-  Upload,
   X,
 } from "lucide-react";
 import React, {
@@ -93,10 +92,12 @@ import {
   sourceConfigFilterProjection,
   type DatasourceViewState,
 } from "./datasource-view-state";
-import { mergeSelectedUploadFiles } from "./file-upload-selection";
+import { FileUploadDropzone } from "./FileUploadDropzone";
 import { IngestionSourceCard } from "./IngestionSourceCard";
 import { IngestionSourceForm } from "./IngestionSourceForm";
 import { KbSharingPanel } from "./KbSharingPanel";
+import { ReuploadFileModal } from "./ReuploadFileModal";
+import { useFileUploadSelection } from "./useFileUploadSelection";
 import type { DataSourceInfo, IngestionJob, IngestorInfo } from "./Models";
 import type {
   ChunkInfo,
@@ -117,6 +118,7 @@ import {
   ingestUrl,
   reloadDataSource,
   renameDataSource,
+  reuploadLocalFile,
   terminateJob,
 } from "./api/index";
 import {
@@ -125,6 +127,7 @@ import {
   ingestTypeConfigs,
   isIngestTypeAvailable,
   isIngestorOnline,
+  supportsReupload,
   supportsScheduledReload,
 } from "./typeConfig";
 
@@ -152,12 +155,6 @@ const IconRenderer = ({
       style={{ display: "inline-block" }}
     />
   );
-};
-
-const formatUploadFileSize = (bytes: number): string => {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 };
 
 // Status badge component with consistent styling
@@ -348,58 +345,20 @@ export default function IngestView() {
 
   // Ingestion state
   const [url, setUrl] = useState("");
-  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
   const [ingestorLimits, setIngestorLimits] = useState<RagIngestorLimits>(() =>
     normalizeRagIngestorLimits(undefined),
   );
-  const fileInputRef = useRef<HTMLInputElement>(null);
+  const {
+    selectedFiles,
+    addFiles: updateSelectedFiles,
+    removeFile: removeSelectedFile,
+    reset: resetSelectedFiles,
+  } = useFileUploadSelection(ingestorLimits.file);
   const ingestSectionRef = useRef<HTMLElement | null>(null);
   const [description, setDescription] = useState("");
   const [includeSubPages, setIncludeSubPages] = useState(false);
   const [showAdvancedOptions, setShowAdvancedOptions] = useState(false);
   const selectedManagedSourceType = ingestTypeConfigs[ingestType]?.sourceType;
-
-  const updateSelectedFiles = useCallback(
-    (files: File[]) => {
-      const result = mergeSelectedUploadFiles(
-        selectedFiles,
-        files,
-        ingestorLimits.file,
-      );
-      if (result.unsupportedCount > 0) {
-        toast(
-          `${result.unsupportedCount} unsupported ${result.unsupportedCount === 1 ? "file was" : "files were"} skipped. Choose PDF, Markdown, or text files.`,
-          "error",
-        );
-      }
-      if (result.oversizedCount > 0) {
-        toast(
-          `${result.oversizedCount} ${result.oversizedCount === 1 ? "file exceeds" : "files exceed"} the ${ingestorLimits.file.max_file_size_mb} MiB platform limit.`,
-          "error",
-        );
-      }
-      if (result.duplicateCount > 0) {
-        toast(
-          `${result.duplicateCount} ${result.duplicateCount === 1 ? "file was" : "files were"} already selected.`,
-          "info",
-        );
-      }
-      if (result.countRejectedCount > 0) {
-        toast(
-          `Only ${ingestorLimits.file.max_files_per_upload} files may be ingested at once.`,
-          "error",
-        );
-      }
-      if (result.totalSizeRejectedCount > 0) {
-        toast(
-          `The selected files exceed the ${ingestorLimits.file.max_total_upload_size_mb} MiB total upload limit.`,
-          "error",
-        );
-      }
-      setSelectedFiles(result.files);
-    },
-    [ingestorLimits.file, selectedFiles, toast],
-  );
 
   // Scrapy settings state (for web ingest type)
   const [crawlMode, setCrawlMode] = useState<
@@ -529,6 +488,10 @@ export default function IngestView() {
   const [isReIngesting, setIsReIngesting] = useState(false);
   const [isCleaningUp, setIsCleaningUp] = useState(false);
   const [reIngestError, setReIngestError] = useState<string | null>(null);
+  const [showReuploadModal, setShowReuploadModal] = useState<string | null>(
+    null,
+  );
+  const [isReuploading, setIsReuploading] = useState(false);
 
   const itemsPerPage = 10;
 
@@ -1556,7 +1519,7 @@ export default function IngestView() {
         toast("Files ingested.", "success");
       }
       setUrl("");
-      setSelectedFiles([]);
+      resetSelectedFiles();
       setDescription("");
       setIngestOwnerTeamSlug("");
       setIngestSearchTeamSlugs(
@@ -1621,6 +1584,25 @@ export default function IngestView() {
     } finally {
       setIsReIngesting(false);
       setShowReIngestConfirm(null);
+    }
+  };
+
+  const handleReuploadFile = async (datasourceId: string, files: File[]) => {
+    setIsReuploading(true);
+    try {
+      await reuploadLocalFile(datasourceId, files);
+      await fetchDataSources();
+      await fetchJobsForDataSource(datasourceId);
+      toast("File re-uploaded.", "success");
+      setShowReuploadModal(null);
+    } catch (error) {
+      console.error("Error re-uploading file:", error);
+      toast(
+        `Re-upload failed: ${getErrorMessage(error, "") || "unknown error"}`,
+        "error",
+      );
+    } finally {
+      setIsReuploading(false);
     }
   };
 
@@ -1879,106 +1861,14 @@ export default function IngestView() {
               ) : (
                 <>
                   {/* File source input */}
-                  <div className="mb-4">
-                    <label className="block text-sm font-medium text-muted-foreground mb-2">
-                      Files
-                    </label>
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      accept=".md,.markdown,.pdf,.txt,text/markdown,text/plain,application/pdf"
-                      multiple
-                      className="sr-only"
-                      aria-label="Choose files to ingest"
-                      onChange={(event) => {
-                        updateSelectedFiles(
-                          Array.from(event.currentTarget.files ?? []),
-                        );
-                        event.currentTarget.value = "";
-                      }}
-                    />
-                    <div
-                      className="rounded-lg border-2 border-dashed border-border bg-muted/20 px-4 py-5 transition-colors hover:border-primary/50 hover:bg-muted/30"
-                      onDragOver={(event) => event.preventDefault()}
-                      onDrop={(event) => {
-                        event.preventDefault();
-                        updateSelectedFiles(
-                          Array.from(event.dataTransfer.files),
-                        );
-                      }}
-                    >
-                      <div className="flex flex-col items-center justify-center gap-3 text-center sm:flex-row sm:text-left">
-                        <div className="rounded-full bg-primary/10 p-2.5 text-primary">
-                          <Upload className="h-5 w-5" />
-                        </div>
-                        <div className="flex-1">
-                          <p className="text-sm font-medium text-foreground">
-                            Drop files here or choose them from your computer
-                          </p>
-                          <p className="mt-0.5 text-xs text-muted-foreground">
-                            PDF, Markdown, and plain text. Up to{" "}
-                            {ingestorLimits.file.max_files_per_upload} files,{" "}
-                            {ingestorLimits.file.max_file_size_mb} MiB each, and{" "}
-                            {ingestorLimits.file.max_total_upload_size_mb} MiB
-                            total.
-                          </p>
-                        </div>
-                        <Button
-                          type="button"
-                          variant="outline"
-                          onClick={() => fileInputRef.current?.click()}
-                          className="shrink-0 gap-2"
-                        >
-                          <Upload className="h-4 w-4" />
-                          Choose files
-                        </Button>
-                      </div>
-                    </div>
+                  <FileUploadDropzone
+                    selectedFiles={selectedFiles}
+                    limits={ingestorLimits.file}
+                    onFilesSelected={updateSelectedFiles}
+                    onRemoveFile={removeSelectedFile}
+                  />
 
-                    {selectedFiles.length > 0 && (
-                      <div className="mt-3 space-y-2" aria-live="polite">
-                        <p className="text-xs font-medium text-muted-foreground">
-                          {selectedFiles.length}{" "}
-                          {selectedFiles.length === 1 ? "file" : "files"}{" "}
-                          selected
-                        </p>
-                        <div className="max-h-36 space-y-1.5 overflow-y-auto">
-                          {selectedFiles.map((file, index) => (
-                            <div
-                              key={`${file.name}-${file.lastModified}-${index}`}
-                              className="flex items-center gap-2 rounded-md border border-border/60 bg-background px-3 py-2"
-                            >
-                              <FileText className="h-4 w-4 shrink-0 text-primary" />
-                              <span
-                                className="min-w-0 flex-1 truncate text-sm"
-                                title={file.name}
-                              >
-                                {file.name}
-                              </span>
-                              <span className="shrink-0 text-xs text-muted-foreground">
-                                {formatUploadFileSize(file.size)}
-                              </span>
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  setSelectedFiles((current) =>
-                                    current.filter(
-                                      (_, itemIndex) => itemIndex !== index,
-                                    ),
-                                  )
-                                }
-                                className="rounded p-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-                                aria-label={`Remove ${file.name}`}
-                              >
-                                <X className="h-3.5 w-3.5" />
-                              </button>
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Quick options - Crawl Mode for web */}
+                  {/* Quick options - Crawl Mode for web */}
                     {ingestType === "web" && (
                       <div className="flex items-center gap-4 mt-2 ml-1">
                         <span className="text-sm text-muted-foreground">
@@ -2040,7 +1930,6 @@ export default function IngestView() {
                         className="w-full"
                       />
                     </div>
-                  </div>
 
                   {/* Advanced settings - Animated Collapsible */}
                   <div>
@@ -2861,6 +2750,9 @@ export default function IngestView() {
                       const supportsReload = supportsScheduledReload(
                         ds.source_type,
                       );
+                      const supportsFileReupload = supportsReupload(
+                        ds.source_type,
+                      );
                       // Helm-seeded config rows (`config_driven: true`) are immutable via
                       // the source-management API until they are adopted.
                       const isConfigDriven = Boolean(
@@ -3137,12 +3029,18 @@ export default function IngestView() {
                                       variant="ghost"
                                       size="sm"
                                       onClick={() =>
-                                        setShowReIngestConfirm(ds.datasource_id)
+                                        supportsFileReupload
+                                          ? setShowReuploadModal(
+                                              ds.datasource_id,
+                                            )
+                                          : setShowReIngestConfirm(
+                                              ds.datasource_id,
+                                            )
                                       }
                                       disabled={
                                         loadingJobs ||
                                         hasActiveJob ||
-                                        !supportsReload ||
+                                        !(supportsReload || supportsFileReupload) ||
                                         isConfigDriven
                                       }
                                       className="h-7 w-7 p-0"
@@ -3151,11 +3049,13 @@ export default function IngestView() {
                                           ? "Loading job status"
                                           : isConfigDriven
                                           ? "Managed by ingestor config"
-                                          : !supportsReload
+                                          : !supportsReload && !supportsFileReupload
                                             ? "Re-ingest not supported"
                                             : hasActiveJob
                                               ? "Job in progress"
-                                              : "Re-ingest"
+                                              : supportsFileReupload
+                                                ? "Re-upload file"
+                                                : "Re-ingest"
                                       }
                                     >
                                       <RotateCcw className="h-3.5 w-3.5" />
@@ -4648,6 +4548,17 @@ export default function IngestView() {
           </motion.div>
         )}
       </AnimatePresence>
+
+      <ReuploadFileModal
+        open={Boolean(showReuploadModal)}
+        limits={ingestorLimits.file}
+        isSubmitting={isReuploading}
+        onClose={() => setShowReuploadModal(null)}
+        onSubmit={(files) => {
+          if (!showReuploadModal) return;
+          return handleReuploadFile(showReuploadModal, files);
+        }}
+      />
 
       {/* Re-ingest Error Dialog */}
       <Dialog

--- a/ui/src/components/rag/ReuploadFileModal.tsx
+++ b/ui/src/components/rag/ReuploadFileModal.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import { Loader2 } from "lucide-react";
+
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { FileUploadDropzone } from "./FileUploadDropzone";
+import type { FileUploadSelectionLimits } from "./file-upload-selection";
+import { useFileUploadSelection } from "./useFileUploadSelection";
+
+interface ReuploadFileModalProps {
+  open: boolean;
+  limits: FileUploadSelectionLimits;
+  isSubmitting: boolean;
+  onClose: () => void;
+  onSubmit: (files: File[]) => void | Promise<void>;
+}
+
+export function ReuploadFileModal({
+  open,
+  limits,
+  isSubmitting,
+  onClose,
+  onSubmit,
+}: ReuploadFileModalProps) {
+  const {
+    selectedFiles,
+    addFiles,
+    removeFile,
+    reset: resetSelectedFiles,
+  } = useFileUploadSelection(limits);
+
+  const handleClose = () => {
+    if (isSubmitting) return;
+    resetSelectedFiles();
+    onClose();
+  };
+
+  const handleSubmit = async () => {
+    if (selectedFiles.length === 0) return;
+    await onSubmit(selectedFiles);
+    resetSelectedFiles();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(nextOpen) => !nextOpen && handleClose()}>
+      <DialogContent className="max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Re-upload File</DialogTitle>
+          <DialogDescription>
+            Replace this data source&apos;s content with a new file. Existing
+            documents will be removed once the new content finishes
+            processing.
+          </DialogDescription>
+        </DialogHeader>
+
+        <FileUploadDropzone
+          selectedFiles={selectedFiles}
+          limits={limits}
+          onFilesSelected={addFiles}
+          onRemoveFile={removeFile}
+        />
+
+        <DialogFooter>
+          <Button variant="ghost" onClick={handleClose} disabled={isSubmitting}>
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSubmit}
+            disabled={isSubmitting || selectedFiles.length === 0}
+          >
+            {isSubmitting && <Loader2 className="h-4 w-4 animate-spin mr-2" />}
+            {isSubmitting ? "Uploading..." : "Re-upload"}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/ui/src/components/rag/api/index.ts
+++ b/ui/src/components/rag/api/index.ts
@@ -272,6 +272,25 @@ export const ingestLocalFile = async (params: {
   return apiPostForm("/v1/ingest/local-file", form);
 };
 
+export const reuploadLocalFile = async (
+  datasourceId: string,
+  files: File[],
+  chunkSize?: number,
+  chunkOverlap?: number,
+): Promise<{
+  datasource_id: string;
+  job_id: string;
+  message: string;
+}> => {
+  const form = new FormData();
+  form.append("datasource_id", datasourceId);
+  files.forEach((file) => form.append("file", file));
+  if (chunkSize !== undefined) form.append("chunk_size", String(chunkSize));
+  if (chunkOverlap !== undefined)
+    form.append("chunk_overlap", String(chunkOverlap));
+  return apiPostForm("/v1/ingest/local-file/reupload", form);
+};
+
 export const reloadDataSource = async (
   datasourceId: string,
 ): Promise<{ datasource_id: string; message: string }> => {

--- a/ui/src/components/rag/file-upload-selection.ts
+++ b/ui/src/components/rag/file-upload-selection.ts
@@ -1,3 +1,9 @@
+export const formatUploadFileSize = (bytes: number): string => {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+};
+
 export interface FileUploadSelectionLimits {
   max_file_size_mb: number;
   max_files_per_upload: number;

--- a/ui/src/components/rag/typeConfig.ts
+++ b/ui/src/components/rag/typeConfig.ts
@@ -107,6 +107,13 @@ const SCHEDULED_RELOAD_SOURCE_TYPES = new Set([
 export const supportsScheduledReload = (sourceType: string): boolean =>
   SCHEDULED_RELOAD_SOURCE_TYPES.has(sourceType.toLowerCase());
 
+// File datasources have no external source to periodically refresh from, but
+// they do support replacing their content in place via a manual re-upload.
+const REUPLOAD_SOURCE_TYPES = new Set(["local_file"]);
+
+export const supportsReupload = (sourceType: string): boolean =>
+  REUPLOAD_SOURCE_TYPES.has(sourceType.toLowerCase());
+
 // Helper function to check if an ingest type is available based on ingestors
 export const isIngestTypeAvailable = (
   ingestType: string,

--- a/ui/src/components/rag/useFileUploadSelection.ts
+++ b/ui/src/components/rag/useFileUploadSelection.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useCallback, useState } from "react";
+
+import { useToast } from "@/components/ui/toast";
+import {
+  mergeSelectedUploadFiles,
+  type FileUploadSelectionLimits,
+} from "./file-upload-selection";
+
+/**
+ * Shared file-queue state and validation messaging for every upload surface
+ * (initial ingest, re-upload, ...) so they all enforce and explain the same
+ * platform limits identically.
+ */
+export function useFileUploadSelection(limits: FileUploadSelectionLimits) {
+  const { toast } = useToast();
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+
+  const addFiles = useCallback(
+    (files: File[]) => {
+      const result = mergeSelectedUploadFiles(selectedFiles, files, limits);
+      if (result.unsupportedCount > 0) {
+        toast(
+          `${result.unsupportedCount} unsupported ${result.unsupportedCount === 1 ? "file was" : "files were"} skipped. Choose PDF, Markdown, or text files.`,
+          "error",
+        );
+      }
+      if (result.oversizedCount > 0) {
+        toast(
+          `${result.oversizedCount} ${result.oversizedCount === 1 ? "file exceeds" : "files exceed"} the ${limits.max_file_size_mb} MiB platform limit.`,
+          "error",
+        );
+      }
+      if (result.duplicateCount > 0) {
+        toast(
+          `${result.duplicateCount} ${result.duplicateCount === 1 ? "file was" : "files were"} already selected.`,
+          "info",
+        );
+      }
+      if (result.countRejectedCount > 0) {
+        toast(
+          `Only ${limits.max_files_per_upload} files may be ingested at once.`,
+          "error",
+        );
+      }
+      if (result.totalSizeRejectedCount > 0) {
+        toast(
+          `The selected files exceed the ${limits.max_total_upload_size_mb} MiB total upload limit.`,
+          "error",
+        );
+      }
+      setSelectedFiles(result.files);
+    },
+    [limits, selectedFiles, toast],
+  );
+
+  const removeFile = useCallback((index: number) => {
+    setSelectedFiles((current) =>
+      current.filter((_, itemIndex) => itemIndex !== index),
+    );
+  }, []);
+
+  const reset = useCallback(() => setSelectedFiles([]), []);
+
+  return { selectedFiles, setSelectedFiles, addFiles, removeFile, reset };
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev18"
+version = "1.0.0.dev19"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Two related fixes to the RAG file-datasource ingest path:

1. **Fix document count**: local-file ingestion never incremented `document_count` on the ingestion job, so the UI always showed "0 documents, 1 chunk" for a file datasource even though the file was fully indexed and retrievable (search/fetch worked fine).
2. **File datasource re-upload**: file-type datasources previously had no way to replace their content — the "Re-ingest" button was permanently disabled for them, and the only option was delete-then-recreate. This adds a `POST /v1/ingest/local-file/reupload` endpoint that replaces a file datasource's content in place (same `datasource_id`, same settings), and a UI modal (reusing the same drag-and-drop upload component as the initial ingest flow) wired to the previously-disabled button.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (commit messages)
- [ ] New selection controls follow the selection-control decision table (n/a — no new selection controls)
- [x] All code style checks pass (ruff clean, npm lint clean)
- [x] New code contribution is covered by automated tests (backend: 5 new tests in `test_local_file_reupload.py`)
- [x] All new and existing tests pass (294 passed, 14 skipped in `rag/server`)