### PR TITLE
feat(ui): add chat sidebar view tabs

### DIFF
--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -344,6 +344,9 @@ jobs:
           # This public setting is compiled into the client bundle, so set it
           # while building as well as when serving the app below.
           NEXT_PUBLIC_SSO_ENABLED: 'true'
+          # The mocked production server still initializes NextAuth. This is
+          # an ephemeral CI-only signing key, not a deployment secret.
+          NEXTAUTH_SECRET: 'ci-only-nextauth-secret-for-mocked-rbac-regression-tests'
           # The specs mock every API, so no real database is contacted. But the
           # home page gates shared-conversation / insights UI on server-side
           # storage mode (getStorageMode reads MONGODB_URI + MONGODB_DATABASE at
@@ -358,6 +361,9 @@ jobs:
         env:
           WORKFLOWS_ENABLED: 'true'
           NEXT_PUBLIC_SSO_ENABLED: 'true'
+          # Keep the production server bootable when the test stack enables
+          # NextAuth's production configuration. This key is CI-only.
+          NEXTAUTH_SECRET: 'ci-only-nextauth-secret-for-mocked-rbac-regression-tests'
           MONGODB_URI: 'mongodb://mock:27017'
           MONGODB_DATABASE: 'mock'
         run: |

--- a/.github/workflows/prebuild-mcp-servers.yml
+++ b/.github/workflows/prebuild-mcp-servers.yml
@@ -33,6 +33,7 @@ on:
         default: ''
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/prebuild-mcp-servers.yml
+++ b/.github/workflows/prebuild-mcp-servers.yml
@@ -177,6 +177,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4
       - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4
         with:
           registry: ${{ env.REGISTRY }}
@@ -206,7 +207,7 @@ jobs:
           echo "prebuild_tag=${PREBUILD_TAG}" >> $GITHUB_OUTPUT
 
       - name: Upload building prebuild status
-        if: matrix.arch == 'amd64'
+        if: matrix.arch == 'amd64' && github.event_name != 'pull_request'
         uses: ./.github/actions/prebuild-status
         with:
           pr_number: ${{ inputs.pr_number || github.event.pull_request.number }}
@@ -255,13 +256,14 @@ jobs:
             AGENT_NAME=${{ matrix.agent }}
             ${{ steps.mcp_build_args.outputs.extra }}
           platforms: ${{ matrix.platform }}
-          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true
+          outputs: ${{ github.event_name == 'pull_request' && 'type=cacheonly' || format('type=image,name={0}/{1},push-by-digest=true,name-canonical=true,push=true', env.REGISTRY, env.IMAGE_NAME) }}
           cache-from: type=gha,scope=prebuild-${{ matrix.agent }}-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=prebuild-${{ matrix.agent }}-${{ matrix.arch }}
           provenance: false
           sbom: false
 
       - name: Export digest
+        if: github.event_name != 'pull_request'
         shell: bash
         run: |
           mkdir -p /tmp/digests
@@ -269,6 +271,7 @@ jobs:
           touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
+        if: github.event_name != 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: digests-${{ matrix.agent }}--${{ matrix.arch }}
@@ -283,6 +286,7 @@ jobs:
       always() &&
       needs.determine-agents.result == 'success' &&
       needs.determine-agents.outputs.should_build == 'true' &&
+      github.event_name != 'pull_request' &&
       startsWith(inputs.head_ref || github.head_ref, 'prebuild/') &&
       github.event.action != 'closed'
     permissions:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.1"
+version = "1.0.1-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -16,6 +16,7 @@ import type { AutonomousTask } from "@/components/autonomous/types";
 import { Tooltip,TooltipContent,TooltipProvider,TooltipTrigger } from "@/components/ui/tooltip";
 import { resolveUsableChatAgentId } from "@/lib/chat-agent-selection";
 import { getErrorMessage } from "@/lib/error-utils";
+import { getConfig } from "@/lib/config";
 import { getStorageMode } from "@/lib/storage-config";
 import { cn,formatDate,truncateText } from "@/lib/utils";
 import { useChatStore } from "@/store/chat-store";
