### PR TITLE
fix(ui): restore collapsed chat hover details

### DIFF
--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -340,6 +340,9 @@ jobs:
           # This public setting is compiled into the client bundle, so set it
           # while building as well as when serving the app below.
           NEXT_PUBLIC_SSO_ENABLED: 'true'
+          # NextAuth requires a secret when the production server starts.
+          # This value is only used by the mocked Playwright job.
+          NEXTAUTH_SECRET: 'caipe-ui-playwright-test-secret'
           # The specs mock every API, so no real database is contacted. But the
           # home page gates shared-conversation / insights UI on server-side
           # storage mode (getStorageMode reads MONGODB_URI + MONGODB_DATABASE at
@@ -354,6 +357,7 @@ jobs:
         env:
           WORKFLOWS_ENABLED: 'true'
           NEXT_PUBLIC_SSO_ENABLED: 'true'
+          NEXTAUTH_SECRET: 'caipe-ui-playwright-test-secret'
           MONGODB_URI: 'mongodb://mock:27017'
           MONGODB_DATABASE: 'mock'
         run: |
@@ -386,6 +390,7 @@ jobs:
           RUN_RBAC_REGRESSION: '1'
           CAIPE_UI_BASE_URL: http://localhost:3000
           WORKFLOWS_ENABLED: 'true'
+          NEXTAUTH_SECRET: 'caipe-ui-playwright-test-secret'
         run: |
           # Run every mocked-RBAC spec under e2e/rbac/, excluding the
           # *-live.spec.ts files (those need live Keycloak/OpenFGA infra and

--- a/ui/e2e/rbac/_mocked-rbac.ts
+++ b/ui/e2e/rbac/_mocked-rbac.ts
@@ -1,5 +1,6 @@
 // assisted-by Codex Codex-sonnet-4-6
 
+import { encode } from "next-auth/jwt";
 import { type Page, type Route } from "@playwright/test";
 
 export const MOCK_RBAC_EMAIL = "non-manager@caipe.local";
@@ -98,6 +99,37 @@ export async function installMockedRbacApp(page: Page, options: MockedRbacOption
   const session = mockSessionBody({ ...options, isAdmin });
   const gates = { ...DEFAULT_ADMIN_GATES, ...(options.gates ?? {}) };
   const handlers = options.handlers ?? [];
+
+  // The mocked API session is not visible to the server-rendered app layout.
+  // Install a lightweight NextAuth JWT as well so production-mode SSR can
+  // pass the authentication boundary without contacting a real IdP or MongoDB.
+  if (process.env.NEXTAUTH_SECRET) {
+    const nowSeconds = Math.floor(Date.now() / 1000);
+    const token = await encode({
+      secret: process.env.NEXTAUTH_SECRET,
+      maxAge: 60 * 60,
+      token: {
+        name: session.user.name,
+        email: session.user.email,
+        role: session.role,
+        isAuthorized: session.isAuthorized,
+        canViewAdmin: session.canViewAdmin,
+        canAccessDynamicAgents: session.canAccessDynamicAgents,
+        accessToken: session.accessToken,
+        expiresAt: nowSeconds + 60 * 60,
+      },
+    });
+    const baseUrl = process.env.CAIPE_UI_BASE_URL ?? "http://localhost:3000";
+    await page.context().addCookies([{
+      name: "next-auth.session-token",
+      value: token,
+      url: baseUrl,
+      httpOnly: true,
+      secure: new URL(baseUrl).protocol === "https:",
+      sameSite: "Lax",
+      expires: nowSeconds + 60 * 60,
+    }]);
+  }
 
   await page.route("**/api/**", async (route) => {
     const request = route.request();

--- a/ui/src/components/chat/AgentHarnessBadge.tsx
+++ b/ui/src/components/chat/AgentHarnessBadge.tsx
@@ -1,0 +1,33 @@
+import { getHarnessPresentation } from "@/lib/agent-presentation";
+import { cn } from "@/lib/utils";
+import { Cpu } from "lucide-react";
+
+interface AgentHarnessBadgeProps {
+  harnessId?: string | null;
+  compact?: boolean;
+  className?: string;
+}
+
+export function AgentHarnessBadge({
+  harnessId,
+  compact = false,
+  className,
+}: AgentHarnessBadgeProps) {
+  const harness = getHarnessPresentation(harnessId);
+
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center gap-1 rounded-full border font-medium leading-none",
+        compact ? "px-1.5 py-0.5 text-[9px]" : "px-2 py-1 text-[10px]",
+        harness.badgeClassName,
+        className,
+      )}
+      title={`Execution harness: ${harness.label}`}
+      aria-label={`Execution harness: ${harness.label}`}
+    >
+      <Cpu className={compact ? "h-2.5 w-2.5" : "h-3 w-3"} aria-hidden="true" />
+      {compact ? harness.shortLabel : harness.label}
+    </span>
+  );
+}

