### PR TITLE
fix(ci): use built-in token for Dependabot Grype scans

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -55,13 +55,13 @@ jobs:
         with:
           egress-policy: audit
 
-      # Fork-triggered pull_request runs never receive repo secrets (GitHub
-      # security boundary), so CI_SECURITY_APP_ID/PRIVATE_KEY resolve empty
-      # there and create-github-app-token hard-fails. The default GITHUB_TOKEN
-      # is also forced read-only for fork PRs regardless of declared
-      # permissions, so security-events: write is unavailable either way.
-      # Detect that case and skip the app-token + SARIF upload, but still run
-      # the scan itself so contributors get results in the job log.
+      # Fork-triggered pull_request runs never receive repository secrets and
+      # their GITHUB_TOKEN is read-only, so security-events: write is
+      # unavailable. Dependabot PRs from this repository do receive the
+      # workflow permission above, so use the built-in token for those runs
+      # instead of a secret-backed GitHub App token. Detect external forks and
+      # skip only their SARIF upload, but still run the scan itself so
+      # contributors get results in the job log.
       - name: 🔍 Determine fork status
         id: fork-check
         env:
@@ -74,15 +74,6 @@ jobs:
           else
             echo "is_fork=false" >> "$GITHUB_OUTPUT"
           fi
-
-      - name: 🔑 Generate GitHub App token
-        id: app-token
-        if: steps.fork-check.outputs.is_fork != 'true'
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
-        with:
-          app-id: ${{ secrets.CI_SECURITY_APP_ID }}
-          private-key: ${{ secrets.CI_SECURITY_APP_PRIVATE_KEY }}
-          permission-security-events: write
 
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -114,8 +105,7 @@ jobs:
           # merge-ref analysis is not matched against the PR head check run.
           ref: ${{ github.event_name == 'pull_request' && format('refs/pull/{0}/head', github.event.pull_request.number) || github.ref }}
           sha: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
-        env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          token: ${{ github.token }}
 
       - name: ℹ️ Note SARIF upload skipped for fork PR
         if: ${{ always() && steps.fork-check.outputs.is_fork == 'true' }}


### PR DESCRIPTION
## Description

Fixes #2625.

Dependabot-triggered pull request runs were failing before the Grype scan because the workflow attempted to mint a GitHub App token using Dependabot secrets. Those credentials do not identify an App installed on this repository.

The filesystem scan now uploads SARIF with the workflow-provided `github.token`, which has the declared `security-events: write` permission. External fork pull requests retain the existing upload guard while still running the scan.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (Fixes #2625)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in the workflow comments
- [x] All code style checks pass (`actionlint` and `git diff --check`)
- [ ] New code contribution is covered by automated tests (workflow-only change)
- [ ] All new and existing tests pass (workflow-only change; no application tests applicable)