@@ -174,6 +175,8 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
   const [conversationView, setConversationView] = useState<ConversationViewId>("chat");
   const [webhookTasks, setWebhookTasks] = useState<AutonomousTask[]>([]);
   const { toast } = useToast();
+  const scheduledTabEnabled = getConfig("schedulerEnabled");
+  const autonomousTabEnabled = getConfig("autonomousAgentsEnabled");
 
   // Agent name lookup for dynamic agent conversations
   const [agentNameMap, setAgentNameMap] = useState<Record<string, string>>({});
@@ -248,7 +251,7 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
   useEffect(() => {
     let cancelled = false;
     const ownerEmail = session?.user?.email?.trim().toLowerCase();
-    if (activeTab !== "chat" || !ownerEmail) {
+    if (activeTab !== "chat" || !ownerEmail || !autonomousTabEnabled) {
       setWebhookTasks([]);
       return;
     }
@@ -274,7 +277,7 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
     return () => {
       cancelled = true;
     };
-  }, [activeTab, session?.user?.email]);
+  }, [activeTab, autonomousTabEnabled, session?.user?.email]);
 
   // Handle mouse move for resizing
   useEffect(() => {
@@ -465,12 +468,18 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
 
   const conversationTabs: Array<{ id: ConversationViewId; label: string; count?: number }> = [
     { id: "chat", label: "Chat" },
-    { id: "scheduled", label: "Scheduled", count: scheduledConversations.length },
-    {
-      id: "autonomous",
-      label: "Autonomous",
-      count: autonomousConversations.length + webhookTasks.length,
-    },
+    ...(scheduledTabEnabled
+      ? [{ id: "scheduled" as const, label: "Scheduled", count: scheduledConversations.length }]
+      : []),
+    ...(autonomousTabEnabled
+      ? [
+          {
+            id: "autonomous" as const,
+            label: "Autonomous",
+            count: autonomousConversations.length + webhookTasks.length,
+          },
+        ]
+      : []),
   ];
 
   return (

--- a/ui/src/components/layout/Sidebar.tsx
+++ b/ui/src/components/layout/Sidebar.tsx
@@ -67,7 +67,9 @@ interface ConversationTitleBadge {
   title: string;
 }
 
-type ConversationSectionId = "autonomous" | "webhook" | "scheduled" | "history";
+type ConversationViewId = "chat" | "scheduled" | "autonomous";
+
+type ConversationSectionId = "webhook" | "history";
 
 type ConversationListItem =
   | {
@@ -79,9 +81,6 @@ type ConversationListItem =
       id: ConversationSectionId;
       label: string;
       count: number;
-      expanded?: boolean;
-      onToggle?: () => void;
-      nested?: boolean;
     }
   | {
       kind: "webhook-task";
@@ -172,9 +171,7 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
   const [editingConversationId, setEditingConversationId] = useState<string | null>(null);
   const [editingTitle, setEditingTitle] = useState("");
   const [renameSavingId, setRenameSavingId] = useState<string | null>(null);
-  const [autonomousRunsExpanded, setAutonomousRunsExpanded] = useState(false);
-  const [webhookRunsExpanded, setWebhookRunsExpanded] = useState(false);
-  const [scheduledRunsExpanded, setScheduledRunsExpanded] = useState(false);
+  const [conversationView, setConversationView] = useState<ConversationViewId>("chat");
   const [webhookTasks, setWebhookTasks] = useState<AutonomousTask[]>([]);
   const { toast } = useToast();
 
@@ -429,63 +426,52 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
   const historyConversations = conversations.filter(
     (conversation) => getConversationRunKind(conversation) === null,
   );
+  const visibleConversations =
+    conversationView === "chat"
+      ? historyConversations
+      : conversationView === "scheduled"
+        ? scheduledConversations
+        : autonomousConversations;
   const conversationListItems: ConversationListItem[] = collapsed
     ? conversations.map((conversation) => ({ kind: "conversation", conversation }))
     : [
-        {
-          kind: "section",
-          id: "autonomous",
-          label: "Autonomous Runs",
-          count: autonomousConversations.length + webhookTasks.length,
-          expanded: autonomousRunsExpanded,
-          onToggle: () => setAutonomousRunsExpanded((expanded) => !expanded),
-        },
-        ...(autonomousRunsExpanded
-          ? autonomousConversations.map(
-              (conversation): ConversationListItem => ({ kind: "conversation", conversation }),
-            )
+        ...(conversationView === "chat"
+          ? [
+              {
+                kind: "section" as const,
+                id: "history" as const,
+                label: "History",
+                count: historyConversations.length,
+              },
+            ]
           : []),
-        ...(autonomousRunsExpanded
+        ...visibleConversations.map(
+          (conversation): ConversationListItem => ({ kind: "conversation", conversation }),
+        ),
+        ...(conversationView === "autonomous" && webhookTasks.length > 0
           ? [
               {
                 kind: "section" as const,
                 id: "webhook" as const,
                 label: "Webhook Runs",
                 count: webhookTasks.length,
-                expanded: webhookRunsExpanded,
-                onToggle: () => setWebhookRunsExpanded((expanded) => !expanded),
-                nested: true,
               },
-              ...(webhookRunsExpanded
-                ? webhookTasks.map(
-                    (task): ConversationListItem => ({ kind: "webhook-task", task }),
-                  )
-                : []),
+              ...webhookTasks.map(
+                (task): ConversationListItem => ({ kind: "webhook-task", task }),
+              ),
             ]
           : []),
-        {
-          kind: "section",
-          id: "scheduled",
-          label: "Scheduled Runs",
-          count: scheduledConversations.length,
-          expanded: scheduledRunsExpanded,
-          onToggle: () => setScheduledRunsExpanded((expanded) => !expanded),
-        },
-        ...(scheduledRunsExpanded
-          ? scheduledConversations.map(
-              (conversation): ConversationListItem => ({ kind: "conversation", conversation }),
-            )
-          : []),
-        {
-          kind: "section",
-          id: "history",
-          label: "History",
-          count: historyConversations.length,
-        },
-        ...historyConversations.map(
-          (conversation): ConversationListItem => ({ kind: "conversation", conversation }),
-        ),
       ];
+
+  const conversationTabs: Array<{ id: ConversationViewId; label: string; count?: number }> = [
+    { id: "chat", label: "Chat" },
+    { id: "scheduled", label: "Scheduled", count: scheduledConversations.length },
+    {
+      id: "autonomous",
+      label: "Autonomous",
+      count: autonomousConversations.length + webhookTasks.length,
+    },
+  ];
 
   return (
     <motion.div
@@ -520,12 +506,59 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
 
       {/* New Chat Button */}
       {activeTab === "chat" && (
-        <div className="px-2 pb-2 shrink-0">
-          <NewChatButton
-            collapsed={collapsed}
-            onNewChat={handleNewChat}
-          />
-        </div>
+        <>
+          <div className="px-2 pb-2 shrink-0">
+            <NewChatButton
+              collapsed={collapsed}
+              onNewChat={handleNewChat}
+            />
+          </div>
+
+          {!collapsed && (
+            <div
+              className="mx-2 mb-2 flex rounded-lg border border-border/60 bg-muted/30 p-1 shrink-0"
+              role="tablist"
+              aria-label="Conversation views"
+            >
+              {conversationTabs.map((tab) => {
+                const isSelected = conversationView === tab.id;
+                const accessibleName = tab.count
+                  ? `${tab.label} (${tab.count})`
+                  : tab.label;
+                return (
+                  <button
+                    key={tab.id}
+                    type="button"
+                    role="tab"
+                    aria-selected={isSelected}
+                    aria-label={accessibleName}
+                    className={cn(
+                      "flex min-w-0 flex-1 items-center justify-center gap-1 rounded-md px-2 py-1.5 text-xs font-medium transition-colors",
+                      isSelected
+                        ? "bg-background text-foreground shadow-sm"
+                        : "text-muted-foreground hover:bg-background/60 hover:text-foreground",
+                    )}
+                    onClick={() => setConversationView(tab.id)}
+                  >
+                    <span className="truncate">{tab.label}</span>
+                    {tab.count ? (
+                      <span
+                        className={cn(
+                          "inline-flex min-w-4 items-center justify-center rounded-full px-1 text-[10px] tabular-nums",
+                          isSelected
+                            ? "bg-primary/15 text-primary"
+                            : "bg-muted text-muted-foreground",
+                        )}
+                      >
+                        {tab.count}
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </>
       )}
 
       {/* Bottom-right indicators: Archive + Storage Mode */}
@@ -595,13 +628,8 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                   if (item.kind === "section") {
                     const sectionHeader = (
                       <>
-                        {item.onToggle ? (
-                          <ChevronRight
-                            className={cn(
-                              "h-3.5 w-3.5 shrink-0 transition-transform",
-                              item.expanded && "rotate-90",
-                            )}
-                          />
+                        {item.id === "webhook" ? (
+                          <Webhook className="h-3.5 w-3.5 shrink-0" />
                         ) : (
                           <History className="h-3.5 w-3.5 shrink-0" />
                         )}
@@ -617,24 +645,12 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                         key={`section-${item.id}`}
                         className={cn(
                           "flex items-center gap-1.5 px-1 pt-2 text-xs font-medium uppercase tracking-wider text-muted-foreground",
-                          item.nested && "ml-4 border-l border-border/60 pl-2",
                         )}
                         data-testid={`conversation-section-${item.id}`}
                       >
-                        {item.onToggle ? (
-                          <button
-                            type="button"
-                            className="flex min-w-0 flex-1 items-center gap-1.5 rounded px-1 py-1 text-left hover:bg-muted/50 hover:text-foreground"
-                            aria-expanded={item.expanded}
-                            onClick={item.onToggle}
-                          >
-                            {sectionHeader}
-                          </button>
-                        ) : (
-                          <div className="flex min-w-0 flex-1 items-center gap-1.5 px-1 py-1">
-                            {sectionHeader}
-                          </div>
-                        )}
+                        <div className="flex min-w-0 flex-1 items-center gap-1.5 px-1 py-1">
+                          {sectionHeader}
+                        </div>
                         {item.id === "history" && storageMode === "mongodb" && (
                           <TooltipProvider delayDuration={300}>
                             <Tooltip>
@@ -1063,16 +1079,22 @@ export function Sidebar({ activeTab, collapsed, onCollapse, onUseCaseSaved }: Si
                 </AnimatePresence>
               )}
 
-              {!isLoadingConversations && conversations.length === 0 && !collapsed && (
+              {!isLoadingConversations && visibleConversations.length === 0 && webhookTasks.length === 0 && !collapsed && (
                 <div className="text-center py-8 px-4">
                   <div className="w-12 h-12 mx-auto mb-3 rounded-xl bg-muted flex items-center justify-center">
                     <Sparkles className="h-5 w-5 text-muted-foreground" />
                   </div>
                   <p className="text-sm font-medium text-muted-foreground">
-                    No conversations yet
+                    {conversationView === "chat"
+                      ? "No conversations yet"
+                      : conversationView === "scheduled"
+                        ? "No scheduled runs yet"
+                        : "No autonomous runs yet"}
                   </p>
                   <p className="text-xs text-muted-foreground/70 mt-1">
-                    Start a new chat to begin
+                    {conversationView === "chat"
+                      ? "Start a new chat to begin"
+                      : "Runs will appear here when they are available"}
                   </p>
                 </div>
               )}

--- a/ui/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/ui/src/components/layout/__tests__/Sidebar.test.tsx
@@ -142,6 +142,16 @@ jest.mock('@/lib/storage-config', () => ({
   getStorageModeDisplay: () => 'MongoDB',
 }))
 
+let mockSchedulerEnabled = true
+let mockAutonomousAgentsEnabled = true
+jest.mock('@/lib/config', () => ({
+  getConfig: (key: string) => {
+    if (key === 'schedulerEnabled') return mockSchedulerEnabled
+    if (key === 'autonomousAgentsEnabled') return mockAutonomousAgentsEnabled
+    return undefined
+  },
+}))
+
 jest.mock('@/lib/utils', () => ({
   cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
   formatDate: () => 'Jan 1, 2026',
@@ -248,6 +258,8 @@ describe('Sidebar — Live Status Indicator', () => {
     ) as unknown as typeof fetch
     mockConversations = []
     mockActiveConversationId = null
+    mockSchedulerEnabled = true
+    mockAutonomousAgentsEnabled = true
     mockIsConversationStreaming.mockImplementation(() => false)
     mockHasUnviewedMessages.mockImplementation(() => false)
     mockIsConversationInputRequired.mockImplementation(() => false)
@@ -599,6 +611,17 @@ describe('Sidebar — Live Status Indicator', () => {
       expect(scheduled).toHaveAttribute('aria-selected', 'true')
       expect(screen.getByText('Nightly report')).toBeInTheDocument()
       expect(screen.queryByText('Review alerts')).not.toBeInTheDocument()
+    })
+
+    it('hides scheduled and autonomous tabs when their features are disabled', () => {
+      mockSchedulerEnabled = false
+      mockAutonomousAgentsEnabled = false
+
+      render(<Sidebar {...defaultProps} />)
+
+      expect(screen.getByRole('tab', { name: 'Chat' })).toBeInTheDocument()
+      expect(screen.queryByRole('tab', { name: /Scheduled/i })).not.toBeInTheDocument()
+      expect(screen.queryByRole('tab', { name: /Autonomous/i })).not.toBeInTheDocument()
     })
 
     it('shows the current user webhook tasks in the autonomous view', async () => {

--- a/ui/src/components/layout/__tests__/Sidebar.test.tsx
+++ b/ui/src/components/layout/__tests__/Sidebar.test.tsx
@@ -504,7 +504,7 @@ describe('Sidebar — Live Status Indicator', () => {
       render(<Sidebar {...defaultProps} />)
 
       expect(screen.queryByText('Important Team 2 Meeting Prep')).not.toBeInTheDocument()
-      fireEvent.click(screen.getByRole('button', { name: /Scheduled Runs/i }))
+      fireEvent.click(screen.getByRole('tab', { name: /Scheduled/i }))
       expect(screen.getByText('Important Team 2 Meeting Prep')).toBeInTheDocument()
       expect(screen.queryByText('sched_ec7107dfab744ddd')).not.toBeInTheDocument()
     })
@@ -518,7 +518,7 @@ describe('Sidebar — Live Status Indicator', () => {
 
       render(<Sidebar {...defaultProps} />)
 
-      fireEvent.click(screen.getByRole('button', { name: /Scheduled Runs/i }))
+      fireEvent.click(screen.getByRole('tab', { name: /Scheduled/i }))
       expect(screen.getByText('sched_ec7107dfab744ddd')).toBeInTheDocument()
     })
 
@@ -534,7 +534,7 @@ describe('Sidebar — Live Status Indicator', () => {
       render(<Sidebar {...defaultProps} />)
 
       expect(screen.queryByText('Review open pull requests')).not.toBeInTheDocument()
-      fireEvent.click(screen.getByRole('button', { name: /Autonomous Runs/i }))
+      fireEvent.click(screen.getByRole('tab', { name: /Autonomous/i }))
       const badge = screen.getByText('Review open pull requests')
       expect(badge).toHaveClass(
         'border-violet-500/30',
@@ -557,11 +557,11 @@ describe('Sidebar — Live Status Indicator', () => {
 
       render(<Sidebar {...defaultProps} />)
 
-      fireEvent.click(screen.getByRole('button', { name: /Autonomous Runs/i }))
+      fireEvent.click(screen.getByRole('tab', { name: /Autonomous/i }))
       expect(screen.getByText('Legacy task title')).toHaveClass('border-violet-500/30')
     })
 
-    it('separates run conversations into collapsed sections above History', () => {
+    it('switches between chat, scheduled, and autonomous conversation views', () => {
       mockConversations = [
         makeConv('conv-normal', 'Normal Chat'),
         makeConv('conv-scheduled', 'Scheduled Chat', {
@@ -576,29 +576,32 @@ describe('Sidebar — Live Status Indicator', () => {
 
       render(<Sidebar {...defaultProps} />)
 
-      const autonomous = screen.getByRole('button', { name: /Autonomous Runs/i })
-      const scheduled = screen.getByRole('button', { name: /Scheduled Runs/i })
-      const history = screen.getByTestId('conversation-section-history')
+      const chat = screen.getByRole('tab', { name: 'Chat' })
+      const autonomous = screen.getByRole('tab', { name: /Autonomous/i })
+      const scheduled = screen.getByRole('tab', { name: /Scheduled/i })
 
-      expect(autonomous).toHaveAttribute('aria-expanded', 'false')
-      expect(scheduled).toHaveAttribute('aria-expanded', 'false')
+      expect(chat).toHaveAttribute('aria-selected', 'true')
+      expect(autonomous).toHaveAttribute('aria-selected', 'false')
+      expect(scheduled).toHaveAttribute('aria-selected', 'false')
+      expect(scheduled).toHaveAccessibleName('Scheduled (1)')
+      expect(autonomous).toHaveAccessibleName('Autonomous (1)')
       expect(screen.queryByText('Review alerts')).not.toBeInTheDocument()
       expect(screen.queryByText('Nightly report')).not.toBeInTheDocument()
       expect(screen.getByText('Normal Chat')).toBeInTheDocument()
-      expect(
-        autonomous.compareDocumentPosition(history) & Node.DOCUMENT_POSITION_FOLLOWING,
-      ).toBeTruthy()
-      expect(
-        scheduled.compareDocumentPosition(history) & Node.DOCUMENT_POSITION_FOLLOWING,
-      ).toBeTruthy()
 
       fireEvent.click(autonomous)
-      expect(autonomous).toHaveAttribute('aria-expanded', 'true')
+      expect(autonomous).toHaveAttribute('aria-selected', 'true')
+      expect(screen.queryByTestId('conversation-section-history')).not.toBeInTheDocument()
       expect(screen.getByText('Review alerts')).toBeInTheDocument()
       expect(screen.queryByText('Nightly report')).not.toBeInTheDocument()
+
+      fireEvent.click(scheduled)
+      expect(scheduled).toHaveAttribute('aria-selected', 'true')
+      expect(screen.getByText('Nightly report')).toBeInTheDocument()
+      expect(screen.queryByText('Review alerts')).not.toBeInTheDocument()
     })
 
-    it('groups the current user webhook tasks in a nested collapsed section', async () => {
+    it('shows the current user webhook tasks in the autonomous view', async () => {
       mockLoadConversationsFromServer.mockResolvedValueOnce(undefined)
       mockListAutonomousTasks.mockResolvedValue([
         {
@@ -625,16 +628,14 @@ describe('Sidebar — Live Status Indicator', () => {
 
       render(<Sidebar {...defaultProps} />)
 
-      const autonomous = await screen.findByRole('button', { name: /Autonomous Runs/i })
+      const autonomous = await screen.findByRole('tab', { name: /Autonomous/i })
       expect(mockListAutonomousTasks).toHaveBeenCalledTimes(1)
       fireEvent.click(autonomous)
 
-      const webhookRuns = screen.getByRole('button', { name: /Webhook Runs/i })
-      expect(webhookRuns).toHaveAttribute('aria-expanded', 'false')
-      expect(screen.queryByText('Daily branch summary')).not.toBeInTheDocument()
-
-      fireEvent.click(webhookRuns)
       expect(await screen.findByText('Daily branch summary')).toBeInTheDocument()
+      const webhookSection = screen.getByTestId('conversation-section-webhook')
+      expect(webhookSection).toBeInTheDocument()
+      expect(webhookSection.querySelector('button')).toBeNull()
       expect(screen.queryByText('Other owner hook')).not.toBeInTheDocument()
 
       fireEvent.click(screen.getByTestId('webhook-task-daily-branch-summary-41a9'))

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev1"
+version = "1.0.1.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Adds accessible conversation tabs to the chat sidebar:

- **Chat** shows regular conversation history.
- **Scheduled** shows scheduled-run conversations with a count badge when `schedulerEnabled` is enabled.
- **Autonomous** shows autonomous and webhook-run entries with a count badge when `autonomousAgentsEnabled` is enabled.

This replaces the previous expand/collapse controls for run sections and updates the sidebar tests for tab selection, filtering, counts, feature-flag visibility, and webhook visibility.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [ ] Functionality is documented
- [ ] New selection controls follow the selection-control decision table, or the custom interaction is justified
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass