### PR TITLE
fix(docs): version historical internal links

### DIFF
--- a/docs/scripts/generate-versioned-docs.js
+++ b/docs/scripts/generate-versioned-docs.js
@@ -58,8 +58,17 @@ function runOut(cmd, opts = {}) {
 // Those never resolve to a docs route, so Docusaurus reports them as broken.
 // Since the content is immutable (it comes from a tag), we rewrite any link that
 // resolves outside `docs/docs/` into an absolute GitHub URL pinned to that
-// version's tag. Intra-docs links are left untouched.
+// version's tag. Intra-docs links are left untouched. Root-absolute links into
+// the docs site need a version prefix when the snapshot is not the latest one.
 // ---------------------------------------------------------------------------
+
+function rewriteVersionedDocsTarget(target, tag, isVersionedRoute) {
+  if (!isVersionedRoute || !target.startsWith('/docs/')) return null;
+
+  const targetPath = target.slice('/docs/'.length);
+  if (!targetPath || targetPath.startsWith(`${tag}/`)) return null;
+  return `/docs/${tag}/${targetPath}`;
+}
 
 function rewriteEscapingTarget(target, fileDirRepoRel, tag) {
   if (!target) return null;
@@ -83,13 +92,19 @@ function rewriteEscapingTarget(target, fileDirRepoRel, tag) {
   return `${GITHUB_BASE}/${kind}/${tag}/${repoPath}${anchor}`;
 }
 
-function sanitizeFileLinks(absFile, fileDirRepoRel, tag) {
+function sanitizeFileLinks(absFile, fileDirRepoRel, tag, isVersionedRoute) {
   const original = fs.readFileSync(absFile, 'utf8');
   let changed = false;
 
   // Inline links: ](target) and ](target "title")
   const inlineRe = /\]\(\s*([^)\s]+?)(\s+"[^"]*"|\s+'[^']*')?\s*\)/g;
   let updated = original.replace(inlineRe, (match, target, title) => {
+    const versionedTarget = rewriteVersionedDocsTarget(target, tag, isVersionedRoute);
+    if (versionedTarget) {
+      changed = true;
+      return `](${versionedTarget}${title || ''})`;
+    }
+
     const next = rewriteEscapingTarget(target, fileDirRepoRel, tag);
     if (!next) return match;
     changed = true;
@@ -99,6 +114,12 @@ function sanitizeFileLinks(absFile, fileDirRepoRel, tag) {
   // Reference-style definitions: [label]: target
   const refRe = /^(\s*\[[^\]]+\]:\s*)(\S+)(.*)$/gm;
   updated = updated.replace(refRe, (match, prefix, target, rest) => {
+    const versionedTarget = rewriteVersionedDocsTarget(target, tag, isVersionedRoute);
+    if (versionedTarget) {
+      changed = true;
+      return `${prefix}${versionedTarget}${rest}`;
+    }
+
     const next = rewriteEscapingTarget(target, fileDirRepoRel, tag);
     if (!next) return match;
     changed = true;
@@ -109,7 +130,7 @@ function sanitizeFileLinks(absFile, fileDirRepoRel, tag) {
   return changed;
 }
 
-function sanitizeVersionLinks(versionDir, tag) {
+function sanitizeVersionLinks(versionDir, tag, isVersionedRoute) {
   let count = 0;
   const walk = (dir) => {
     for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
@@ -122,7 +143,7 @@ function sanitizeVersionLinks(versionDir, tag) {
           'docs/docs',
           path.dirname(relWithinVersion).split(path.sep).join('/')
         );
-        if (sanitizeFileLinks(abs, fileDirRepoRel, tag)) count += 1;
+        if (sanitizeFileLinks(abs, fileDirRepoRel, tag, isVersionedRoute)) count += 1;
         if (sanitizeMdxBreakingPatterns(abs)) count += 1;
       }
     }
@@ -228,6 +249,7 @@ if (!fs.existsSync(NODE_MODULES)) {
 
 let versions = JSON.parse(fs.readFileSync(PUBLISHED_JSON, 'utf8'));
 versions = [...new Set(versions)].sort(compareVersionsDesc);
+const latestPublishedVersion = versions[0];
 
 if (versions.length === 0) {
   console.log('No published versions listed; nothing to generate. Building current docs only.');
@@ -284,7 +306,7 @@ try {
       if (fs.existsSync(wtSidebarFile)) {
         fs.cpSync(wtSidebarFile, path.join(VERSIONED_SIDEBARS_DIR, `version-${tag}-sidebars.json`));
       }
-      const fixed = sanitizeVersionLinks(destVersionDir, tag);
+      const fixed = sanitizeVersionLinks(destVersionDir, tag, tag !== latestPublishedVersion);
       console.log(`    captured version-${tag}${fixed ? ` (rewrote source links in ${fixed} file(s))` : ''}`);
     } finally {
       run(`git -C "${REPO_ROOT}" worktree remove --force "${worktree}"`);


### PR DESCRIPTION
## Description

Fixes the deterministic failure in the 1.0.0 docs publish workflow:

https://github.com/caipe-io/ai-platform-engineering/actions/runs/33780725103/job/100733437282

The versioned-docs generator preserved root-absolute internal links such as /docs/workshop/mas. Once 1.0.0 became the latest published version, the 0.5.69 and 0.6.0 snapshots moved under version-prefixed routes, so those links became broken. Historical non-latest snapshots now receive their version prefix during generation; latest/current docs retain root-relative routes.

The unrelated image-build failures in the same release fan-out were Docker Hub BuildKit HTTP 500 errors and are not changed here.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Functionality is documented
- [x] All relevant checks pass

Validation:
- Reproduced the CI sequence with NEW_VERSION=1.0.0.
- Generated 1.0.0, 0.6.0, and 0.5.69 snapshots.
- Confirmed historical workshop links are version-prefixed.
- NODE_OPTIONS=--max-old-space-size=8192 npm run build passed.