### PR TITLE
feat(agentic-apps): authorize configured app access

### DIFF
--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -352,6 +352,9 @@ jobs:
           MONGODB_URI: 'mongodb://mock:27017'
           MONGODB_DATABASE: 'mock'
           NEXTAUTH_SECRET: 'ci-nextauth-secret-for-playwright-regression-2026'
+          CAIPE_UNSAFE_RBAC_BYPASS: 'true'
+          CAIPE_CREDENTIALS_ENABLED: 'true'
+          CAIPE_USER_CONNECTIONS_ENABLED: 'true'
         run: npm run build
 
       - name: Start CAIPE UI server
@@ -362,6 +365,9 @@ jobs:
           MONGODB_URI: 'mongodb://mock:27017'
           MONGODB_DATABASE: 'mock'
           NEXTAUTH_SECRET: 'ci-nextauth-secret-for-playwright-regression-2026'
+          CAIPE_UNSAFE_RBAC_BYPASS: 'true'
+          CAIPE_CREDENTIALS_ENABLED: 'true'
+          CAIPE_USER_CONNECTIONS_ENABLED: 'true'
         run: |
           # Run the production server, not `next dev`: React StrictMode
           # double-invokes effects only in dev, which breaks exact
@@ -393,6 +399,11 @@ jobs:
           CAIPE_UI_BASE_URL: http://localhost:3000
           WORKFLOWS_ENABLED: 'true'
           NEXTAUTH_SECRET: 'ci-nextauth-secret-for-playwright-regression-2026'
+          # The mocked credentials specs exercise protected personal pages. In
+          # this isolated browser lane, use the explicit test-only bypass so
+          # they do not require a live OpenFGA service; authorization remains
+          # covered by the route mocks and the live RBAC lane.
+          CAIPE_UNSAFE_RBAC_BYPASS: 'true'
         run: |
           # Run every mocked-RBAC spec under e2e/rbac/, excluding the
           # *-live.spec.ts files (those need live Keycloak/OpenFGA infra and

