### PR TITLE
feat(projects): add projects workspace skeleton

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.3"
+version = "1.0.1-dev.4"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/app/(app)/projects/page.tsx
+++ b/ui/src/app/(app)/projects/page.tsx
@@ -1,0 +1,15 @@
+import { notFound } from "next/navigation";
+
+import { AuthGuard } from "@/components/auth-guard";
+import { ProjectsHub } from "@/components/projects/ProjectsHub";
+import { getServerConfig } from "@/lib/config";
+
+export default function ProjectsPage() {
+  if (!getServerConfig().projectsEnabled) notFound();
+
+  return (
+    <AuthGuard>
+      <ProjectsHub />
+    </AuthGuard>
+  );
+}

--- a/ui/src/components/projects/ProjectsHub.tsx
+++ b/ui/src/components/projects/ProjectsHub.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { FolderKanban, Rocket } from "lucide-react";
+
+/**
+ * Public Projects entry point.
+ *
+ * Project catalog providers and lifecycle operations can register here
+ * without coupling the application shell to a specific provider.
+ */
+export function ProjectsHub() {
+  return (
+    <main className="flex min-h-full items-center justify-center p-6">
+      <section className="w-full max-w-2xl rounded-2xl border border-border/60 bg-card/40 p-8 text-center shadow-sm">
+        <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-2xl bg-primary/10 text-primary">
+          <FolderKanban className="h-7 w-7" aria-hidden="true" />
+        </div>
+        <h1 className="mt-5 text-2xl font-semibold tracking-tight">Projects</h1>
+        <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-muted-foreground">
+          A shared workspace for organizing projects, teams, and connected
+          resources.
+        </p>
+        <div className="mt-8 rounded-xl border border-dashed border-border p-6 text-left">
+          <div className="flex items-start gap-3">
+            <Rocket className="mt-0.5 h-5 w-5 shrink-0 text-primary" aria-hidden="true" />
+            <div>
+              <h2 className="font-medium">Project catalog coming soon</h2>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Enable this surface to provide a neutral home for project
+                providers and onboarding workflows.
+              </p>
+            </div>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev3"
+version = "1.0.1.dev4"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Adds the initial authenticated Projects route and neutral landing surface.

- Returns not found when PROJECTS_ENABLED is disabled.
- Reuses the shared AuthGuard.
- Provides a provider-neutral landing state for future project catalog and onboarding work.

This intentionally does not include provider-specific APIs, data models, onboarding integrations, authorization rules, or branding.

## Type of Change

- [x] New Feature
- [ ] Bugfix
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] All code style checks pass
- [x] TypeScript checks pass