### PR TITLE
fix(ci): allow autonomous path detection on pull requests

### DIFF
--- a/.github/workflows/ci-autonomous-agents.yml
+++ b/.github/workflows/ci-autonomous-agents.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
   determine-changes:


### PR DESCRIPTION
# Description

Grant the autonomous-agents workflow read access to pull-request metadata. `dorny/paths-filter` uses the pull-request files API for PR events; with only `contents: read`, its determine-changes job fails with `Resource not accessible by integration`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

Not applicable.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] New selection controls are not applicable
- [x] All code style checks pass
- [x] New code contribution is covered by the workflow permission contract
- [x] All relevant checks pass

Validation: `git diff --check`; reproduced the failure on mirror PR #585 and confirmed the missing permission is the cause.