### PR TITLE
docs(releases): add 1.0.0 release post

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -33,7 +33,7 @@ const legacyMigrationSlugs = [
   ...Array.from({length: 8}, (_, i) => `migration-0.4.${i}-to-0.4.${i + 1}`),
 ];
 
-const currentReleaseSlugs = ['release-0.4.0', 'release-0.5.0', 'release-0.6.0'];
+const currentReleaseSlugs = ['release-0.4.0', 'release-0.5.0', 'release-0.6.0', 'release-1.0.0'];
 
 // Keyed by the surviving post; the values are slugs that no longer resolve to a page. A
 // current slug must never appear in its own list, or it would redirect to itself.

--- a/docs/releases/2026-09-03-release-1-0-0.md
+++ b/docs/releases/2026-09-03-release-1-0-0.md
@@ -2,7 +2,7 @@
 slug: release-1.0.0
 title: "Release 1.0.0: A Unified Platform Experience"
 date: 2026-09-03
-authors: [sriaradhyula]
+authors: [sriaradhyula, cisco-erilutz, kevkantes]
 tags: [release]
 ---
 

--- a/docs/releases/2026-09-03-release-1-0-0.md
+++ b/docs/releases/2026-09-03-release-1-0-0.md
@@ -1,0 +1,204 @@
+---
+slug: release-1.0.0
+title: "Release 1.0.0: A Unified Platform Experience"
+date: 2026-09-03
+authors: [sriaradhyula]
+tags: [release]
+---
+
+## Highlights
+
+CAIPE 1.0 brings the platform's main user experiences together around one application
+shell. A customizable home page, global navigation, command palette, platform-health
+notifications, searchable pickers, and consistent breadcrumbs make the UI easier to
+navigate and operate.
+
+This release also completes the move to the CAIPE package and image namespace, expands
+Webex administration and self-service identity linking, and adds more governed RAG
+workflows for file data sources. The legacy agent-builder and legacy authorization paths
+are retired; dynamic agents and the centralized authorization service are the supported
+runtime paths.
+
+<!-- truncate -->
+
+## What's New
+
+### Unified application experience
+
+- **Customizable home page** with Quick Start and optional platform widgets.
+- **Global navigation and breadcrumbs** across workspace, settings, administration, and
+  workflows.
+- **Global command palette** for quickly finding pages and actions.
+- **Platform health notifications** surfaced in the application shell.
+- **Searchable agent pickers** shared by chat, administration, and configuration screens.
+- Release notes are available from the user-scoped General settings area, and the About
+  view reports the deployed version.
+
+### Webex and messaging
+
+- Self-service Webex identity linking from user settings, with safer OAuth state handling
+  and race-resistant link claims.
+- Webex administration now mirrors Slack more closely, including Advanced settings,
+  configured-space ownership, per-surface default agents, and 1:1 conversation support.
+- Webex conversations are tagged for Insights, pinned threads stay with their first-
+  responding agent, and disabled direct messages are handled quietly.
+- The legacy Webex migration tab and backend are retired.
+
+### Knowledge bases and data sources
+
+- File data sources can be re-uploaded from the UI through a dedicated endpoint and modal.
+- Re-uploads preserve job history.
+- Collection IDs are visible in the collection detail pane and can be used to filter the
+  RAG search MCP tool.
+- RAG application controls and access checks are aligned with the centralized
+  authorization model.
+
+### Insights and operations
+
+- Insights Statistics now includes API and Webex sections alongside Slack.
+- API-created conversations stay out of the interactive chat-history listing.
+- Audit-service S3 reads are parallelized for lower read latency.
+- Audit events preserve the real caller identity for authorization-bridge decisions and
+  retention failures return actionable errors.
+
+### Platform and security
+
+- Container images and chart defaults use the `ghcr.io/caipe-io` namespace.
+- The legacy dynamic-agent OpenFGA path and legacy agent builder are removed in favor of
+  the centralized authorization service and current dynamic-agent configuration.
+- The insecure Slack HMAC identity-link mechanism is removed.
+
+## Bug Fixes
+
+- Fixed Webex picker access for self-service users and corrected stale or duplicated
+  Webex panel requests.
+- Fixed Webex callback redirects, identity-link races, disabled-DM handling, footer
+  formatting, and configured-space ownership requirements.
+- Fixed chart hover alignment and wide-chart rendering, rolling DAU/MAU windows, and
+  source selection in Insights Statistics.
+- Fixed stale authorization tuples and duplicate Webex-space mappings.
+- Fixed RAG file re-upload history preservation and collection-filter behavior.
+- Fixed legacy conversation identifier handling and new-chat agent resolution.
+
+## Security
+
+The Slack HMAC identity-link flow has been removed. OAuth state cookies enforce a maximum
+age, and authorization-bridge audit events retain the authenticated caller identity.
+Dependency and CI hardening updates are included in the 1.0 series.
+
+## Breaking Changes
+
+- Helm image defaults moved from `ghcr.io/cnoe-io/*` to `ghcr.io/caipe-io/*`. Deployments
+  with explicit image repositories must update those overrides.
+- `global.image.channel` was removed from the parent chart values. Remove it from custom
+  values files; image tags and repositories now determine the selected release channel.
+- The legacy agent builder, legacy dynamic-agent OpenFGA authorization path, and legacy
+  Webex migration UI/backend are no longer available.
+- The Slack HMAC identity-link secret is no longer used. Remove it from external-secret
+  mappings and migrate to the supported identity-link flow.
+
+## Known Issues
+
+None known at this time.
+
+---
+
+## Upgrade Guide: 0.6.0 → 1.0.0
+
+### Overview
+
+This is a major release. The supported runtime remains dynamic agents with centralized
+authorization, but several legacy UI and authorization paths have been removed. Review
+the values changes below before upgrading, especially if your deployment overrides image
+repositories or configures the old Slack identity-link flow.
+
+### Helm Values Changes
+
+#### Breaking Changes
+
+**Image repositories**
+
+The default repositories for CAIPE images changed from `ghcr.io/cnoe-io/*` to
+`ghcr.io/caipe-io/*`.
+
+**Action**: If your `values.yaml` overrides an image repository, update the override to
+the matching `ghcr.io/caipe-io` repository. If it uses the chart defaults, no manual
+repository edit is needed.
+
+**`global.image.channel`**
+
+This parent-chart key was removed:
+
+```yaml
+global:
+  image:
+    channel: ""
+```
+
+**Action**: Delete the key from your values file. It is no longer consumed by the chart.
+
+**Slack HMAC identity-link secret**
+
+The old `SLACK_LINK_HMAC_SECRET` mapping is no longer supported.
+
+**Action**: Remove that key from ExternalSecret or secret mappings. Use the current
+Webex/Slack identity-link flow exposed by the application.
+
+#### New Optional Fields
+
+No new required Helm values are introduced by 1.0.0. The new UI and RAG capabilities are
+available through the existing feature and component configuration.
+
+#### Deprecated / Removed Keys
+
+| Key or setting | Status in 1.0.0 | Action |
+|---|---|---|
+| `global.image.channel` | Removed | Delete from `values.yaml` |
+| `SLACK_LINK_HMAC_SECRET` | Removed | Delete secret and ExternalSecret mappings |
+| Legacy agent-builder settings | Removed | Use current dynamic-agent configuration |
+
+### Upgrade Runbook
+
+#### 1. Back up deployment configuration
+
+Save the current Helm values and take the normal MongoDB backup required by your
+operational policy.
+
+#### 2. Update values.yaml
+
+Remove `global.image.channel`, remove any `SLACK_LINK_HMAC_SECRET` mapping, and update
+explicit `ghcr.io/cnoe-io/*` image overrides to `ghcr.io/caipe-io/*`.
+
+#### 3. Update the chart
+
+```bash
+helm upgrade ai-platform-engineering \
+  oci://ghcr.io/caipe-io/charts/ai-platform-engineering \
+  --version 1.0.0 \
+  -f your-values.yaml
+```
+
+#### 4. Verify
+
+```bash
+kubectl get pods -n <namespace>
+kubectl get events -n <namespace> --sort-by=.lastTimestamp
+```
+
+Then sign in to the UI and verify chat, agent selection, platform health, Insights
+Statistics, and any enabled Webex or RAG workflows. If you use file data sources, verify
+that a test re-upload retains the existing job history.
+
+### Personal Impact Analysis
+
+If your deployment uses chart-default images and does not configure the retired Slack
+HMAC flow, the upgrade requires no image-repository edits. Deployments with explicit
+`ghcr.io/cnoe-io/*` repositories or legacy identity-link secrets must update those
+values before upgrading.
+
+### Full Values Diff
+
+The substantive parent-chart changes are the removal of `global.image.channel`, the
+removal of the old Slack HMAC secret example, and the move of default image repositories
+from `ghcr.io/cnoe-io/*` to `ghcr.io/caipe-io/*`. Component chart README and values files
+are regenerated to match the same namespace migration.

--- a/docs/releases/2026-09-03-release-1-0-0.md
+++ b/docs/releases/2026-09-03-release-1-0-0.md
@@ -2,7 +2,7 @@
 slug: release-1.0.0
 title: "Release 1.0.0: A Unified Platform Experience"
 date: 2026-09-03
-authors: [sriaradhyula, cisco-erilutz, kevkantes]
+authors: [sriaradhyula, cisco-erilutz, kevkantes, subbaksh, suwhang-cisco]
 tags: [release]
 ---
 


### PR DESCRIPTION
## Description

Adds the missing 1.0.0 release-series post required by the manual release workflow. The failed run stopped at the release-post guard because no docs/releases/*release-1-0-0.md file existed:

https://github.com/caipe-io/ai-platform-engineering/actions/runs/33775310497/job/100715423135

The post covers the 0.6.0 → 1.0.0 changes, breaking Helm values changes, and upgrade runbook. It also registers the 1.0.0 release slug for legacy /blog/releases redirects.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Checklist

- [x] Functionality is documented
- [x] All relevant checks pass

Validation: npm run build in docs/ passed. The build reports six existing unrelated broken-anchor warnings.