### PR TITLE
feat(projects): add projects navigation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.2"
+version = "1.0.1-dev.3"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/components/layout/ApplicationNavigation.tsx
+++ b/ui/src/components/layout/ApplicationNavigation.tsx
@@ -53,6 +53,7 @@ import {
   CalendarClock,
   ChevronDown,
   Database,
+  FolderKanban,
   Home,
   KeyRound,
   LayoutGrid,
@@ -84,6 +85,7 @@ interface ApplicationNavigationItem {
 function activeAreaForPath(pathname: string | null): string | null {
   if (pathname === "/") return "home";
   if (pathname?.startsWith("/chat")) return "chat";
+  if (pathname?.startsWith("/projects")) return "projects";
   if (pathname?.startsWith("/knowledge-bases")) return "knowledge";
   if (pathname?.startsWith("/credentials")) return "credentials";
   if (pathname?.startsWith("/workflows")) return "workflows";
@@ -222,6 +224,12 @@ function ApplicationNavigationContents({
   const items = [
     { key: "home",href: "/",label: "Home",icon: Home },
     { key: "chat",href: chatHref,label: "Chat",icon: MessageCircle },
+    config.projectsEnabled && {
+      key: "projects",
+      href: "/projects",
+      label: "Projects",
+      icon: FolderKanban,
+    },
     { key: "skills",href: "/skills",label: "Skills",icon: Zap },
     config.workflowsEnabled && {
       key: "workflows",

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev2"
+version = "1.0.1.dev3"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Adds the Projects destination to the shared application navigation.

- Adds the Projects icon and label to the left application rail.
- Highlights Projects for nested project routes.
- Reuses the PROJECTS_ENABLED flag from the base PR, so the entry remains hidden by default.

## Type of Change

- [x] New Feature
- [ ] Bugfix
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] Existing navigation tests pass