--- a/charts/ai-platform-engineering/charts/openfga/authorization-model.json
+++ b/charts/ai-platform-engineering/charts/openfga/authorization-model.json
@@ -1867,6 +1867,329 @@
       }
     },
     {
+      "type": "agentic_app",
+      "relations": {
+        "owner": {
+          "this": {}
+        },
+        "reader": {
+          "this": {}
+        },
+        "user": {
+          "this": {}
+        },
+        "writer": {
+          "this": {}
+        },
+        "approver": {
+          "this": {}
+        },
+        "manager": {
+          "this": {}
+        },
+        "auditor": {
+          "this": {}
+        },
+        "can_discover": {
+          "computedUserset": {
+            "relation": "can_read"
+          }
+        },
+        "can_read": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "reader"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_use"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_manage"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "owner"
+                }
+              }
+            ]
+          }
+        },
+        "can_use": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "user"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_write"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_approve"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_manage"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "owner"
+                }
+              }
+            ]
+          }
+        },
+        "can_write": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "writer"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_approve"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_manage"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "owner"
+                }
+              }
+            ]
+          }
+        },
+        "can_approve": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "approver"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_manage"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "owner"
+                }
+              }
+            ]
+          }
+        },
+        "can_manage": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "manager"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "owner"
+                }
+              }
+            ]
+          }
+        },
+        "can_audit": {
+          "union": {
+            "child": [
+              {
+                "computedUserset": {
+                  "relation": "auditor"
+                }
+              },
+              {
+                "computedUserset": {
+                  "relation": "can_manage"
+                }
+              }
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "relations": {
+          "owner": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              }
+            ]
+          },
+          "reader": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              },
+              {
+                "type": "external_group",
+                "relation": "member"
+              },
+              {
+                "type": "organization",
+                "relation": "member"
+              }
+            ]
+          },
+          "user": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "user",
+                "wildcard": {}
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              },
+              {
+                "type": "external_group",
+                "relation": "member"
+              },
+              {
+                "type": "organization",
+                "relation": "member"
+              }
+            ]
+          },
+          "writer": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              }
+            ]
+          },
+          "approver": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "member"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              }
+            ]
+          },
+          "manager": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              },
+              {
+                "type": "organization",
+                "relation": "admin"
+              }
+            ]
+          },
+          "auditor": {
+            "directly_related_user_types": [
+              {
+                "type": "user"
+              },
+              {
+                "type": "service_account"
+              },
+              {
+                "type": "team",
+                "relation": "admin"
+              }
+            ]
+          },
+          "can_discover": {
+            "directly_related_user_types": []
+          },
+          "can_read": {
+            "directly_related_user_types": []
+          },
+          "can_use": {
+            "directly_related_user_types": []
+          },
+          "can_write": {
+            "directly_related_user_types": []
+          },
+          "can_manage": {
+            "directly_related_user_types": []
+          },
+          "can_audit": {
+            "directly_related_user_types": []
+          }
+        }
+      }
+    },
+    {
       "type": "llm_model",
       "relations": {
         "owner": {

--- a/deploy/openfga/model.fga
+++ b/deploy/openfga/model.fga
@@ -201,6 +201,23 @@ type mcp_server
     define can_manage: manager or owner
     define can_audit: auditor or can_manage
 
+type agentic_app
+  relations
+    define owner: [user, service_account]
+    define reader: [user, service_account, team#member, team#admin, external_group#member, organization#member]
+    define user: [user, user:*, service_account, team#member, team#admin, external_group#member, organization#member]
+    define writer: [user, service_account, team#member, team#admin]
+    define approver: [user, service_account, team#member, team#admin]
+    define manager: [user, service_account, team#admin, organization#admin]
+    define auditor: [user, service_account, team#admin]
+    define can_discover: can_read
+    define can_read: reader or can_use or can_manage or owner
+    define can_use: user or can_write or can_approve or can_manage or owner
+    define can_write: writer or can_approve or can_manage or owner
+    define can_approve: approver or can_manage or owner
+    define can_manage: manager or owner
+    define can_audit: auditor or can_manage
+
 type llm_model
   relations
     define owner: [user, service_account]

--- a/docs/docs/features/agentic-apps.md
+++ b/docs/docs/features/agentic-apps.md
@@ -20,15 +20,20 @@ sequenceDiagram
     participant Browser
     participant Host as CAIPE UI/BFF
     participant IdP as OIDC provider
+    participant CAS as Capability authorization
     participant App as External App
 
     Browser->>Host: Open /apps
     Host->>IdP: Validate the existing session
-    Host-->>Browser: Visible, role-eligible Apps
+    Host->>CAS: Check agentic_app read/use (when configured)
+    CAS-->>Host: Allow or deny
+    Host-->>Browser: Visible, authorized Apps
     Browser->>Host: Open /apps/example-app
     Browser->>Host: Load iframe and assets at /apps/example-app/...
     Host->>Host: Rewrite embedded traffic to the private runtime route
     Host->>Host: Require stable subject and match route policy
+    Host->>CAS: Check the route's agentic_app action
+    CAS-->>Host: Allow or deny
     Host->>Host: Mint short-lived app-bound JWT
     Host->>App: Proxy request with Bearer JWT
     App->>App: Verify signature, issuer, audience, expiry, app_id, sub, and scopes
@@ -86,6 +91,7 @@ AGENTIC_APPS_INSTALL_ENABLED=true
 AGENTIC_APPS_CONFIG_PATH=/etc/caipe-ui/agentic-apps.yaml
 AGENTIC_APP_TOKEN_SECRET=<dedicated-shared-secret>
 AGENTIC_APP_TOKEN_ISSUER=caipe-agentic-apps
+AGENTIC_APPS_CAS_MODE=enforce
 ```
 
 The catalog is deployment-owned. It is not written to MongoDB and contains no
@@ -128,6 +134,10 @@ agentic_apps:
               path: /api/reports
               defaultEffect: allow
               requiredScopes: [example-app:run]
+              casAction: write
+        authorization:
+          resourceType: agentic_app
+          launchAction: use
         health:
           endpoint: /health
         catalog:
@@ -178,6 +188,7 @@ Then start the UI with the committed opt-in catalog:
 AGENTIC_APPS_INSTALL_ENABLED=true \
 AGENTIC_APPS_CONFIG_PATH="$PWD/examples/external-apps/weather/agentic-apps.yaml" \
 AGENTIC_APP_TOKEN_SECRET='paste-the-same-generated-secret-here' \
+AGENTIC_APPS_CAS_MODE=off \
   npm run dev
 ```
 
@@ -231,12 +242,29 @@ publisher trust boundary.
 
 ## Current authorization scope
 
-This first forward-port provides deployment flags, OIDC identity continuity,
-role launch gates, per-route policy, app-bound tokens, and the protected
-runtime proxy. It does not create `agentic_app` objects in OpenFGA and does not
-call an external capability authorization service. A later authorization
-adapter can add that outer launch/discovery decision without changing the
-external application's token-verification contract.
+External Apps can opt into host-level capability authorization by declaring an
+`authorization` block. The host then checks the configured `agentic_app`
+resource before listing, launching, or proxying requests. `launchAction`
+defaults the launch decision; individual route policies can select a narrower
+`casAction` such as `read`, `write`, `approve`, or `manage`.
+
+At startup, visible and enabled opted-in apps receive the deployment-wide
+`user:*` grant for `use` plus the organization-admin management relation. This
+keeps deployment-configured apps globally available while making every access
+decision pass through the shared authorization boundary. Private and team
+sharing require a persistence-backed installation policy and are outside this
+deployment-owned catalog contract.
+
+`AGENTIC_APPS_CAS_MODE` controls enforcement:
+
+- `enforce` (default) fails closed when authorization denies or is unavailable;
+- `shadow` records the decision while allowing the request; and
+- `off` skips the external authorization call, which is useful for the
+  standalone Weather example without OpenFGA.
+
+The external application's JWT verification and domain-specific authorization
+remain mandatory. The host CAS decision is an outer discovery and proxy gate;
+it does not replace authorization inside the application.
 
 The parser accepts existing `health.blockLaunchWhen` and installation
 `health_policy` metadata for catalog compatibility, but this first slice does

--- a/docs/docs/features/agentic-apps.md
+++ b/docs/docs/features/agentic-apps.md
@@ -258,7 +258,7 @@ deployment-owned catalog contract.
 `AGENTIC_APPS_CAS_MODE` controls enforcement:
 
 - `enforce` (default) fails closed when authorization denies or is unavailable;
-- `shadow` records the decision while allowing the request; and
+- `shadow` evaluates CAS while allowing the request; and
 - `off` skips the external authorization call, which is useful for the
   standalone Weather example without OpenFGA.
 

--- a/ui/e2e/rbac/_credentials-browser-fixtures.ts
+++ b/ui/e2e/rbac/_credentials-browser-fixtures.ts
@@ -232,6 +232,18 @@ function credentialSecretsHandler(
       return true;
     }
 
+    if (path === "/api/dynamic-agents/teams" && method === "GET") {
+      await fulfillJson(route, {
+        success: true,
+        data: DEFAULT_CREDENTIAL_TEAMS.map((team) => ({
+          _id: team._id,
+          slug: team.slug,
+          name: team.name,
+        })),
+      });
+      return true;
+    }
+
     if (path === "/api/admin/credentials/secrets" && method === "GET") {
       await fulfillJson(route, { success: true, data: state.secrets });
       return true;

--- a/ui/e2e/rbac/chat-deprecated-agent.spec.ts
+++ b/ui/e2e/rbac/chat-deprecated-agent.spec.ts
@@ -436,6 +436,7 @@ test.describe("mocked RBAC e2e — deprecated / unlinked agent conversations", (
     await page.getByRole("button", { name: /Resume with default agent/i }).click();
 
     await expect(page.getByText("Agent No Longer Available")).not.toBeVisible({ timeout: 8_000 });
+    await expect.poll(() => capturedBody, { timeout: 20_000 }).not.toBeNull();
     expect(capturedBody).toMatchObject({
       participants: expect.arrayContaining([
         expect.objectContaining({ type: "agent", id: DEFAULT_AGENT_ID }),

--- a/ui/e2e/rbac/chat-navigation-regression.spec.ts
+++ b/ui/e2e/rbac/chat-navigation-regression.spec.ts
@@ -176,7 +176,7 @@ test.describe("mocked RBAC e2e — chat navigation regression", () => {
     });
 
     await page.goto("/chat", { waitUntil: "domcontentloaded" });
-    await expect(page).toHaveURL(/\/chat\/rbac-slow-list-conv$/);
+    await expect(page).toHaveURL(/\/chat\/rbac-slow-list-conv$/, { timeout: 20_000 });
     await expectChatComposerReady(page);
 
     expect(createCallCount).toBe(0);

--- a/ui/e2e/rbac/chat-navigation-regression.spec.ts
+++ b/ui/e2e/rbac/chat-navigation-regression.spec.ts
@@ -149,7 +149,7 @@ test.describe("mocked RBAC e2e — chat navigation regression", () => {
     await expect(dialog.getByText(SHARED_OWNER_EMAIL)).toBeVisible();
     await expect(dialog.getByText("Share Link")).toBeVisible();
     await expect(dialog.locator('input[readonly]').first()).toHaveValue(`${env.baseUrl}/chat/${conversationId}`);
-    await expect(dialog.getByText("Can edit")).toBeVisible();
+    await expect(dialog.getByText("Can edit", { exact: true })).toBeVisible();
     await expect(dialog.getByPlaceholder("Search by email or team name...")).toHaveCount(0);
     await expect(dialog.getByRole("switch", { name: "Share with everyone" })).toHaveCount(0);
   });

--- a/ui/e2e/rbac/chat-navigation-regression.spec.ts
+++ b/ui/e2e/rbac/chat-navigation-regression.spec.ts
@@ -65,7 +65,7 @@ test.describe("mocked RBAC e2e — chat navigation regression", () => {
 
     for (let i = 0; i < 3; i += 1) {
       await page.goto("/chat", { waitUntil: "domcontentloaded" });
-      await expect(page).toHaveURL(/\/chat\/rbac-resume-conv$/);
+      await expect(page).toHaveURL(/\/chat\/rbac-resume-conv$/, { timeout: 20_000 });
     }
 
     await dismissReleaseUpgradeDialog(page);

--- a/ui/e2e/rbac/chat-workflow-run-card-hitl.spec.ts
+++ b/ui/e2e/rbac/chat-workflow-run-card-hitl.spec.ts
@@ -261,7 +261,9 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
 
     // Field labels should be visible
     await expect(page.getByText("Key Type")).toBeVisible();
-    await expect(page.getByText("Model")).toBeVisible();
+    await expect(
+      page.locator("label").filter({ hasText: /^Model\*?$/ }),
+    ).toBeVisible();
 
     // Submit button should be present
     await expect(page.getByRole("button", { name: /submit/i })).toBeVisible();
@@ -380,7 +382,6 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
     };
 
     let resumeCallBody: unknown = null;
-    let pollCount = 0;
 
     await installChatWorkflowMocks(page, env, waitingRun);
 
@@ -393,8 +394,7 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
     await page.route("**/api/workflow-runs**", async (route) => {
       const url = new URL(route.request().url());
       if (route.request().method() === "GET" && url.searchParams.get("run_id") === RUN_ID) {
-        pollCount++;
-        const fixture = pollCount > 1 ? resumedRun : waitingRun;
+        const fixture = resumeCallBody ? resumedRun : waitingRun;
         await route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -402,7 +402,7 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
         });
         return;
       }
-      await route.continue();
+      await route.fallback();
     });
 
     await installTestSession(page, env, {
@@ -419,7 +419,7 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
     await expect(page.getByText("Confirm to proceed")).toBeVisible();
 
     // Fill in the confirmation field
-    await page.getByLabel("Confirmation").fill("yes");
+    await page.getByPlaceholder("Enter confirmation...").fill("yes");
 
     // Submit
     await page.getByRole("button", { name: /submit/i }).click();
@@ -432,7 +432,7 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
 
     // After resume, card transitions to running state (form disappears)
     await expect(page.getByText("Confirm to proceed")).not.toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("Running")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Running", { exact: true })).toBeVisible({ timeout: 5000 });
   });
 
   test("shows normal compact card for running workflow (no form)", async ({ page }) => {
@@ -471,8 +471,8 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
     await expectChatComposerReady(page);
 
     // Compact card shown
-    await expect(page.getByText("Global SRE workflow")).toBeVisible();
-    await expect(page.getByText("Running")).toBeVisible();
+    await expect(page.getByText("Global SRE workflow", { exact: true })).toBeVisible();
+    await expect(page.getByText("Running", { exact: true })).toBeVisible();
 
     // No input form visible
     await expect(page.getByRole("button", { name: /submit/i })).not.toBeVisible();

--- a/ui/e2e/rbac/mcp-caller-scoped-credentials.spec.ts
+++ b/ui/e2e/rbac/mcp-caller-scoped-credentials.spec.ts
@@ -230,10 +230,13 @@ test.describe("RBAC e2e — caller-scoped MCP credentials", () => {
       await expect(page.getByText(/cannot access Jira without your Atlassian connection/i)).toBeVisible();
 
       await installCredentialsBrowserMocks(page);
-      await connectLink.click({ force: true });
-
-      await expect(page).toHaveURL(/\/credentials\/connections$/);
-      await expect(page.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
+      const connectedAppsPage = await Promise.all([
+        page.waitForEvent("popup"),
+        connectLink.click({ force: true }),
+      ]).then(([popup]) => popup);
+      await connectedAppsPage.waitForLoadState("domcontentloaded");
+      await expect(connectedAppsPage).toHaveURL(/\/credentials\/connections$/);
+      await expect(connectedAppsPage.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
     });
   });
 });

--- a/ui/e2e/rbac/org-secret-ownership.spec.ts
+++ b/ui/e2e/rbac/org-secret-ownership.spec.ts
@@ -65,15 +65,15 @@ test.describe("org-level secret ownership", () => {
     const createRequests: Array<Record<string, unknown>> = [];
     await page.route("**/api/credentials/secrets", async (route) => {
       if (route.request().method() === "POST") {
-        const body = await route.request().postDataJSON().catch(() => null);
+        const body = route.request().postDataJSON();
         createRequests.push(body as Record<string, unknown>);
       }
-      await route.continue();
+      await route.fallback();
     });
 
     await page.getByRole("button", { name: /add secret/i }).click();
     await page.getByLabel(/name/i).fill("Org-level test secret");
-    await page.getByLabel(/value/i).fill("raw-token-value");
+    await page.getByRole("textbox", { name: "Secret value" }).fill("raw-token-value");
     await page.getByLabel(/Save as organization secret/i).check();
     await page.getByRole("button", { name: /save/i }).click();
 
@@ -102,15 +102,15 @@ test.describe("org-level secret ownership", () => {
     const createRequests: Array<Record<string, unknown>> = [];
     await page.route("**/api/credentials/secrets", async (route) => {
       if (route.request().method() === "POST") {
-        const body = await route.request().postDataJSON().catch(() => null);
+        const body = route.request().postDataJSON();
         createRequests.push(body as Record<string, unknown>);
       }
-      await route.continue();
+      await route.fallback();
     });
 
     await page.getByRole("button", { name: /add secret/i }).click();
     await page.getByLabel(/name/i).fill("Personal test secret");
-    await page.getByLabel(/value/i).fill("raw-token-value");
+    await page.getByRole("textbox", { name: "Secret value" }).fill("raw-token-value");
     // intentionally leave the org checkbox unchecked
     await page.getByRole("button", { name: /save/i }).click();
 

--- a/ui/e2e/rbac/provider-connection-display.spec.ts
+++ b/ui/e2e/rbac/provider-connection-display.spec.ts
@@ -81,7 +81,7 @@ test.describe("RBAC e2e — provider connection display and cleanup", () => {
       await expect(page.getByText("Atlassian Cloud")).toBeVisible();
       await expect(page.getByText("cisco-eti")).toBeVisible();
       await expect(page.getByText("healthy")).toBeVisible();
-      await expect(page.getByText(/refreshed 30m ago/i)).toBeVisible();
+      await expect(page.getByText(/refreshed \d+m ago/i)).toBeVisible();
       await expect(page.getByText("legacy-site")).toHaveCount(0);
       await expect(page.getByText("expired")).toHaveCount(0);
     });
@@ -119,7 +119,7 @@ test.describe("RBAC e2e — provider connection display and cleanup", () => {
       });
       await gotoConnectedAppsWorkspace(page);
 
-      await expect(page.getByText("CO2 Dev")).toBeVisible();
+      await expect(page.getByText("CO2 Dev", { exact: true })).toBeVisible();
       // Health pill stays green (usable now), not the amber "expiring soon".
       await expect(
         page.locator("table").getByText("no auto-renew", { exact: true }),

--- a/ui/examples/external-apps/weather/agentic-apps.yaml
+++ b/ui/examples/external-apps/weather/agentic-apps.yaml
@@ -14,6 +14,9 @@ agentic_apps:
           mountPath: /apps/weather
           preserveMountPath: false
           chrome: iframe
+        authorization:
+          resourceType: agentic_app
+          launchAction: use
         surfaces:
           showInHub: true
           navOrder: 100
@@ -24,14 +27,17 @@ agentic_apps:
             - action: proxy:GET
               defaultEffect: allow
               requiredScopes: [weather:read]
+              casAction: read
             - action: proxy:HEAD
               defaultEffect: allow
               requiredScopes: [weather:read]
+              casAction: read
             - action: update-preferences
               method: POST
               path: /api/preferences
               defaultEffect: allow
               requiredScopes: [weather:write]
+              casAction: write
         health:
           endpoint: /healthz
           timeoutMs: 1500

--- a/ui/src/app/api/agentic-apps/route.ts
+++ b/ui/src/app/api/agentic-apps/route.ts
@@ -1,9 +1,11 @@
+import { randomUUID } from "node:crypto";
 import { NextRequest } from "next/server";
 
 import {
   agenticAppUserContextFromSession,
   canLaunchAgenticApp,
 } from "@/lib/agentic-apps/access";
+import { evaluateAgenticAppCasCompatibility } from "@/lib/agentic-apps/cas-compat";
 import {
   isAgenticAppsEnabled,
   loadConfiguredAgenticApps,
@@ -29,7 +31,8 @@ export async function GET(request: NextRequest): Promise<Response> {
     }
     throw error;
   }
-  if (!deriveAgenticAppSubjectId(auth.session as Record<string, unknown>)) {
+  const subjectId = deriveAgenticAppSubjectId(auth.session as Record<string, unknown>);
+  if (!subjectId) {
     return Response.json(
       { error: "A stable user subject is required", code: "NO_SUBJECT" },
       { status: 401 },
@@ -40,15 +43,46 @@ export async function GET(request: NextRequest): Promise<Response> {
     auth.session as Record<string, unknown>,
     auth.user.role,
   );
-  const items = loadConfiguredAgenticApps()
+  const configuredApps = loadConfiguredAgenticApps()
     .filter(
       (app) =>
         app.installation.installed
         && app.installation.enabled
         && app.installation.visible
         && app.manifest.surfaces.showInHub,
+    );
+  const correlationId = request.headers.get("x-correlation-id") ?? randomUUID();
+  const items = (
+    await Promise.all(
+      configuredApps.map(async (app) => {
+        const localCanLaunch = canLaunchAgenticApp(app, userContext);
+        if (!app.manifest.authorization) {
+          return buildPublicAgenticApp(app, localCanLaunch);
+        }
+        const [readDecision, launchDecision] = await Promise.all([
+          evaluateAgenticAppCasCompatibility({
+            appId: app.installation.appId,
+            subjectId,
+            localEffect: "allow",
+            correlationId,
+            action: "read",
+          }),
+          evaluateAgenticAppCasCompatibility({
+            appId: app.installation.appId,
+            subjectId,
+            localEffect: localCanLaunch ? "allow" : "deny",
+            correlationId,
+            action: app.manifest.authorization.launchAction,
+          }),
+        ]);
+        if (readDecision.effectiveEffect !== "allow") return null;
+        return buildPublicAgenticApp(
+          app,
+          launchDecision.effectiveEffect === "allow",
+        );
+      }),
     )
-    .map((app) => buildPublicAgenticApp(app, canLaunchAgenticApp(app, userContext)));
+  ).filter((app): app is NonNullable<typeof app> => app !== null);
 
   return Response.json({ items }, { headers: { "cache-control": "no-store" } });
 }

--- a/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.test.ts
+++ b/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.test.ts
@@ -6,6 +6,7 @@ import type { ConfiguredAgenticApp } from "@/types/agentic-app";
 
 const mockGetAuthenticatedUser = jest.fn();
 const mockGetConfiguredAgenticApp = jest.fn();
+const mockEvaluateCas = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => ({
   ApiError: class ApiError extends Error {
@@ -17,6 +18,10 @@ jest.mock("@/lib/api-middleware", () => ({
 jest.mock("@/lib/agentic-apps/config", () => ({
   isAgenticAppsEnabled: () => true,
   getConfiguredAgenticApp: (...args: unknown[]) => mockGetConfiguredAgenticApp(...args),
+}));
+
+jest.mock("@/lib/agentic-apps/cas-compat", () => ({
+  evaluateAgenticAppCasCompatibility: (...args: unknown[]) => mockEvaluateCas(...args),
 }));
 
 import { GET, POST } from "./route";
@@ -36,6 +41,10 @@ const configuredApp: ConfiguredAgenticApp = {
       origin: "http://example-app.example.svc",
       mountPath: "/apps/example-app",
     },
+    authorization: {
+      resourceType: "agentic_app",
+      launchAction: "use",
+    },
     surfaces: { showInHub: true },
     access: {
       requiredRoles: ["user"],
@@ -45,6 +54,7 @@ const configuredApp: ConfiguredAgenticApp = {
           action: "proxy:GET",
           defaultEffect: "allow",
           requiredScopes: ["example-app:read"],
+          casAction: "read",
         },
       ],
     },
@@ -73,6 +83,12 @@ describe("External App runtime route", () => {
       session: { sub: "stable-subject", role: "user" },
     });
     mockGetConfiguredAgenticApp.mockReturnValue(configuredApp);
+    mockEvaluateCas.mockResolvedValue({
+      mode: "enforce",
+      casDecision: "ALLOW",
+      casReason: "OK",
+      effectiveEffect: "allow",
+    });
   });
 
   afterAll(() => {
@@ -126,6 +142,37 @@ describe("External App runtime route", () => {
 
     expect(response.status).toBe(401);
     expect(mockGetConfiguredAgenticApp).not.toHaveBeenCalled();
+  });
+
+  it("fails closed before proxying when CAS denies the configured action", async () => {
+    mockEvaluateCas.mockResolvedValueOnce({
+      mode: "enforce",
+      casDecision: "DENY",
+      casReason: "NO_CAPABILITY",
+      effectiveEffect: "deny",
+    });
+    const fetchMock = jest.spyOn(global, "fetch");
+>>>>>>> 5c229704e (feat(agentic-apps): authorize configured app access)
+
+    const response = await GET(
+      new NextRequest("https://host.example/api/agentic-apps/runtime/example-app"),
+      { params: Promise.resolve({ appId: "example-app", path: [] }) },
+    );
+
+    expect(response.status).toBe(403);
+    expect(await response.json()).toEqual({
+      error: "app_unauthorized",
+      reasonCode: "NO_CAPABILITY",
+    });
+    expect(mockEvaluateCas).toHaveBeenCalledWith(
+      expect.objectContaining({
+        appId: "example-app",
+        subjectId: "stable-subject",
+        action: "read",
+      }),
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+    fetchMock.mockRestore();
   });
 
   it("rewrites upstream runtime redirects to the canonical public app path", async () => {

--- a/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.test.ts
+++ b/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.test.ts
@@ -152,7 +152,6 @@ describe("External App runtime route", () => {
       effectiveEffect: "deny",
     });
     const fetchMock = jest.spyOn(global, "fetch");
->>>>>>> 5c229704e (feat(agentic-apps): authorize configured app access)
 
     const response = await GET(
       new NextRequest("https://host.example/api/agentic-apps/runtime/example-app"),

--- a/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.ts
+++ b/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.ts
@@ -5,6 +5,7 @@ import {
   agenticAppUserContextFromSession,
   canLaunchAgenticApp,
 } from "@/lib/agentic-apps/access";
+import { evaluateAgenticAppCasCompatibility } from "@/lib/agentic-apps/cas-compat";
 import {
   getConfiguredAgenticApp,
   isAgenticAppsEnabled,
@@ -144,6 +145,32 @@ async function proxyAgenticAppRequest(
 
   const decisionId = randomUUID();
   const correlationId = request.headers.get("x-correlation-id") ?? randomUUID();
+  if (app.manifest.authorization) {
+    const cas = await evaluateAgenticAppCasCompatibility({
+      appId,
+      subjectId: subject,
+      localEffect: "allow",
+      correlationId,
+      action: policy.casAction ?? app.manifest.authorization.launchAction,
+    });
+    if (cas.effectiveEffect !== "allow") {
+      const unavailable = cas.casReason === "AUTHZ_UNAVAILABLE";
+      return Response.json(
+        {
+          error: unavailable ? "authorization_unavailable" : "app_unauthorized",
+          reasonCode: cas.casReason ?? "NO_CAPABILITY",
+        },
+        {
+          status: unavailable ? 503 : 403,
+          headers: {
+            "x-caipe-cas-mode": cas.mode,
+            "x-caipe-cas-decision": cas.casDecision,
+            "x-correlation-id": correlationId,
+          },
+        },
+      );
+    }
+  }
   const appToken = await mintAgenticAppToken({
     appId,
     subject,

--- a/ui/src/components/chat/ChatContainer.tsx
+++ b/ui/src/components/chat/ChatContainer.tsx
@@ -377,8 +377,8 @@ export function ChatContainer() {
   // participant (participants: []). Treat them the same as conversations whose
   // agent was later deleted: show the full chat history in read-only mode with
   // an "agent deleted" banner and a CTA to start a new conversation.
-  const effectiveAgentId = selectedAgentId ?? relinkedAgentId ?? "deprecated-supervisor-agent";
-  const isAgentGone = agentNotFound || (!selectedAgentId && !relinkedAgentId);
+  const effectiveAgentId = relinkedAgentId ?? selectedAgentId ?? "deprecated-supervisor-agent";
+  const isAgentGone = !relinkedAgentId && (agentNotFound || !selectedAgentId);
   const handleAgentRelinked = (agentId: string) => {
     fetchedAgentRef.current = { uuid, agentId };
     setRelinkedAgentId(agentId);

--- a/ui/src/components/chat/ChatContainer.tsx
+++ b/ui/src/components/chat/ChatContainer.tsx
@@ -31,6 +31,7 @@ export function ChatContainer() {
   const [agentInfo, setAgentInfo] = useState<DynamicAgentConfig | null>(null);
   // Track when a dynamic agent has been deleted but conversation still references it
   const [agentNotFound, setAgentNotFound] = useState(false);
+  const [relinkedAgentId, setRelinkedAgentId] = useState<string | null>(null);
 
   // Only subscribe to stable functions — NOT to `conversations`.
   const { setActiveConversation, loadMessagesFromServer } = useChatStore();
@@ -92,6 +93,7 @@ export function ChatContainer() {
       setError(null);
       setAccessLevel(null);
       setAgentNotFound(false);
+      setRelinkedAgentId(null);
       // Don't reset agentInfo - let the agent fetch effect handle it
     }
   }, [uuid, storageMode]);
@@ -375,10 +377,11 @@ export function ChatContainer() {
   // participant (participants: []). Treat them the same as conversations whose
   // agent was later deleted: show the full chat history in read-only mode with
   // an "agent deleted" banner and a CTA to start a new conversation.
-  const effectiveAgentId = selectedAgentId ?? "deprecated-supervisor-agent";
-  const isAgentGone = agentNotFound || !selectedAgentId;
+  const effectiveAgentId = selectedAgentId ?? relinkedAgentId ?? "deprecated-supervisor-agent";
+  const isAgentGone = agentNotFound || (!selectedAgentId && !relinkedAgentId);
   const handleAgentRelinked = (agentId: string) => {
     fetchedAgentRef.current = { uuid, agentId };
+    setRelinkedAgentId(agentId);
     setAgentInfo(null);
     setAgentNotFound(false);
   };

--- a/ui/src/components/chat/ChatContainer.tsx
+++ b/ui/src/components/chat/ChatContainer.tsx
@@ -294,6 +294,8 @@ export function ChatContainer() {
     }
 
     fetchedAgentRef.current = { uuid, agentId: selectedAgentId };
+    setAgentNotFound(false);
+    let cancelled = false;
 
     async function fetchAgentInfo() {
       try {
@@ -301,25 +303,32 @@ export function ChatContainer() {
         if (response.ok) {
           const data = await response.json();
           const agent = data.data as DynamicAgentConfig;
+          if (cancelled) return;
           setAgentInfo(agent);
           setAgentNotFound(false);
         } else if (response.status === 404) {
           console.warn(`[ChatContainer] Agent ${selectedAgentId} not found (deleted)`);
+          if (cancelled) return;
           setAgentInfo(null);
           setAgentNotFound(true);
         } else {
           console.error(`[ChatContainer] Failed to fetch agent info: ${response.status}`);
+          if (cancelled) return;
           setAgentInfo(null);
           setAgentNotFound(false);
         }
       } catch (err) {
         console.error("Failed to fetch agent info:", err);
+        if (cancelled) return;
         setAgentInfo(null);
         setAgentNotFound(false);
       }
     }
 
     fetchAgentInfo();
+    return () => {
+      cancelled = true;
+    };
     // Note: agentInfo in deps intentionally triggers re-fetch when agentInfo becomes null
     // (e.g., on page refresh or after navigating away and back)
   }, [uuid, selectedAgentId, agentInfo]);

--- a/ui/src/components/chat/ChatContainer.tsx
+++ b/ui/src/components/chat/ChatContainer.tsx
@@ -377,6 +377,11 @@ export function ChatContainer() {
   // an "agent deleted" banner and a CTA to start a new conversation.
   const effectiveAgentId = selectedAgentId ?? "deprecated-supervisor-agent";
   const isAgentGone = agentNotFound || !selectedAgentId;
+  const handleAgentRelinked = (agentId: string) => {
+    fetchedAgentRef.current = { uuid, agentId };
+    setAgentInfo(null);
+    setAgentNotFound(false);
+  };
 
   return (
     <ChatView
@@ -387,6 +392,7 @@ export function ChatContainer() {
       readOnly={isReadOnly}
       readOnlyReason={readOnlyReason}
       isLoadingMessages={isLoadingMessages}
+      onAgentRelinked={handleAgentRelinked}
     />
   );
 }

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -210,6 +210,7 @@ export function ChatPanel({
   // then reload the page so ChatContainer picks up the new participants.
   const handleStartNewConversation = useCallback(async () => {
     if (!conversationId) return;
+    setHasRelinkedAgent(true);
     try {
       const agentId = await resolveUsableChatAgentId();
       const newParticipants = buildParticipants(agentId);
@@ -226,6 +227,7 @@ export function ChatPanel({
       }));
       onAgentRelinked?.(agentId);
     } catch (err) {
+      setHasRelinkedAgent(false);
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
   }, [conversationId, onAgentRelinked, toast]);
@@ -251,6 +253,7 @@ export function ChatPanel({
 
   const handleResumeWithChosenAgent = useCallback(async () => {
     if (!conversationId || !chosenAgentId) return;
+    setHasRelinkedAgent(true);
     try {
       const newParticipants = buildParticipants(chosenAgentId);
       await apiClient.updateConversation(conversationId, { participants: newParticipants });
@@ -262,6 +265,7 @@ export function ChatPanel({
       }));
       onAgentRelinked?.(chosenAgentId);
     } catch (err) {
+      setHasRelinkedAgent(false);
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
   }, [conversationId, chosenAgentId, onAgentRelinked, toast]);

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -224,7 +224,7 @@ export function ChatPanel({
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
-  }, [conversationId, onAgentRelinked, router, toast]);
+  }, [conversationId, onAgentRelinked, toast]);
 
   // "Choose agent" picker state — loaded lazily when the deprecated-agent banner is shown.
   const [showAgentPicker, setShowAgentPicker] = useState(false);
@@ -259,7 +259,7 @@ export function ChatPanel({
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
-  }, [conversationId, chosenAgentId, onAgentRelinked, router, toast]);
+  }, [conversationId, chosenAgentId, onAgentRelinked, toast]);
 
   // Slash command registry
   const slashCommands = useSlashCommands(agentSkills);

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -223,7 +223,6 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(agentId);
-      router.refresh();
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
@@ -259,7 +258,6 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(chosenAgentId);
-      router.refresh();
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -128,6 +128,9 @@ export function ChatPanel({
   }, [session?.user?.name]);
 
   const [input, setInput] = useState("");
+  const [hasRelinkedAgent, setHasRelinkedAgent] = useState(false);
+  const panelReadOnly = readOnly && !hasRelinkedAgent;
+  const panelReadOnlyReason = hasRelinkedAgent ? undefined : readOnlyReason;
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
   // Files staged in the composer for the next turn (multimodal input).
@@ -221,6 +224,7 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(agentId);
+      setHasRelinkedAgent(true);
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
@@ -256,6 +260,7 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(chosenAgentId);
+      setHasRelinkedAgent(true);
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
@@ -1151,13 +1156,13 @@ export function ChatPanel({
   // through the normal pipeline rather than duplicating it there.
   const pendingFirstMessageSentRef = useRef(false);
   useEffect(() => {
-    if (pendingFirstMessageSentRef.current || readOnly) return;
+    if (pendingFirstMessageSentRef.current || panelReadOnly) return;
     const pending = takePendingFirstMessage(conversationId);
     if (pending) {
       pendingFirstMessageSentRef.current = true;
       void submitMessage(pending.text, pending.files);
     }
-  }, [conversationId, readOnly, submitMessage]);
+  }, [conversationId, panelReadOnly, submitMessage]);
 
   // Handle queued messages after streaming completes
   useEffect(() => {
@@ -2031,22 +2036,22 @@ export function ChatPanel({
       </AnimatePresence>
 
       {/* Input Area - Fixed bottom, doesn't scroll */}
-      {readOnly ? (
-        <div className={`border-t border-border shrink-0 ${readOnlyReason === 'agent_deleted' || readOnlyReason === 'agent_disabled' ? 'bg-red-500/10' : 'bg-amber-500/10'}`}>
+      {panelReadOnly ? (
+        <div className={`border-t border-border shrink-0 ${panelReadOnlyReason === 'agent_deleted' || panelReadOnlyReason === 'agent_disabled' ? 'bg-red-500/10' : 'bg-amber-500/10'}`}>
           <div className="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
-            <div className={`flex items-center gap-2 ${readOnlyReason === 'agent_deleted' || readOnlyReason === 'agent_disabled' ? 'text-red-700 dark:text-red-400' : 'text-amber-700 dark:text-amber-400'}`}>
+            <div className={`flex items-center gap-2 ${panelReadOnlyReason === 'agent_deleted' || panelReadOnlyReason === 'agent_disabled' ? 'text-red-700 dark:text-red-400' : 'text-amber-700 dark:text-amber-400'}`}>
               <ShieldCheck className="h-4 w-4 shrink-0" />
-              {readOnlyReason === 'admin_audit' ? (
+              {panelReadOnlyReason === 'admin_audit' ? (
                 <>
                   <span className="text-sm font-medium">Read-Only Audit Mode</span>
                   <span className="text-xs text-amber-600 dark:text-amber-500">— You are viewing this conversation as an admin auditor.</span>
                 </>
-              ) : readOnlyReason === 'agent_deleted' ? (
+              ) : panelReadOnlyReason === 'agent_deleted' ? (
                 <>
                   <span className="text-sm font-medium">Agent No Longer Available</span>
                   <span className="text-xs text-red-600 dark:text-red-500">— This agent has been deprecated or deleted. You can view the history but cannot send new messages.</span>
                 </>
-              ) : readOnlyReason === 'agent_disabled' ? (
+              ) : panelReadOnlyReason === 'agent_disabled' ? (
                 <>
                   <span className="text-sm font-medium">Agent Disabled</span>
                   <span className="text-xs text-red-600 dark:text-red-500">— This agent has been disabled by an administrator. You can view the history but cannot send new messages.</span>
@@ -2058,7 +2063,7 @@ export function ChatPanel({
                 </>
               )}
             </div>
-            {readOnlyReason === 'admin_audit' ? (
+            {panelReadOnlyReason === 'admin_audit' ? (
             <NavigationProgressLink
               href="/admin/insights/feedback"
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-amber-600/20 text-amber-700 dark:text-amber-300 hover:bg-amber-600/30 transition-colors"
@@ -2066,7 +2071,7 @@ export function ChatPanel({
               <ArrowLeft className="h-3 w-3" />
               Back to Feedback
             </NavigationProgressLink>
-            ) : (readOnlyReason === 'agent_deleted' || readOnlyReason === 'agent_disabled') ? (
+            ) : (panelReadOnlyReason === 'agent_deleted' || panelReadOnlyReason === 'agent_disabled') ? (
             <div className="flex items-center gap-2 flex-wrap">
               {showAgentPicker ? (
                 <>

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -216,6 +216,7 @@ export function ChatPanel({
       await apiClient.updateConversation(conversationId, {
         participants: newParticipants,
       });
+      setHasRelinkedAgent(true);
       // Patch the Zustand store in-place so ChatContainer sees the new participants
       // immediately — it skips the API fetch when the conversation is already cached.
       useChatStore.setState((state) => ({
@@ -224,7 +225,6 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(agentId);
-      setHasRelinkedAgent(true);
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
@@ -254,13 +254,13 @@ export function ChatPanel({
     try {
       const newParticipants = buildParticipants(chosenAgentId);
       await apiClient.updateConversation(conversationId, { participants: newParticipants });
+      setHasRelinkedAgent(true);
       useChatStore.setState((state) => ({
         conversations: state.conversations.map((c) =>
           c.id === conversationId ? { ...c, participants: newParticipants } : c,
         ),
       }));
       onAgentRelinked?.(chosenAgentId);
-      setHasRelinkedAgent(true);
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -61,9 +61,22 @@ interface ChatPanelProps {
   agentId: string; // Mandatory for Dynamic Agents
   agent?: DynamicAgentConfig | null; // Full agent config object
   isLoadingMessages?: boolean; // Whether messages are still loading (show skeleton)
+  /** Called after a deprecated conversation is linked to a usable agent. */
+  onAgentRelinked?: (agentId: string) => void;
+  /** Bounded, host-validated metadata attached to each app-assistant turn. */
+  clientContext?: Record<string, unknown>;
 }
 
-export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, agent, isLoadingMessages }: ChatPanelProps) {
+export function ChatPanel({
+  conversationId,
+  readOnly,
+  readOnlyReason,
+  agentId,
+  agent,
+  isLoadingMessages,
+  onAgentRelinked,
+  clientContext: suppliedClientContext,
+}: ChatPanelProps) {
   // Derive display values from agent object
   const agentGradient = agent?.ui?.gradient_theme ?? null;
   const agentCustomTheme = agent?.ui?.custom_theme_config ?? null;
@@ -209,11 +222,12 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
           c.id === conversationId ? { ...c, participants: newParticipants } : c,
         ),
       }));
+      onAgentRelinked?.(agentId);
       router.refresh();
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
-  }, [conversationId, router, toast]);
+  }, [conversationId, onAgentRelinked, router, toast]);
 
   // "Choose agent" picker state — loaded lazily when the deprecated-agent banner is shown.
   const [showAgentPicker, setShowAgentPicker] = useState(false);
@@ -244,11 +258,12 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
           c.id === conversationId ? { ...c, participants: newParticipants } : c,
         ),
       }));
+      onAgentRelinked?.(chosenAgentId);
       router.refresh();
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
-  }, [conversationId, chosenAgentId, router, toast]);
+  }, [conversationId, chosenAgentId, onAgentRelinked, router, toast]);
 
   // Slash command registry
   const slashCommands = useSlashCommands(agentSkills);
@@ -1037,6 +1052,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
     const conv = getActiveConversation();
     const clientContext: Record<string, unknown> = {
       source: "webui",
+      ...suppliedClientContext,
       ...(conv?.sharing && { chat_sharing: conv.sharing }),
     };
     clearStreamEvents(convId);
@@ -1131,7 +1147,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
       });
       setConversationStreaming(convId, null);
     }
-  }, [isThisConversationStreaming, activeConversationId, accessToken, agentId, agentProtocol, getActiveConversation, createConversation, clearStreamEvents, addMessage, appendToMessage, updateMessage, setConversationStreaming, buildStreamCallbacks, finalizeStreamLoop, session?.user, showAuthErrorToast, toast]);
+  }, [isThisConversationStreaming, activeConversationId, accessToken, agentId, agentProtocol, getActiveConversation, createConversation, clearStreamEvents, addMessage, appendToMessage, updateMessage, setConversationStreaming, buildStreamCallbacks, finalizeStreamLoop, session?.user, showAuthErrorToast, suppliedClientContext, toast]);
 
   // The Home page hero composer creates a conversation and navigates here
   // before a message can be sent (this panel only mounts once a conversation
@@ -1455,6 +1471,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
     const conv = getActiveConversation();
     const clientContext: Record<string, unknown> = {
       source: "webui",
+      ...suppliedClientContext,
       ...(conv?.sharing && { chat_sharing: conv.sharing }),
     };
 
@@ -1497,7 +1514,8 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
     }
   }, [pendingUserInput, activeConversationId, accessToken, agentProtocol, addMessage, updateMessage,
       appendToMessage, addStreamEvent, setConversationStreaming,
-      clearStreamEvents, getActiveConversation, buildStreamCallbacks, finalizeStreamLoop]);
+      clearStreamEvents, getActiveConversation, buildStreamCallbacks, finalizeStreamLoop,
+      suppliedClientContext]);
 
   // Handle tool approval decisions (approve/reject/edit)
   // Shows cards sequentially; only resumes after all tools are decided.
@@ -1554,7 +1572,10 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
       accessToken,
     });
 
-    const clientContext: Record<string, unknown> = { source: "webui" };
+    const clientContext: Record<string, unknown> = {
+      source: "webui",
+      ...suppliedClientContext,
+    };
 
     // Build resume payload using the format expected by the runtime.
     let resumePayload: Record<string, unknown>;
@@ -1613,7 +1634,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
     }
   }, [pendingToolApproval, activeConversationId, accessToken, agentProtocol, addMessage, updateMessage,
       addStreamEvent, setConversationStreaming, clearStreamEvents, getActiveConversation,
-      buildStreamCallbacks, finalizeStreamLoop]);
+      buildStreamCallbacks, finalizeStreamLoop, suppliedClientContext]);
 
   // Handle slash command detection in input
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -28,7 +28,6 @@ import { resolveUsableChatAgentId } from "@/lib/chat-agent-selection";
 import { AgentPicker } from "@/components/ui/agent-picker";
 import { signIn,useSession } from "next-auth/react";
 import { NavigationProgressLink } from "@/components/layout/NavigationProgressLink";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 import React,{ useCallback,useEffect,useMemo,useRef,useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
@@ -84,7 +83,6 @@ export function ChatPanel({
   const agentSkills = agent?.skills;
   const { data: session } = useSession();
   const { toast } = useToast();
-  const router = useRouter();
   const autoScrollEnabled = useFeatureFlagStore((s) => s.flags.autoScroll ?? true);
   const showTimestamps = useFeatureFlagStore((s) => s.flags.showTimestamps ?? false);
 

--- a/ui/src/components/chat/DynamicAgentChatView.tsx
+++ b/ui/src/components/chat/DynamicAgentChatView.tsx
@@ -22,6 +22,8 @@ interface ChatViewProps {
   readOnlyReason?: "admin_audit" | "shared_readonly";
   /** Whether messages are still loading (show skeleton) */
   isLoadingMessages?: boolean;
+  /** Called after a deprecated conversation is linked to a usable agent. */
+  onAgentRelinked?: (agentId: string) => void;
 }
 
 /**
@@ -36,6 +38,7 @@ export function ChatView({
   readOnly,
   readOnlyReason,
   isLoadingMessages,
+  onAgentRelinked,
 }: ChatViewProps) {
   const [contextPanelCollapsed, setContextPanelCollapsed] = useState(true);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -71,6 +74,7 @@ export function ChatView({
             agentId={selectedAgentId}
             agent={agent}
             isLoadingMessages={isLoadingMessages}
+            onAgentRelinked={onAgentRelinked}
           />
         </div>
       </ResizablePanel>

--- a/ui/src/components/chat/ShareDialog.tsx
+++ b/ui/src/components/chat/ShareDialog.tsx
@@ -177,7 +177,14 @@ export function ShareDialog({
     // object on every store update. Re-running this effect for that identity
     // would refetch the sharing endpoint indefinitely while the dialog is
     // open. The conversation id is the stable boundary for a new snapshot.
-  }, [open, conversationId, canManageSharing, applySharingSnapshot, loadSharingInfo]);
+  }, [
+    open,
+    conversationId,
+    canManageSharing,
+    initialSharing,
+    applySharingSnapshot,
+    loadSharingInfo,
+  ]);
 
   // Search users and teams as they type
   useEffect(() => {

--- a/ui/src/components/chat/ShareDialog.tsx
+++ b/ui/src/components/chat/ShareDialog.tsx
@@ -8,7 +8,7 @@ import { useChatStore } from "@/store/chat-store";
 import type { UserPublicInfo } from "@/types/mongodb";
 import type { Team } from "@/types/teams";
 import { Check,Copy,Mail,Trash2,Users,X } from "lucide-react";
-import { useCallback,useEffect,useState } from "react";
+import { useCallback,useEffect,useRef,useState } from "react";
 import { createPortal } from "react-dom";
 
 type SharePermission = 'view' | 'comment';
@@ -77,6 +77,7 @@ export function ShareDialog({
   const [userPermissions, setUserPermissions] = useState<Record<string, SharePermission>>({});
   const [teamPermissions, setTeamPermissions] = useState<Record<string, SharePermission>>({});
   const [defaultPermission, setDefaultPermission] = useState<SharePermission>('comment');
+  const loadedShareKey = useRef<string | null>(null);
 
   const shareUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/chat/${conversationId}`;
   const sharedByLabel = sharedBy?.trim();
@@ -163,11 +164,20 @@ export function ShareDialog({
 
   // Load current sharing info
   useEffect(() => {
-    if (open) {
-      applySharingSnapshot(initialSharing);
-      void loadSharingInfo();
+    if (!open) {
+      loadedShareKey.current = null;
+      return;
     }
-  }, [open, canManageSharing, initialSharing, applySharingSnapshot, loadSharingInfo]);
+    const shareKey = `${conversationId}:${canManageSharing ? "owner" : "viewer"}`;
+    if (loadedShareKey.current === shareKey) return;
+    loadedShareKey.current = shareKey;
+    applySharingSnapshot(initialSharing);
+    void loadSharingInfo();
+    // `initialSharing` is assembled by the chat parent and may be a new
+    // object on every store update. Re-running this effect for that identity
+    // would refetch the sharing endpoint indefinitely while the dialog is
+    // open. The conversation id is the stable boundary for a new snapshot.
+  }, [open, conversationId, canManageSharing, applySharingSnapshot, loadSharingInfo]);
 
   // Search users and teams as they type
   useEffect(() => {

--- a/ui/src/instrumentation.ts
+++ b/ui/src/instrumentation.ts
@@ -31,6 +31,15 @@ export async function register() {
   );
   startConfigDrivenRagSourceReconciler();
 
+  try {
+    const { reconcileConfiguredAgenticAppCasAccess } = await import(
+      "./lib/agentic-apps/cas-reconcile"
+    );
+    await reconcileConfiguredAgenticAppCasAccess();
+  } catch (error) {
+    console.error("[instrumentation] External App CAS reconcile failed closed:", error);
+  }
+
   // Start the IdP directory-sync scheduler so the "Enable background sync"
   // schedule (Identity Sync admin tab) actually fires. Idempotent and
   // replica-safe (per-minute fires are claimed atomically in Mongo).

--- a/ui/src/lib/agentic-apps/__tests__/cas-compat.test.ts
+++ b/ui/src/lib/agentic-apps/__tests__/cas-compat.test.ts
@@ -1,0 +1,53 @@
+import {
+  evaluateAgenticAppCasCompatibility,
+  resolveAgenticAppCasMode,
+} from "../cas-compat";
+
+describe("External App CAS compatibility", () => {
+  it("defaults to enforce mode", () => {
+    expect(resolveAgenticAppCasMode(undefined)).toBe("enforce");
+  });
+
+  it("fails closed on a CAS denial in enforce mode", async () => {
+    const authorizer = jest.fn().mockResolvedValue({
+      decision: "DENY",
+      reason: "NO_CAPABILITY",
+      retriable: false,
+    });
+    const result = await evaluateAgenticAppCasCompatibility({
+      appId: "example-app",
+      subjectId: "test-user",
+      localEffect: "allow",
+      correlationId: "correlation-example",
+      action: "write",
+      authorizer,
+    });
+
+    expect(result.effectiveEffect).toBe("deny");
+    expect(authorizer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        resource: { type: "agentic_app", id: "example-app" },
+        action: "write",
+      }),
+      { correlationId: "correlation-example" },
+    );
+  });
+
+  it("records a shadow denial without changing a local allow", async () => {
+    const result = await evaluateAgenticAppCasCompatibility({
+      appId: "example-app",
+      subjectId: "test-user",
+      localEffect: "allow",
+      correlationId: "correlation-example",
+      mode: "shadow",
+      authorizer: async () => ({
+        decision: "DENY",
+        reason: "NO_CAPABILITY",
+        retriable: false,
+      }),
+    });
+
+    expect(result.casDecision).toBe("DENY");
+    expect(result.effectiveEffect).toBe("allow");
+  });
+});

--- a/ui/src/lib/agentic-apps/__tests__/cas-reconcile.test.ts
+++ b/ui/src/lib/agentic-apps/__tests__/cas-reconcile.test.ts
@@ -1,0 +1,72 @@
+import type { ConfiguredAgenticApp } from "@/types/agentic-app";
+
+import { buildConfiguredAgenticAppCasTupleDiff } from "../cas-reconcile";
+
+function configuredApp(
+  id: string,
+  visible: boolean,
+  authorization = true,
+): ConfiguredAgenticApp {
+  return {
+    manifest: {
+      id,
+      displayName: id,
+      description: "Example",
+      apiVersion: "1.0",
+      runtime: {
+        kind: "proxied-next-zone",
+        origin: "https://app.example.test",
+        mountPath: `/apps/${id}`,
+      },
+      ...(authorization
+        ? { authorization: { resourceType: "agentic_app", launchAction: "use" } }
+        : {}),
+      surfaces: { showInHub: true },
+      access: {
+        tokenScopes: ["example:read"],
+        policyActions: [{ action: "proxy:GET", defaultEffect: "allow" }],
+      },
+    },
+    installation: {
+      appId: id,
+      packageId: id,
+      installed: true,
+      enabled: true,
+      visible,
+    },
+  };
+}
+
+describe("configured External App CAS reconciliation", () => {
+  it("grants visible authorized apps and revokes hidden ones", () => {
+    const diff = buildConfiguredAgenticAppCasTupleDiff([
+      configuredApp("visible-app", true),
+      configuredApp("hidden-app", false),
+      configuredApp("local-only-app", true, false),
+    ]);
+
+    expect(diff.writes).toEqual(
+      expect.arrayContaining([
+        {
+          user: "user:*",
+          relation: "user",
+          object: "agentic_app:visible-app",
+        },
+      ]),
+    );
+    expect(diff.deletes).toEqual(
+      expect.arrayContaining([
+        {
+          user: "user:*",
+          relation: "user",
+          object: "agentic_app:hidden-app",
+        },
+      ]),
+    );
+    expect([...diff.writes, ...diff.deletes]).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ object: "agentic_app:local-only-app" }),
+      ]),
+    );
+  });
+});

--- a/ui/src/lib/agentic-apps/__tests__/config.test.ts
+++ b/ui/src/lib/agentic-apps/__tests__/config.test.ts
@@ -25,6 +25,10 @@ describe("External Apps deployment config", () => {
           manifest: expect.objectContaining({
             id: "example-app",
             runtime: expect.objectContaining({ maxRequestBodyBytes: 67108864 }),
+            authorization: {
+              resourceType: "agentic_app",
+              launchAction: "use",
+            },
             access: expect.objectContaining({ tokenScopes: ["example-app:read"] }),
           }),
           installation: expect.objectContaining({
@@ -209,6 +213,9 @@ function validConfig(): string {
           mountPath: /apps/example-app
           chrome: iframe
           maxRequestBodyBytes: 67108864
+        authorization:
+          resourceType: agentic_app
+          launchAction: use
         surfaces:
           showInHub: true
           navOrder: 50
@@ -218,6 +225,7 @@ function validConfig(): string {
           policyActions:
             - action: proxy:GET
               defaultEffect: allow
+              casAction: read
         health:
           endpoint: /health
   installations:

--- a/ui/src/lib/agentic-apps/cas-compat.ts
+++ b/ui/src/lib/agentic-apps/cas-compat.ts
@@ -1,0 +1,66 @@
+import { authorize } from "@/lib/authz";
+import type { AuthorizeRequest, AuthorizeResult, DecisionContext } from "@/lib/authz";
+import type { AgenticAppCasAction } from "@/types/agentic-app";
+
+export type AgenticAppCasMode = "off" | "shadow" | "enforce";
+
+export interface AgenticAppCasCompatibilityResult {
+  mode: AgenticAppCasMode;
+  casDecision: "ALLOW" | "DENY" | "NOT_EVALUATED";
+  casReason?: AuthorizeResult["reason"];
+  effectiveEffect: "allow" | "deny";
+}
+
+type CasAuthorizer = (
+  request: AuthorizeRequest,
+  context?: DecisionContext,
+) => Promise<AuthorizeResult>;
+
+export async function evaluateAgenticAppCasCompatibility(input: {
+  appId: string;
+  subjectId: string;
+  localEffect: "allow" | "deny";
+  correlationId: string;
+  action?: AgenticAppCasAction;
+  mode?: AgenticAppCasMode;
+  authorizer?: CasAuthorizer;
+}): Promise<AgenticAppCasCompatibilityResult> {
+  const mode = input.mode ?? resolveAgenticAppCasMode();
+  if (mode === "off") {
+    return {
+      mode,
+      casDecision: "NOT_EVALUATED",
+      effectiveEffect: input.localEffect,
+    };
+  }
+
+  let result: AuthorizeResult;
+  try {
+    result = await (input.authorizer ?? authorize)(
+      {
+        subject: { type: "user", id: input.subjectId },
+        resource: { type: "agentic_app", id: input.appId },
+        action: input.action ?? "use",
+      },
+      { correlationId: input.correlationId },
+    );
+  } catch {
+    result = { decision: "DENY", reason: "AUTHZ_UNAVAILABLE", retriable: true };
+  }
+
+  return {
+    mode,
+    casDecision: result.decision,
+    casReason: result.reason,
+    effectiveEffect:
+      input.localEffect === "deny" || (mode === "enforce" && result.decision !== "ALLOW")
+        ? "deny"
+        : "allow",
+  };
+}
+
+export function resolveAgenticAppCasMode(
+  value = process.env.AGENTIC_APPS_CAS_MODE,
+): AgenticAppCasMode {
+  return value === "off" || value === "shadow" ? value : "enforce";
+}

--- a/ui/src/lib/agentic-apps/cas-reconcile.ts
+++ b/ui/src/lib/agentic-apps/cas-reconcile.ts
@@ -1,0 +1,47 @@
+import { reconcileTupleDiff } from "@/lib/authz/reconcile";
+import { loadConfiguredAgenticApps } from "@/lib/agentic-apps/config";
+import type { TeamResourceTupleDiff } from "@/lib/rbac/openfga";
+import { organizationObjectId } from "@/lib/rbac/organization";
+import type { ConfiguredAgenticApp } from "@/types/agentic-app";
+
+export function buildConfiguredAgenticAppCasTupleDiff(
+  apps: readonly ConfiguredAgenticApp[],
+): TeamResourceTupleDiff {
+  const writes: TeamResourceTupleDiff["writes"] = [];
+  const deletes: TeamResourceTupleDiff["deletes"] = [];
+
+  for (const app of apps) {
+    if (!app.manifest.authorization) continue;
+    const appId = app.installation.appId;
+    const tuples = [
+      { user: "user:*", relation: "user", object: `agentic_app:${appId}` },
+      {
+        user: `${organizationObjectId()}#admin`,
+        relation: "manager",
+        object: `agentic_app:${appId}`,
+      },
+    ];
+    if (
+      app.installation.installed
+      && app.installation.enabled
+      && app.installation.visible
+    ) {
+      writes.push(...tuples);
+    } else {
+      deletes.push(...tuples);
+    }
+  }
+  return { writes, deletes };
+}
+
+export async function reconcileConfiguredAgenticAppCasAccess(): Promise<void> {
+  const diff = buildConfiguredAgenticAppCasTupleDiff(loadConfiguredAgenticApps());
+  const result = await reconcileTupleDiff(diff, {
+    source: "external_apps_configured_access",
+  });
+  if (result.enabled && (result.writes > 0 || result.deletes > 0)) {
+    console.log(
+      `[external-apps/cas] Reconciled configured access: ${result.writes} grants, ${result.deletes} revocations`,
+    );
+  }
+}

--- a/ui/src/lib/agentic-apps/config.ts
+++ b/ui/src/lib/agentic-apps/config.ts
@@ -11,6 +11,7 @@ import { MAX_AGENTIC_APP_REQUEST_BODY_BYTES } from "@/types/agentic-app";
 
 const APP_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const HTTP_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"]);
+const CAS_ACTIONS = new Set(["read", "use", "write", "approve", "manage"]);
 
 type RawPackage = {
   package_id?: unknown;
@@ -243,6 +244,20 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
   const healthRaw = raw.health === undefined
     ? undefined
     : asRecord(raw.health, `${path}.health`);
+  const authorizationRaw = raw.authorization === undefined
+    ? undefined
+    : asRecord(raw.authorization, `${path}.authorization`);
+  if (
+    authorizationRaw
+    && (
+      authorizationRaw.resourceType !== "agentic_app"
+      || authorizationRaw.launchAction !== "use"
+    )
+  ) {
+    throw new Error(
+      `${path}.authorization must declare resourceType "agentic_app" and launchAction "use"`,
+    );
+  }
 
   return {
     id,
@@ -274,6 +289,9 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
           }
         : {}),
     },
+    ...(authorizationRaw
+      ? { authorization: { resourceType: "agentic_app" as const, launchAction: "use" as const } }
+      : {}),
     surfaces: {
       showInHub: optionalBoolean(
         surfacesRaw.showInHub,
@@ -367,6 +385,7 @@ function parsePolicyAction(value: unknown, path: string): AgenticAppPolicyAction
       "requiredScopes",
       "method",
       "path",
+      "casAction",
     ],
     path,
   );
@@ -378,6 +397,9 @@ function parsePolicyAction(value: unknown, path: string): AgenticAppPolicyAction
   }
   if ((raw.method === undefined) !== (raw.path === undefined)) {
     throw new Error(`${path}.method and ${path}.path must be declared together`);
+  }
+  if (raw.casAction !== undefined && !CAS_ACTIONS.has(String(raw.casAction))) {
+    throw new Error(`${path}.casAction is invalid`);
   }
   const defaultEffect = raw.defaultEffect ?? "deny";
   if (defaultEffect !== "allow" && defaultEffect !== "deny") {
@@ -403,6 +425,9 @@ function parsePolicyAction(value: unknown, path: string): AgenticAppPolicyAction
     ...(method ? { method: method as AgenticAppPolicyAction["method"] } : {}),
     ...(raw.path !== undefined
       ? { path: requiredAbsolutePath(raw.path, `${path}.path`) }
+      : {}),
+    ...(raw.casAction !== undefined
+      ? { casAction: raw.casAction as AgenticAppPolicyAction["casAction"] }
       : {}),
   };
 }

--- a/ui/src/lib/rbac/__tests__/rebac/resource-model.test.ts
+++ b/ui/src/lib/rbac/__tests__/rebac/resource-model.test.ts
@@ -37,6 +37,7 @@ describe("universal ReBAC resource model", () => {
       "webex_workspace",
       "webex_space",
       "agent",
+      "agentic_app",
       "llm_model",
       "mcp_gateway",
       "mcp_server",
@@ -73,6 +74,7 @@ describe("universal ReBAC resource model", () => {
     expect(isSupportedResourceAction("mcp_server", "invoke")).toBe(true);
     expect(isSupportedResourceAction("mcp_server", "create")).toBe(true);
     expect(isSupportedResourceAction("llm_model", "write")).toBe(true);
+    expect(isSupportedResourceAction("agentic_app", "approve")).toBe(true);
     expect(isSupportedResourceAction("user_profile", "read")).toBe(true);
     expect(isSupportedResourceAction("user_profile", "create")).toBe(true);
     expect(isSupportedResourceAction("secret_ref", "use")).toBe(true);

--- a/ui/src/lib/rbac/fga-enforcement-manifest.ts
+++ b/ui/src/lib/rbac/fga-enforcement-manifest.ts
@@ -116,6 +116,15 @@ export const FGA_ENFORCEMENT_MANIFEST: Record<
     notes:
       "agent#can_use gates execution; reconcileAgentRelationships writes ownership/share tuples.",
   },
+  agentic_app: {
+    status: "rebac_enforced",
+    surfaces: [
+      "ui/src/lib/agentic-apps/cas-compat.ts",
+      "ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.ts",
+    ],
+    notes:
+      "Configured External Apps opt into agentic_app CAS checks; startup reconciliation grants visible apps and runtime token minting fails closed.",
+  },
   llm_model: {
     status: "rebac_enforced",
     surfaces: ["ui/src/app/api/llm-models/route.ts"],

--- a/ui/src/lib/rbac/resource-catalog.ts
+++ b/ui/src/lib/rbac/resource-catalog.ts
@@ -45,6 +45,7 @@ const DEFAULT_RESOURCES: readonly RebacCatalogResource[] = [
   resource("webex_workspace", "workspace-default", "Default Webex Workspace", "role_gated"),
   resource("webex_space", "workspace-default--platform", "Platform Space", "role_gated"),
   resource("agent", "platform-engineer", "Platform Engineer", "rebac_shadowed"),
+  resource("agentic_app", "example-app", "Example External App", "rebac_enforced"),
   resource("llm_model", "default", "Default LLM Model", "rebac_enforced"),
   resource("mcp_gateway", "list", "AgentGateway MCP list", "rebac_shadowed"),
   resource("mcp_server", "argocd", "Argo CD MCP Server", "role_gated"),

--- a/ui/src/lib/rbac/resource-model.ts
+++ b/ui/src/lib/rbac/resource-model.ts
@@ -83,6 +83,11 @@ export const UNIVERSAL_REBAC_RESOURCE_TYPES: readonly UniversalRebacResourceType
       description: "Agent execution and configuration resource.",
     },
     {
+      type: "agentic_app",
+      actions: ["discover", "read", "use", "write", "approve", "manage", "audit"],
+      description: "Hosted External App surface and its authorization scope.",
+    },
+    {
       type: "llm_model",
       actions: [
         "discover",

--- a/ui/src/types/agentic-app.ts
+++ b/ui/src/types/agentic-app.ts
@@ -1,4 +1,5 @@
 export type AgenticAppRuntimeKind = "proxied-next-zone";
+export type AgenticAppCasAction = "read" | "use" | "write" | "approve" | "manage";
 
 export const DEFAULT_AGENTIC_APP_MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
 export const MAX_AGENTIC_APP_REQUEST_BODY_BYTES = 64 * 1024 * 1024;
@@ -11,6 +12,8 @@ export interface AgenticAppPolicyAction {
   requiredScopes?: string[];
   method?: "GET" | "HEAD" | "POST" | "PUT" | "PATCH" | "DELETE";
   path?: string;
+  /** CAS capability that must be confirmed before scopes are minted. */
+  casAction?: AgenticAppCasAction;
 }
 
 export interface AgenticAppManifest {
@@ -25,6 +28,11 @@ export interface AgenticAppManifest {
     preserveMountPath?: boolean;
     chrome?: "iframe";
     maxRequestBodyBytes?: number;
+  };
+  /** Optional CAS contract for deployments that authorize app access in OpenFGA. */
+  authorization?: {
+    resourceType: "agentic_app";
+    launchAction: "use";
   };
   surfaces: {
     showInHub: boolean;

--- a/ui/src/types/rbac-universal.ts
+++ b/ui/src/types/rbac-universal.ts
@@ -50,6 +50,7 @@ export const UNIVERSAL_REBAC_RESOURCE_TYPE_NAMES = [
   "webex_workspace",
   "webex_space",
   "agent",
+  "agentic_app",
   "llm_model",
   "mcp_gateway",
   "mcp_server",


### PR DESCRIPTION
# Description

Adds an opt-in CAS/OpenFGA boundary for deployment-configured External Apps. Configured apps can declare an agentic_app authorization resource and route-level CAS actions; the host then enforces discovery, launch, and proxy decisions before minting app-bound tokens.

This also adds the agentic_app resource model, startup reconciliation for globally visible deployment-owned apps, documentation, and an updated Weather example. Private/team sharing remains outside this deployment-owned catalog contract.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other

## Validation

- 7 focused Jest suites / 146 tests
- npx tsc --noEmit
- npm run lint -- --quiet
- npm run build
- git diff --check

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] No new selection control is introduced
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All relevant tests pass