### PR TITLE
fix(rbac): allow self-service read access to Webex bot picker

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.0-dev.20"
+version = "1.0.0-dev.21"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/app/api/admin/webex/bots/route.ts
+++ b/ui/src/app/api/admin/webex/bots/route.ts
@@ -2,15 +2,19 @@ import { NextRequest } from "next/server";
 
 import {
   getAuthFromBearerOrSession,
-  requireRbacPermission,
   successResponse,
   withErrorHandler,
 } from "@/lib/api-middleware";
 import { callWebexBotAdmin } from "@/lib/webex-bot-admin";
+import { requireResourcePermission } from "@/lib/rbac/resource-authz";
 
 export const GET = withErrorHandler(async (request: NextRequest) => {
   const { session } = await getAuthFromBearerOrSession(request);
-  await requireRbacPermission(session, "admin_ui", "view");
+  await requireResourcePermission(
+    session,
+    { type: "admin_surface", id: "webex", action: "read" },
+    { bypassForOrgAdmin: true },
+  );
   const catalog = await callWebexBotAdmin<{ bots: unknown[] }>("/admin/webex/bots");
   return successResponse(catalog);
 });

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.0.dev20"
+version = "1.0.0.dev21"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

The Webex "Configure Spaces" self-service discovery flow calls
`GET /api/admin/webex/bots` to populate the bot picker, but that route
required the full `admin_ui#view` permission (org-admin or team member
with manage access). This blocked non-admin users with a
`403 admin_ui#view / pdp_denied` error when opening the panel, even
though the underlying discovery (`available-spaces`) and submission
(`spaces/onboard`) endpoints underneath are already self-service-capable.

This switches the bots route to the same `admin_surface:webex#read`
check (with org-admin bypass) already used by
`available-spaces/route.ts`, restoring parity with the analogous Slack
self-service channel-submission flow (Slack has no equivalent
bot-picker endpoint since it uses a single bot token).

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented (no user-facing docs change needed; permission model already documented for the equivalent Slack flow)
- [ ] New selection controls follow the selection-control decision table (n/a)
- [x] All code style checks pass (`npx eslint` on the changed file)
- [ ] New code contribution is covered by automated tests (single-line permission-check swap mirroring an existing, already-tested pattern; no new behavior)
- [x] All new and existing tests pass