--- a/ui/src/components/chat/NewChatButton.tsx
+++ b/ui/src/components/chat/NewChatButton.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { AgentAvatar } from "@/components/dynamic-agents/AgentAvatar";
+import { AgentHarnessBadge } from "@/components/chat/AgentHarnessBadge";
 import { Button } from "@/components/ui/button";
+import { Tooltip,TooltipContent,TooltipProvider,TooltipTrigger } from "@/components/ui/tooltip";
 import { resolveUsableChatAgent } from "@/lib/chat-agent-selection";
 import { cn } from "@/lib/utils";
 import type { DynamicAgentConfig } from "@/types/dynamic-agent";
@@ -23,6 +25,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [defaultAgentId, setDefaultAgentId] = useState<string | null>(null);
   const [defaultAgentName, setDefaultAgentName] = useState<string>("New Chat");
+  const [defaultAgentHarnessId, setDefaultAgentHarnessId] = useState<string | undefined>();
   const [defaultAgentResolved, setDefaultAgentResolved] = useState(false);
 
   // Resolve the same usable agent as the Home composer: personal Web default,
@@ -38,6 +41,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
         if (cancelled) return;
         setDefaultAgentId(agent.id);
         setDefaultAgentName(agent.name);
+        setDefaultAgentHarnessId(agent.execution_harness_id);
       } catch {
         if (!cancelled) {
           setDefaultAgentId(null);
@@ -74,7 +78,10 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
         // Update default agent display name now that we have the full list
         if (defaultAgentId) {
           const found = fetched.find((a) => a._id === defaultAgentId);
-          if (found) setDefaultAgentName(found.name);
+          if (found) {
+            setDefaultAgentName(found.name);
+            setDefaultAgentHarnessId(found.execution_harness_id);
+          }
         }
       } catch (err) {
         console.error("Error fetching dynamic agents:", err);
@@ -150,15 +157,31 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
   // Collapsed mode: simple button without dropdown
   if (collapsed) {
     return (
-      <Button
-        onClick={handleMainClick}
-        disabled={!defaultAgentResolved}
-        className="w-full px-2 bg-primary/10 hover:bg-primary/20 text-primary border border-primary/30 hover-glow"
-        variant="ghost"
-        size="icon"
-      >
-        <Plus className="h-4 w-4 shrink-0" />
-      </Button>
+      <TooltipProvider delayDuration={150}>
+        <Tooltip className="block w-full">
+          <TooltipTrigger asChild>
+            <Button
+              aria-label={`New chat with ${defaultAgentName}`}
+              onClick={handleMainClick}
+              disabled={!defaultAgentResolved}
+              className="w-full px-2 bg-primary/10 hover:bg-primary/20 text-primary border border-primary/30 hover-glow"
+              variant="ghost"
+              size="icon"
+            >
+              <Plus className="h-4 w-4 shrink-0" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="right" sideOffset={10} className="px-3 py-2">
+            <p className="font-semibold">New chat</p>
+            <div className="mt-1 flex items-center gap-2 text-[11px] font-normal text-muted-foreground">
+              <span>{defaultAgentName}</span>
+              {defaultAgentHarnessId ? (
+                <AgentHarnessBadge harnessId={defaultAgentHarnessId} compact />
+              ) : null}
+            </div>
+          </TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
     );
   }
 

--- a/ui/src/components/chat/__tests__/NewChatButton.test.tsx
+++ b/ui/src/components/chat/__tests__/NewChatButton.test.tsx
@@ -18,6 +18,7 @@ jest.mock("lucide-react", () => ({
   Bot: () => <span data-testid="bot-icon" />,
   Loader2: () => <span data-testid="loader-icon" />,
   Search: () => <span data-testid="search-icon" />,
+  Cpu: () => <span data-testid="cpu-icon" />,
 }));
 
 const mockFetch = jest.fn();
@@ -100,5 +101,27 @@ describe("NewChatButton", () => {
     fireEvent.click(mainButton);
 
     expect(onNewChat).toHaveBeenCalledWith("agent-first");
+  });
+
+  it("labels the collapsed action and reveals its default agent on hover", async () => {
+    mockResolveUsableChatAgent.mockResolvedValue({
+      id: "agent-default",
+      name: "Platform Helper",
+      execution_harness_id: "agentcore",
+      source: "platform-default",
+    });
+
+    render(<NewChatButton collapsed={true} onNewChat={jest.fn()} />);
+
+    const button = await screen.findByRole("button", {
+      name: "New chat with Platform Helper",
+    });
+    fireEvent.mouseEnter(button);
+
+    expect(await screen.findByRole("tooltip")).toHaveTextContent("New chat");
+    expect(screen.getByRole("tooltip")).toHaveTextContent("Platform Helper");
+    expect(
+      screen.getByLabelText("Execution harness: Amazon Bedrock AgentCore"),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -3,6 +3,7 @@
 // assisted-by Codex Codex-sonnet-4-6
 
 import { NewChatButton } from "@/components/chat/NewChatButton";
+import { AgentHarnessBadge } from "@/components/chat/AgentHarnessBadge";
 import { ConversationListSkeleton } from "@/components/chat/ConversationListSkeleton";
 import { RecycleBinDialog } from "@/components/chat/RecycleBinDialog";
 import { ShareButton } from "@/components/chat/ShareButton";
@@ -19,6 +20,7 @@ import { cn,formatDate,truncateText } from "@/lib/utils";
 import { useChatStore } from "@/store/chat-store";
 import type { Conversation } from "@/types/a2a";
 import { getAgentId } from "@/types/a2a";
+import type { DynamicAgentConfig } from "@/types/dynamic-agent";
 import { AnimatePresence,motion } from "framer-motion";
 import {
 Archive,
@@ -57,6 +59,8 @@ interface SidebarProps {
   onCollapse: (collapsed: boolean) => void;
   onUseCaseSaved?: () => void;
 }
+
+type SidebarAgent = Pick<DynamicAgentConfig, "_id" | "name" | "execution_harness_id">;
 
 function getScheduleBadge(conv: Conversation): { label: string; title: string } | null {
   const scheduleId = conv.metadata?.schedule_id;
@@ -114,7 +118,7 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
   const { toast } = useToast();
 
   // Agent name lookup for dynamic agent conversations
-  const [agentNameMap, setAgentNameMap] = useState<Record<string, string>>({});
+  const [agentMap, setAgentMap] = useState<Record<string, SidebarAgent>>({});
   const [agentNamesLoading, setAgentNamesLoading] = useState(true);
 
   // Load conversations from server when sidebar mounts (MongoDB mode only)
@@ -162,11 +166,11 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
         const response = await fetch("/api/dynamic-agents/available");
         const data = await response.json();
         if (!cancelled && data.success && Array.isArray(data.data)) {
-          const map: Record<string, string> = {};
-          data.data.forEach((agent: { _id: string; name: string }) => {
-            map[agent._id] = agent.name;
+          const map: Record<string, SidebarAgent> = {};
+          data.data.forEach((agent: SidebarAgent) => {
+            map[agent._id] = agent;
           });
-          setAgentNameMap(map);
+          setAgentMap(map);
         }
       } catch (err) {
         console.error('[Sidebar] Failed to fetch agents for name lookup:', err);
@@ -338,18 +342,30 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
       )}
       {/* Collapse Toggle */}
       <div className="flex items-center justify-end p-2 h-12 shrink-0">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={() => onCollapse(!collapsed)}
-          className="h-8 w-8 hover:bg-muted shrink-0"
-        >
-          {collapsed ? (
-            <ChevronRight className="h-4 w-4" />
-          ) : (
-            <ChevronLeft className="h-4 w-4" />
-          )}
-        </Button>
+        <TooltipProvider delayDuration={150}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <Button
+                aria-label={collapsed ? "Expand conversation history" : "Collapse conversation history"}
+                variant="ghost"
+                size="icon"
+                onClick={() => onCollapse(!collapsed)}
+                className="h-8 w-8 hover:bg-muted shrink-0"
+              >
+                {collapsed ? (
+                  <ChevronRight className="h-4 w-4" />
+                ) : (
+                  <ChevronLeft className="h-4 w-4" />
+                )}
+              </Button>
+            </TooltipTrigger>
+            <TooltipContent side={collapsed ? "right" : "left"} sideOffset={8}>
+              <p className="text-xs">
+                {collapsed ? "Expand conversation history" : "Collapse conversation history"}
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       </div>
 
       {/* New Chat Button */}
@@ -486,12 +502,34 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                   const scheduleBadge = getScheduleBadge(conv);
                   const isEditingTitle = editingConversationId === conv.id;
                   const isSavingTitle = renameSavingId === conv.id;
+                  const conversationAgentId = getAgentId(conv);
+                  const conversationAgent = conversationAgentId
+                    ? agentMap[conversationAgentId]
+                    : undefined;
+                  const conversationStatus = isLive
+                    ? "Live response"
+                    : isInputRequired
+                      ? "Input required"
+                      : isUnviewed
+                        ? "New response"
+                        : formatDate(conv.updatedAt);
+                  const conversationAgentName = conversationAgent?.name
+                    ?? (agentNamesLoading ? "Loading agent…" : "Unknown agent");
+                  const openConversation = () => {
+                    setActiveConversation(conv.id);
+                    startTransition(() => {
+                      router.push(`/chat/${conv.id}`);
+                    });
+                  };
 
                   return (
                   <div
                     key={conv.id}
                     className="group/conv"
                   >
+                    <TooltipProvider delayDuration={150}>
+                    <Tooltip className="block w-full">
+                    <TooltipTrigger asChild>
                     <motion.div
                       initial={{ opacity: 0, x: -10 }}
                       animate={{ opacity: 1, x: 0 }}
@@ -511,12 +549,18 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                                   ? "hover:bg-muted/50 border border-blue-500/20"
                                   : "hover:bg-muted/50 border border-transparent"
                       )}
-                      onClick={() => {
-                        setActiveConversation(conv.id);
-                        startTransition(() => {
-                          router.push(`/chat/${conv.id}`);
-                        });
-                      }}
+                      aria-label={collapsed
+                        ? `${conv.title}. ${conversationAgentName}. ${conversationStatus}`
+                        : undefined}
+                      role={collapsed ? "button" : undefined}
+                      tabIndex={collapsed ? 0 : undefined}
+                      onClick={openConversation}
+                      onKeyDown={collapsed ? (event) => {
+                        if (event.key === "Enter" || event.key === " ") {
+                          event.preventDefault();
+                          openConversation();
+                        }
+                      } : undefined}
                     >
                     <div className={cn(
                       "shrink-0 w-8 h-8 rounded-md flex items-center justify-center relative",
@@ -619,10 +663,8 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                             </span>
                             {/* Dynamic Agent indicator */}
                             {(() => {
-                              const agId = getAgentId(conv);
-                              if (!agId) return null;
-                              const agentName = agentNameMap[agId];
-                              if (!agentName && agentNamesLoading) {
+                              if (!conversationAgentId) return null;
+                              if (!conversationAgent && agentNamesLoading) {
                                 return (
                                   <>
                                     <span className="ml-1.5 text-[10px] text-purple-500 dark:text-purple-400">•</span>
@@ -634,8 +676,8 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                                 );
                               }
                               return (
-                                <span className="ml-1.5 truncate text-[10px] text-purple-500 dark:text-purple-400" title={agentName || 'Unknown Agent'}>
-                                  • {truncateText(agentName || 'Unknown', 20)}
+                                <span className="ml-1.5 truncate text-[10px] text-purple-500 dark:text-purple-400" title={conversationAgent?.name || 'Unknown Agent'}>
+                                  • {truncateText(conversationAgent?.name || 'Unknown', 20)}
                                 </span>
                               );
                             })()}
@@ -810,6 +852,52 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                       </>
                     )}
                   </motion.div>
+                  </TooltipTrigger>
+                  {collapsed ? (
+                    <TooltipContent
+                      side="right"
+                      sideOffset={10}
+                      className="w-64 whitespace-normal px-3 py-2.5"
+                    >
+                      <div className="space-y-2">
+                        <div>
+                          <p className="line-clamp-2 text-sm font-semibold leading-snug text-foreground">
+                            {conv.title}
+                          </p>
+                          <p className={cn(
+                            "mt-1 text-[11px] font-normal",
+                            isLive
+                              ? "text-emerald-500"
+                              : isInputRequired
+                                ? "text-amber-500"
+                                : isUnviewed
+                                  ? "text-blue-500"
+                                  : "text-muted-foreground",
+                          )}>
+                            {conversationStatus}
+                          </p>
+                        </div>
+                        <div className="flex min-w-0 items-center gap-2 border-t border-border/50 pt-2">
+                          <span className="min-w-0 flex-1 truncate text-[11px] font-medium text-foreground/85">
+                            {conversationAgentName}
+                          </span>
+                          {conversationAgent?.execution_harness_id ? (
+                            <AgentHarnessBadge
+                              harnessId={conversationAgent.execution_harness_id}
+                              compact
+                            />
+                          ) : null}
+                        </div>
+                        {scheduleBadge ? (
+                          <p className="truncate text-[10px] font-normal text-cyan-600 dark:text-cyan-300">
+                            {scheduleBadge.title}
+                          </p>
+                        ) : null}
+                      </div>
+                    </TooltipContent>
+                  ) : null}
+                  </Tooltip>
+                  </TooltipProvider>
                   </div>
                     );
                   })}

--- a/ui/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/ui/src/components/layout/__tests__/Sidebar.test.tsx
@@ -114,6 +114,7 @@ jest.mock('lucide-react', () => ({
   TrendingUp: (props: unknown) => <span data-testid="icon-trending-up" {...props} />,
   RefreshCw: (props: unknown) => <span data-testid="icon-refresh" {...props} />,
   X: (props: unknown) => <span data-testid="icon-x" {...props} />,
+  Cpu: (props: unknown) => <span data-testid="icon-cpu" {...props} />,
 }))
 
 jest.mock('@/components/ui/button', () => ({
@@ -804,12 +805,13 @@ describe('Sidebar — Live Status Indicator', () => {
   // --------------------------------------------------------------------------
 
   describe('collapsed sidebar', () => {
-    it('does not render conversation titles when collapsed', () => {
+    it('keeps conversation identity available to the collapsed hover target', () => {
       mockConversations = [makeConv('conv-1', 'Hidden Title')]
 
       render(<Sidebar {...defaultProps} collapsed={true} />)
 
-      expect(screen.queryByText('Hidden Title')).not.toBeInTheDocument()
+      expect(screen.getByRole('button', { name: /Hidden Title/ })).toBeInTheDocument()
+      expect(screen.getByText('Hidden Title')).toBeInTheDocument()
     })
 
     it('does not render "Live" or "New response" text when collapsed', () => {
@@ -828,6 +830,28 @@ describe('Sidebar — Live Status Indicator', () => {
       render(<Sidebar {...defaultProps} collapsed={true} />)
 
       expect(screen.getByTestId('icon-radio')).toBeInTheDocument()
+    })
+
+    it('shows agent and harness identity in the collapsed conversation tooltip', async () => {
+      global.fetch = jest.fn().mockResolvedValue({
+        json: async () => ({
+          success: true,
+          data: [{ _id: 'agent-1', name: 'Example Agent', execution_harness_id: 'claude_agent_sdk' }],
+        }),
+      } as Response)
+      mockConversations = [
+        makeConv('conv-1', 'Review deployment', {
+          participants: [{ type: 'agent', id: 'agent-1' }],
+        }),
+      ]
+
+      render(<Sidebar {...defaultProps} collapsed={true} />)
+
+      expect(await screen.findByText('Example Agent')).toBeInTheDocument()
+      expect(screen.getByLabelText('Execution harness: Claude Agent SDK')).toBeInTheDocument()
+      expect(
+        screen.getByRole('button', { name: /Review deployment\. Example Agent/ }),
+      ).toBeInTheDocument()
     })
   })
 })

--- a/ui/src/lib/agent-presentation.ts
+++ b/ui/src/lib/agent-presentation.ts
@@ -1,0 +1,52 @@
+export interface HarnessPresentation {
+  label: string;
+  shortLabel: string;
+  badgeClassName: string;
+}
+
+const HARNESS_PRESENTATIONS: Record<string, HarnessPresentation> = {
+  dynamic_agents: {
+    label: "LangChain Deep Agents",
+    shortLabel: "Deep Agents",
+    badgeClassName:
+      "border-teal-500/30 bg-teal-500/10 text-teal-700 dark:text-teal-300",
+  },
+  agentcore: {
+    label: "Amazon Bedrock AgentCore",
+    shortLabel: "AgentCore",
+    badgeClassName:
+      "border-orange-500/30 bg-orange-500/10 text-orange-700 dark:text-orange-300",
+  },
+  claude_agent_sdk: {
+    label: "Claude Agent SDK",
+    shortLabel: "Claude SDK",
+    badgeClassName:
+      "border-violet-500/30 bg-violet-500/10 text-violet-700 dark:text-violet-300",
+  },
+};
+
+function normalizeHarnessId(harnessId?: string | null): string {
+  const normalized = harnessId?.trim().toLowerCase();
+  if (
+    !normalized ||
+    normalized === "langchain-deepagents" ||
+    normalized === "langchain_deepagents"
+  ) {
+    return "dynamic_agents";
+  }
+  return normalized;
+}
+
+export function getHarnessPresentation(
+  harnessId?: string | null,
+): HarnessPresentation {
+  const normalized = normalizeHarnessId(harnessId);
+  return (
+    HARNESS_PRESENTATIONS[normalized] ?? {
+      label: normalized,
+      shortLabel: normalized,
+      badgeClassName:
+        "border-slate-500/30 bg-slate-500/10 text-slate-700 dark:text-slate-300",
+    }
+  );
+}

--- a/ui/src/lib/chat-agent-selection.ts
+++ b/ui/src/lib/chat-agent-selection.ts
@@ -11,6 +11,7 @@ interface ApiEnvelope<T> {
 export interface ResolvedChatAgent {
   id: string;
   name: string;
+  execution_harness_id?: string;
   source: "user-default" | "platform-default" | "first-available";
 }
 
@@ -80,6 +81,7 @@ export async function resolveUsableChatAgent(): Promise<ResolvedChatAgent> {
       return {
         id: userAgent._id,
         name: userAgent.name,
+        execution_harness_id: userAgent.execution_harness_id,
         source: "user-default",
       };
     }
@@ -91,6 +93,7 @@ export async function resolveUsableChatAgent(): Promise<ResolvedChatAgent> {
       return {
         id: defaultAgent._id,
         name: defaultAgent.name,
+        execution_harness_id: defaultAgent.execution_harness_id,
         source: "platform-default",
       };
     }

--- a/ui/src/types/dynamic-agent.ts
+++ b/ui/src/types/dynamic-agent.ts
@@ -407,6 +407,8 @@ export type ResumeData =
 
 export interface DynamicAgentConfig {
   _id: string;
+  /** Runtime selected by Harness Gateway. Missing legacy values mean Dynamic Agents. */
+  execution_harness_id?: string;
   name: string;
   description?: string;
   system_prompt: string;


### PR DESCRIPTION
## Summary

Restores the focused collapsed-sidebar chat navigation behavior extracted from the original upstream implementation.

When the sidebar is collapsed, hovering or focusing a conversation shows:

- Conversation title
- Current status or last-updated date
- Dynamic agent name
- Execution harness, when available
- Schedule information, when applicable

Collapsed conversation rows also expose an accessible label and support Enter/Space keyboard activation. The collapsed New Chat and sidebar collapse controls include explanatory tooltips.

All collapsed direct left-rail icons, including search, show a tooltip. Navigation items with child destinations retain their fan-out flyouts instead of showing a duplicate tooltip.

This extracts only the UI navigation behavior; it does not include the unrelated Harness Engine changes from [PR #2401](https://github.com/caipe-io/ai-platform-engineering/pull/2401).

## Related PRs

- Original source PR: [#2401](https://github.com/caipe-io/ai-platform-engineering/pull/2401)
- Mirror PR: [cisco-eti/ai-platform-engineering-mirror#615](https://github.com/cisco-eti/ai-platform-engineering-mirror/pull/615)

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [x] I have read the contributing guidelines
- [ ] Existing issues have been referenced (not applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass (focused tests pass; full suite not run)

## Validation

Focused UI tests:

```text
npm test -- --runInBand src/components/layout/__tests__/Sidebar.test.tsx src/components/chat/__tests__/NewChatButton.test.tsx
```

Additional checks:

```text
npm run lint
npm run build
```
