### PR TITLE
feat(keycloak): support MCP DCR and RAG ingestors

### DIFF
--- a/charts/ai-platform-engineering/charts/keycloak/openid-configuration-override.json
+++ b/charts/ai-platform-engineering/charts/keycloak/openid-configuration-override.json
@@ -1,0 +1,3 @@
+{
+  "authorization_response_iss_parameter_supported": false
+}

--- a/charts/ai-platform-engineering/charts/keycloak/realm-config.json
+++ b/charts/ai-platform-engineering/charts/keycloak/realm-config.json
@@ -149,7 +149,9 @@
         "http://localhost:8085",
         "http://localhost:8085/*",
         "http://127.0.0.1:8085",
-        "http://127.0.0.1:8085/*"
+        "http://127.0.0.1:8085/*",
+        "cursor://anysphere.cursor-mcp/oauth/callback",
+        "cursor://anysphere.cursor-mcp/*"
       ],
       "webOrigins": [
         "http://localhost:8085",
@@ -288,6 +290,41 @@
     }
   ],
   "clientScopes": [
+    {
+      "name": "basic",
+      "description": "OpenID Connect scope for all basic token claims",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
     {
       "name": "profile",
       "description": "OpenID Connect built-in scope: profile",
@@ -717,6 +754,27 @@
         "config": {}
       },
       {
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ],
+          "allowed-client-scopes": [
+            "basic",
+            "openid",
+            "profile",
+            "email",
+            "roles",
+            "groups",
+            "org",
+            "offline_access"
+          ]
+        }
+      },
+      {
         "name": "Max Clients Limit",
         "providerId": "max-clients",
         "subType": "anonymous",
@@ -773,6 +831,58 @@
             "saml-user-attribute-mapper"
           ]
         }
+      }
+    ]
+  },
+  "clientProfiles": {
+    "profiles": [
+      {
+        "name": "mcp-public-pkce",
+        "description": "Require PKCE S256 for anonymously registered public MCP clients",
+        "executors": [
+          {
+            "executor": "pkce-enforcer",
+            "configuration": {
+              "auto-configure": true
+            }
+          }
+        ]
+      }
+    ]
+  },
+  "clientPolicies": {
+    "policies": [
+      {
+        "name": "mcp-public-dcr-pkce",
+        "description": "Apply PKCE S256 to anonymous OIDC registrations for public MCP clients",
+        "enabled": true,
+        "conditions": [
+          {
+            "condition": "client-updater-context",
+            "configuration": {
+              "update-client-source": [
+                "ByAnonymous"
+              ]
+            }
+          },
+          {
+            "condition": "client-type",
+            "configuration": {
+              "protocol": "openid-connect"
+            }
+          },
+          {
+            "condition": "client-access-type",
+            "configuration": {
+              "type": [
+                "public"
+              ]
+            }
+          }
+        ],
+        "profiles": [
+          "mcp-public-pkce"
+        ]
       }
     ]
   },

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-idp.sh
@@ -462,6 +462,20 @@ json.dump(client, sys.stdout)
 
 _reconcile_caipe_platform_client_secret
 
+# MCP DCR is optional for deployments that do not expose Tome. Keep this
+# reconcile best-effort so a transient Keycloak Admin API error cannot abort
+# the broader identity/bootstrap job under set -e.
+MCP_DCR_HELPER="${MCP_DCR_HELPER_PATH:-/scripts/mcp-dcr.sh}"
+if [ -r "${MCP_DCR_HELPER}" ]; then
+  # shellcheck source=./mcp-dcr.sh
+  . "${MCP_DCR_HELPER}"
+  if ! _reconcile_mcp_dynamic_client_registration; then
+    echo "${TAG:-[init-idp]} WARNING: MCP DCR reconcile failed; URL-only MCP clients may not work." >&2
+  fi
+else
+  echo "${TAG:-[init-idp]} WARNING: ${MCP_DCR_HELPER} is missing; skipping MCP DCR reconcile." >&2
+fi
+
 # -------------------------------------------------------------------
 # Reconcile the public CLI client (caipe-cli / forge-cli).
 #
@@ -488,7 +502,13 @@ _reconcile_caipe_platform_client_secret
 _reconcile_cli_client() {
   local CLI_CLIENT_ID="${KEYCLOAK_CLI_CLIENT_ID:-caipe-cli}"
   # Space- or comma-separated lists; defaults match realm-config.json.
-  local CLI_REDIRECT_URIS="${KEYCLOAK_CLI_REDIRECT_URIS:-http://localhost:8085 http://localhost:8085/* http://127.0.0.1:8085 http://127.0.0.1:8085/*}"
+  # 8085 is mcp-remote's/Claude Code's OAuth callback port. Cursor Desktop
+  # redirects via its own app URI scheme (cursor://anysphere.cursor-mcp/...),
+  # not a localhost port — confirmed from Keycloak's own LOGIN_ERROR event
+  # log (error="invalid_redirect_uri", redirect_uri="cursor://anysphere.
+  # cursor-mcp/oauth/callback") after an earlier attempt to register a
+  # (wrong) localhost:8787 port instead.
+  local CLI_REDIRECT_URIS="${KEYCLOAK_CLI_REDIRECT_URIS:-http://localhost:8085 http://localhost:8085/* http://127.0.0.1:8085 http://127.0.0.1:8085/* cursor://anysphere.cursor-mcp/oauth/callback cursor://anysphere.cursor-mcp/*}"
   local CLI_WEB_ORIGINS="${KEYCLOAK_CLI_WEB_ORIGINS:-http://localhost:8085 http://127.0.0.1:8085}"
   local CLI_ACCESS_TOKEN_LIFESPAN="${KEYCLOAK_CLI_ACCESS_TOKEN_LIFESPAN:-28800}"
 
@@ -607,6 +627,69 @@ print(json.dumps(existing))
 }
 
 _reconcile_cli_client
+
+# -------------------------------------------------------------------
+# Ensure offline_access is in the realm default-role composite.
+#
+# Keycloak realm import does not reliably set composite memberships on
+# default-roles-<realm> (see realm-config.json's defaultRole.composites),
+# so patch it at runtime to guarantee all users — including plain local-
+# Keycloak logins with no upstream IdP broker configured — receive
+# offline_access automatically. Needed for MCP OAuth/PKCE clients (e.g.
+# Claude Code) that request offline_access; without it, first login fails
+# with "Offline tokens not allowed for the user or client". Must run
+# before the no-upstream-IdP early exit below, since local-Keycloak-only
+# installs never reach the upstream-IdP-broker code path.
+# -------------------------------------------------------------------
+_ensure_default_role_offline_access() {
+  local DEFAULT_REALM_ROLE="default-roles-${REALM}"
+  echo "[init-idp] Ensuring offline_access is in ${DEFAULT_REALM_ROLE} ..."
+  if [ -z "${AUTH:-}" ]; then
+    local _tok
+    _tok=$(curl -sf -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+      -d "grant_type=password&client_id=admin-cli&username=${KEYCLOAK_ADMIN:-admin}&password=${KEYCLOAK_ADMIN_PASSWORD:-admin}" 2>/dev/null \
+      | grep -o '"access_token" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+    if [ -z "${_tok}" ]; then
+      echo "[init-idp]   WARNING: could not acquire admin token — skipping offline_access default-role check."
+      return 0
+    fi
+    AUTH="Authorization: Bearer ${_tok}"
+  fi
+
+  local DEFAULT_ROLE_ID
+  DEFAULT_ROLE_ID=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/roles" 2>/dev/null \
+    | json_id_by_field "name" "${DEFAULT_REALM_ROLE}")
+  if [ -z "${DEFAULT_ROLE_ID}" ]; then
+    echo "[init-idp]   WARNING: ${DEFAULT_REALM_ROLE} role not found."
+    return 0
+  fi
+
+  local COMPOSITES
+  COMPOSITES=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/roles-by-id/${DEFAULT_ROLE_ID}/composites" 2>/dev/null || echo "[]")
+  if echo "${COMPOSITES}" | grep -q '"offline_access"'; then
+    echo "[init-idp]   offline_access already in ${DEFAULT_REALM_ROLE}."
+    return 0
+  fi
+
+  local OFFLINE_ROLE_ID
+  OFFLINE_ROLE_ID=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/roles" 2>/dev/null \
+    | json_id_by_field "name" "offline_access")
+  if [ -z "${OFFLINE_ROLE_ID}" ]; then
+    echo "[init-idp]   WARNING: offline_access role not found in realm."
+    return 0
+  fi
+
+  curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \
+    "${KC_URL}/admin/realms/${REALM}/roles-by-id/${DEFAULT_ROLE_ID}/composites" \
+    -d "[{\"id\":\"${OFFLINE_ROLE_ID}\",\"name\":\"offline_access\"}]" && \
+    echo "[init-idp]   Added offline_access to ${DEFAULT_REALM_ROLE}." || \
+    echo "[init-idp]   WARNING: failed to add offline_access to ${DEFAULT_REALM_ROLE}."
+}
+
+_ensure_default_role_offline_access
 
 # -------------------------------------------------------------------
 # Strict client-secret mode guard (init-idp scope: caipe-ui + caipe-platform).
@@ -1078,39 +1161,6 @@ echo "[init-idp]   jwks:      ${JWKS_EP}"
 if [ -z "${TOKEN_EP}" ] || [ -z "${AUTHZ_EP}" ]; then
   echo "[init-idp] ERROR: failed to parse discovery document" >&2
   exit 1
-fi
-
-# --- ensure offline_access is in the realm default-role composite ---
-# Keycloak realm import does not reliably set composite memberships,
-# so we patch it at runtime to guarantee all users (including SSO-
-# brokered users) receive the offline_access role automatically.
-DEFAULT_REALM_ROLE="default-roles-${REALM}"
-echo "[init-idp] Ensuring offline_access is in ${DEFAULT_REALM_ROLE} ..."
-DEFAULT_ROLE_ID=$(curl -sf -H "${AUTH}" \
-  "${KC_URL}/admin/realms/${REALM}/roles" 2>/dev/null \
-  | json_id_by_field "name" "${DEFAULT_REALM_ROLE}")
-
-if [ -n "${DEFAULT_ROLE_ID}" ]; then
-  COMPOSITES=$(curl -sf -H "${AUTH}" \
-    "${KC_URL}/admin/realms/${REALM}/roles-by-id/${DEFAULT_ROLE_ID}/composites" 2>/dev/null || echo "[]")
-  if echo "${COMPOSITES}" | grep -q '"offline_access"'; then
-    echo "[init-idp]   offline_access already in ${DEFAULT_REALM_ROLE}."
-  else
-    OFFLINE_ROLE_ID=$(curl -sf -H "${AUTH}" \
-      "${KC_URL}/admin/realms/${REALM}/roles" 2>/dev/null \
-      | json_id_by_field "name" "offline_access")
-    if [ -n "${OFFLINE_ROLE_ID}" ]; then
-      curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \
-        "${KC_URL}/admin/realms/${REALM}/roles-by-id/${DEFAULT_ROLE_ID}/composites" \
-        -d "[{\"id\":\"${OFFLINE_ROLE_ID}\",\"name\":\"offline_access\"}]" && \
-        echo "[init-idp]   Added offline_access to ${DEFAULT_REALM_ROLE}." || \
-        echo "[init-idp]   WARNING: failed to add offline_access to ${DEFAULT_REALM_ROLE}."
-    else
-      echo "[init-idp]   WARNING: offline_access role not found in realm."
-    fi
-  fi
-else
-  echo "[init-idp]   WARNING: ${DEFAULT_REALM_ROLE} role not found."
 fi
 
 # CAIPE business authorization is OpenFGA-backed. Do not add application roles
@@ -2254,6 +2304,89 @@ if [ -n "${WB_CLIENT_ID}" ]; then
   fi
 else
   echo "[init-idp]   WARNING: caipe-webex-bot client not found — Webex RBAC/OBO setup skipped."
+fi
+
+# -------------------------------------------------------------------
+# Ensure caipe-rag-ingestor confidential client exists with its
+# self-audience mapper. Ingestors use client_credentials to obtain a
+# JWT that rag-server validates with audience=caipe-rag-ingestor.
+# The client is NOT in realm-config.json (created imperatively here so
+# it lands on existing realms during upgrades, not only first boot).
+# -------------------------------------------------------------------
+RAG_INGESTOR_CLIENT_ID="${RAG_INGESTOR_OIDC_CLIENT_ID:-caipe-rag-ingestor}"
+RAG_INGESTOR_AUDIENCE_MAPPER="rag-ingestor-self-audience"
+
+echo "[init-idp] Ensuring '${RAG_INGESTOR_CLIENT_ID}' client exists ..."
+RAG_INGESTOR_UUID=$(curl -sf -H "${AUTH}" \
+  "${KC_URL}/admin/realms/${REALM}/clients?clientId=${RAG_INGESTOR_CLIENT_ID}" 2>/dev/null \
+  | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"/\1/')
+
+if [ -z "${RAG_INGESTOR_UUID}" ]; then
+  echo "[init-idp]   Creating '${RAG_INGESTOR_CLIENT_ID}' client ..."
+  if [ -n "${RAG_INGESTOR_OIDC_CLIENT_SECRET:-}" ]; then
+    SECRET_JSON=", \"secret\": \"${RAG_INGESTOR_OIDC_CLIENT_SECRET}\""
+  else
+    SECRET_JSON=""
+  fi
+  curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \
+    "${KC_URL}/admin/realms/${REALM}/clients" \
+    -d "{
+      \"clientId\": \"${RAG_INGESTOR_CLIENT_ID}\",
+      \"enabled\": true,
+      \"publicClient\": false,
+      \"bearerOnly\": false,
+      \"standardFlowEnabled\": false,
+      \"directAccessGrantsEnabled\": false,
+      \"serviceAccountsEnabled\": true,
+      \"protocol\": \"openid-connect\",
+      \"description\": \"Machine-to-machine client for RAG ingestors. Uses client_credentials; rag-server validates aud=caipe-rag-ingestor.\"
+      ${SECRET_JSON}
+    }" && echo "[init-idp]   Created '${RAG_INGESTOR_CLIENT_ID}' client."
+
+  # Re-fetch UUID after creation
+  RAG_INGESTOR_UUID=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/clients?clientId=${RAG_INGESTOR_CLIENT_ID}" 2>/dev/null \
+    | grep -o '"id" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"/\1/')
+else
+  echo "[init-idp]   '${RAG_INGESTOR_CLIENT_ID}' client already exists (${RAG_INGESTOR_UUID})."
+fi
+
+if [ -n "${RAG_INGESTOR_UUID}" ]; then
+  # Ensure self-audience mapper so access tokens carry aud=caipe-rag-ingestor
+  RAG_MAPPERS=$(curl -sf -H "${AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/clients/${RAG_INGESTOR_UUID}/protocol-mappers/models" 2>/dev/null || echo "[]")
+  if echo "${RAG_MAPPERS}" | TARGET_AUD="${RAG_INGESTOR_CLIENT_ID}" python3 -c '
+import sys, json, os
+mappers = json.load(sys.stdin)
+target = os.environ["TARGET_AUD"]
+found = any(
+    m.get("protocolMapper") == "oidc-audience-mapper" and
+    m.get("config", {}).get("included.custom.audience") == target
+    for m in mappers
+)
+sys.exit(0 if found else 1)
+' 2>/dev/null; then
+    echo "[init-idp]   Audience mapper '${RAG_INGESTOR_AUDIENCE_MAPPER}' already correct — skipping."
+  else
+    echo "[init-idp]   Creating/updating audience mapper '${RAG_INGESTOR_AUDIENCE_MAPPER}' ..."
+    curl -sf -X POST -H "${AUTH}" -H "Content-Type: application/json" \
+      "${KC_URL}/admin/realms/${REALM}/clients/${RAG_INGESTOR_UUID}/protocol-mappers/models" \
+      -d "{
+        \"name\": \"${RAG_INGESTOR_AUDIENCE_MAPPER}\",
+        \"protocol\": \"openid-connect\",
+        \"protocolMapper\": \"oidc-audience-mapper\",
+        \"consentRequired\": false,
+        \"config\": {
+          \"included.custom.audience\": \"${RAG_INGESTOR_CLIENT_ID}\",
+          \"id.token.claim\": \"false\",
+          \"access.token.claim\": \"true\",
+          \"introspection.token.claim\": \"true\"
+        }
+      }" && echo "[init-idp]   Mapper '${RAG_INGESTOR_AUDIENCE_MAPPER}' created on '${RAG_INGESTOR_CLIENT_ID}'." || \
+      echo "[init-idp]   WARNING: failed to create audience mapper on '${RAG_INGESTOR_CLIENT_ID}'."
+  fi
+else
+  echo "[init-idp]   WARNING: '${RAG_INGESTOR_CLIENT_ID}' UUID not found after creation attempt — skipping audience mapper."
 fi
 
 echo "[init-idp] Done — IdP '${ALIAS}' is ready (auto-redirect enabled)."

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/init-token-exchange.sh
@@ -812,6 +812,20 @@ seed_openfga_service_account_grants() {
 
 seed_openfga_service_account_grants
 
+# MCP DCR is optional for deployments that do not expose Tome. Keep this
+# reconcile best-effort so a transient Keycloak Admin API error cannot abort
+# the broader identity/bootstrap job under set -e.
+MCP_DCR_HELPER="${MCP_DCR_HELPER_PATH:-/scripts/mcp-dcr.sh}"
+if [ -r "${MCP_DCR_HELPER}" ]; then
+  # shellcheck source=./mcp-dcr.sh
+  . "${MCP_DCR_HELPER}"
+  if ! _reconcile_mcp_dynamic_client_registration "${AUTH}"; then
+    echo "${TAG:-[init-idp]} WARNING: MCP DCR reconcile failed; URL-only MCP clients may not work." >&2
+  fi
+else
+  echo "${TAG:-[init-idp]} WARNING: ${MCP_DCR_HELPER} is missing; skipping MCP DCR reconcile." >&2
+fi
+
 # -------------------------------------------------------------------
 # Reconcile the public CLI client (caipe-cli / forge-cli).
 #

--- a/charts/ai-platform-engineering/charts/keycloak/scripts/mcp-dcr.sh
+++ b/charts/ai-platform-engineering/charts/keycloak/scripts/mcp-dcr.sh
@@ -1,0 +1,224 @@
+#!/bin/sh
+# Shared, idempotent Keycloak reconciliation for generic remote MCP clients.
+# Sourced by both init-idp.sh and init-token-exchange.sh. The caller provides
+# REALM and KC_URL; an existing Authorization header may be passed as $1.
+
+# -------------------------------------------------------------------
+# Reconcile the OAuth client-registration pieces required by generic
+# remote MCP clients.
+#
+# Keycloak's OIDC DCR provider assigns its internal `basic` client scope
+# to every dynamically registered client. CAIPE's hand-authored realm did
+# not contain that scope, and persisted realms can retain an anonymous
+# Allowed Client Scopes policy that does not allow the MCP scope set. The
+# result is a discovery endpoint that advertises DCR but rejects a client
+# that only knows the MCP server URL.
+#
+# Keep existing operator-approved scopes and add the minimum CAIPE/MCP set.
+# This is idempotent and covers upgrades where --import-realm is skipped.
+# -------------------------------------------------------------------
+_reconcile_mcp_dynamic_client_registration() {
+  local MCP_LOG_PREFIX MCP_AUTH MCP_ADMIN_USER MCP_ADMIN_PASS MCP_ADMIN_TOKEN
+  local MCP_REALM_JSON MCP_REALM_ID MCP_SCOPES_JSON MCP_BASIC_SCOPE_ID MCP_BASIC_SCOPE_JSON
+  local MCP_POLICY_TYPE MCP_COMPONENTS_JSON MCP_POLICY_JSON MCP_POLICY_ID
+  local MCP_POLICY_URL MCP_POLICY_METHOD MCP_PROFILES_JSON MCP_UPDATED_PROFILES_JSON
+  local MCP_POLICIES_JSON MCP_UPDATED_POLICIES_JSON
+
+  MCP_AUTH="${1:-}"
+  MCP_LOG_PREFIX="${TAG:-[init-idp]}"
+
+  echo "${MCP_LOG_PREFIX} Reconciling generic MCP dynamic client registration ..."
+  if [ -z "${MCP_AUTH}" ]; then
+    MCP_ADMIN_USER="${KEYCLOAK_ADMIN:-admin}"
+    MCP_ADMIN_PASS="${KEYCLOAK_ADMIN_PASSWORD:-admin}"
+    MCP_ADMIN_TOKEN=$(curl -sf -X POST "${KC_URL}/realms/master/protocol/openid-connect/token" \
+      -d "grant_type=password&client_id=admin-cli&username=${MCP_ADMIN_USER}&password=${MCP_ADMIN_PASS}" 2>/dev/null \
+      | grep -o '"access_token" *: *"[^"]*"' | head -1 | sed 's/.*"\([^"]*\)"$/\1/')
+    if [ -z "${MCP_ADMIN_TOKEN}" ]; then
+      echo "${MCP_LOG_PREFIX}   ERROR: could not acquire admin token for MCP DCR reconcile." >&2
+      return 1
+    fi
+    MCP_AUTH="Authorization: Bearer ${MCP_ADMIN_TOKEN}"
+  fi
+
+  MCP_REALM_JSON=$(curl -sf -H "${MCP_AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}" 2>/dev/null || echo "")
+  MCP_REALM_ID=$(MCP_REALM_JSON="${MCP_REALM_JSON}" python3 -c '
+import json
+import os
+
+try:
+    print(json.loads(os.environ["MCP_REALM_JSON"])["id"])
+except (KeyError, TypeError, json.JSONDecodeError):
+    pass
+' 2>/dev/null)
+  if [ -z "${MCP_REALM_ID}" ]; then
+    echo "${MCP_LOG_PREFIX}   ERROR: could not resolve realm id for '${REALM}'." >&2
+    return 1
+  fi
+
+  MCP_SCOPES_JSON=$(curl -sf -H "${MCP_AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/client-scopes" 2>/dev/null || echo "[]")
+  MCP_BASIC_SCOPE_ID=$(MCP_SCOPES_JSON="${MCP_SCOPES_JSON}" python3 -c '
+import json
+import os
+
+try:
+    scopes = json.loads(os.environ["MCP_SCOPES_JSON"])
+    print(next((scope.get("id", "") for scope in scopes if scope.get("name") == "basic"), ""))
+except (TypeError, json.JSONDecodeError):
+    pass
+' 2>/dev/null)
+
+  if [ -z "${MCP_BASIC_SCOPE_ID}" ]; then
+    echo "${MCP_LOG_PREFIX}   Creating Keycloak's required 'basic' client scope ..."
+    MCP_BASIC_SCOPE_JSON='{"name":"basic","description":"OpenID Connect scope for all basic token claims","protocol":"openid-connect","attributes":{"include.in.token.scope":"false","display.on.consent.screen":"false"},"protocolMappers":[{"name":"auth_time","protocol":"openid-connect","protocolMapper":"oidc-usersessionmodel-note-mapper","consentRequired":false,"config":{"user.session.note":"AUTH_TIME","id.token.claim":"true","introspection.token.claim":"true","access.token.claim":"true","claim.name":"auth_time","jsonType.label":"long"}},{"name":"sub","protocol":"openid-connect","protocolMapper":"oidc-sub-mapper","consentRequired":false,"config":{"introspection.token.claim":"true","access.token.claim":"true"}}]}'
+    if ! curl -sf -o /dev/null -X POST -H "${MCP_AUTH}" -H "Content-Type: application/json" \
+      "${KC_URL}/admin/realms/${REALM}/client-scopes" -d "${MCP_BASIC_SCOPE_JSON}"; then
+      echo "${MCP_LOG_PREFIX}   ERROR: failed to create the 'basic' client scope." >&2
+      return 1
+    fi
+  else
+    echo "${MCP_LOG_PREFIX}   Client scope 'basic' already exists."
+  fi
+
+  MCP_POLICY_TYPE="org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy"
+  MCP_COMPONENTS_JSON=$(curl -sf -H "${MCP_AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/components?parent=${MCP_REALM_ID}&type=${MCP_POLICY_TYPE}" \
+    2>/dev/null || echo "")
+  if [ -z "${MCP_COMPONENTS_JSON}" ]; then
+    echo "${MCP_LOG_PREFIX}   ERROR: could not read Keycloak client-registration policies." >&2
+    return 1
+  fi
+
+  MCP_POLICY_JSON=$(MCP_COMPONENTS_JSON="${MCP_COMPONENTS_JSON}" \
+    MCP_REALM_ID="${MCP_REALM_ID}" MCP_POLICY_TYPE="${MCP_POLICY_TYPE}" python3 -c '
+import json
+import os
+
+components = json.loads(os.environ["MCP_COMPONENTS_JSON"])
+policy = next(
+    (
+        item
+        for item in components
+        if item.get("providerId") == "allowed-client-templates"
+        and item.get("subType") == "anonymous"
+    ),
+    {},
+)
+policy.update(
+    {
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "providerType": os.environ["MCP_POLICY_TYPE"],
+        "parentId": os.environ["MCP_REALM_ID"],
+        "subType": "anonymous",
+    }
+)
+config = policy.get("config") or {}
+allowed = list(config.get("allowed-client-scopes") or [])
+for scope in ("basic", "openid", "profile", "email", "roles", "groups", "org", "offline_access"):
+    if scope not in allowed:
+        allowed.append(scope)
+config["allow-default-scopes"] = ["true"]
+config["allowed-client-scopes"] = allowed
+policy["config"] = config
+print(json.dumps(policy))
+' 2>/dev/null)
+  if [ -z "${MCP_POLICY_JSON}" ]; then
+    echo "${MCP_LOG_PREFIX}   ERROR: failed to render the MCP DCR scope policy." >&2
+    return 1
+  fi
+
+  MCP_POLICY_ID=$(MCP_POLICY_JSON="${MCP_POLICY_JSON}" python3 -c '
+import json
+import os
+
+print(json.loads(os.environ["MCP_POLICY_JSON"]).get("id", ""))
+' 2>/dev/null)
+  if [ -n "${MCP_POLICY_ID}" ]; then
+    MCP_POLICY_URL="${KC_URL}/admin/realms/${REALM}/components/${MCP_POLICY_ID}"
+    MCP_POLICY_METHOD="PUT"
+  else
+    MCP_POLICY_URL="${KC_URL}/admin/realms/${REALM}/components"
+    MCP_POLICY_METHOD="POST"
+  fi
+
+  if curl -sf -o /dev/null -X "${MCP_POLICY_METHOD}" -H "${MCP_AUTH}" \
+    -H "Content-Type: application/json" "${MCP_POLICY_URL}" -d "${MCP_POLICY_JSON}"; then
+    echo "${MCP_LOG_PREFIX}   Anonymous DCR allows the advertised MCP scope set."
+  else
+    echo "${MCP_LOG_PREFIX}   ERROR: failed to reconcile the MCP DCR scope policy." >&2
+    return 1
+  fi
+  MCP_PROFILES_JSON=$(curl -sf -H "${MCP_AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/client-policies/profiles" 2>/dev/null || echo "")
+  MCP_UPDATED_PROFILES_JSON=$(MCP_PROFILES_JSON="${MCP_PROFILES_JSON}" python3 -c '
+import json
+import os
+
+document = json.loads(os.environ["MCP_PROFILES_JSON"])
+profiles = list(document.get("profiles") or [])
+desired = {
+    "name": "mcp-public-pkce",
+    "description": "Require PKCE S256 for anonymously registered public MCP clients",
+    "executors": [
+        {
+            "executor": "pkce-enforcer",
+            "configuration": {"auto-configure": True},
+        }
+    ],
+}
+profiles = [profile for profile in profiles if profile.get("name") != desired["name"]]
+profiles.append(desired)
+print(json.dumps({"profiles": profiles}))
+' 2>/dev/null)
+  if [ -z "${MCP_UPDATED_PROFILES_JSON}" ] || ! curl -sf -o /dev/null -X PUT \
+    -H "${MCP_AUTH}" -H "Content-Type: application/json" \
+    "${KC_URL}/admin/realms/${REALM}/client-policies/profiles" \
+    -d "${MCP_UPDATED_PROFILES_JSON}"; then
+    echo "${MCP_LOG_PREFIX}   ERROR: failed to reconcile the MCP public-PKCE profile." >&2
+    return 1
+  fi
+
+  MCP_POLICIES_JSON=$(curl -sf -H "${MCP_AUTH}" \
+    "${KC_URL}/admin/realms/${REALM}/client-policies/policies" 2>/dev/null || echo "")
+  MCP_UPDATED_POLICIES_JSON=$(MCP_POLICIES_JSON="${MCP_POLICIES_JSON}" python3 -c '
+import json
+import os
+
+document = json.loads(os.environ["MCP_POLICIES_JSON"])
+policies = list(document.get("policies") or [])
+desired = {
+    "name": "mcp-public-dcr-pkce",
+    "description": "Apply PKCE S256 to anonymous OIDC registrations for public MCP clients",
+    "enabled": True,
+    "conditions": [
+        {
+            "condition": "client-updater-context",
+            "configuration": {"update-client-source": ["ByAnonymous"]},
+        },
+        {
+            "condition": "client-type",
+            "configuration": {"protocol": "openid-connect"},
+        },
+        {
+            "condition": "client-access-type",
+            "configuration": {"type": ["public"]},
+        },
+    ],
+    "profiles": ["mcp-public-pkce"],
+}
+policies = [policy for policy in policies if policy.get("name") != desired["name"]]
+policies.append(desired)
+print(json.dumps({"policies": policies}))
+' 2>/dev/null)
+  if [ -z "${MCP_UPDATED_POLICIES_JSON}" ] || ! curl -sf -o /dev/null -X PUT \
+    -H "${MCP_AUTH}" -H "Content-Type: application/json" \
+    "${KC_URL}/admin/realms/${REALM}/client-policies/policies" \
+    -d "${MCP_UPDATED_POLICIES_JSON}"; then
+    echo "${MCP_LOG_PREFIX}   ERROR: failed to reconcile the MCP public-PKCE policy." >&2
+    return 1
+  fi
+  echo "${MCP_LOG_PREFIX}   Anonymous public MCP clients require PKCE S256."
+}

--- a/charts/ai-platform-engineering/charts/keycloak/templates/configmap-init-scripts.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/configmap-init-scripts.yaml
@@ -5,6 +5,8 @@ metadata:
   labels:
     {{- include "keycloak.labels" . | nindent 4 }}
 data:
+  mcp-dcr.sh: |-
+    {{- .Files.Get "scripts/mcp-dcr.sh" | nindent 4 }}
   init-token-exchange.sh: |-
     {{- .Files.Get "scripts/init-token-exchange.sh" | nindent 4 }}
   init-idp.sh: |-

--- a/charts/ai-platform-engineering/charts/keycloak/templates/configmap-openid-configuration.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/configmap-openid-configuration.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "keycloak.fullname" . }}-openid-configuration
+  labels:
+    {{- include "keycloak.labels" . | nindent 4 }}
+data:
+  openid-configuration-override.json: |-
+    {{- .Files.Get "openid-configuration-override.json" | nindent 4 }}

--- a/charts/ai-platform-engineering/charts/keycloak/templates/deployment.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/deployment.yaml
@@ -13,6 +13,7 @@ spec:
     metadata:
       annotations:
         checksum/keycloak-realm: {{ include (print $.Template.BasePath "/configmap-realm.yaml") . | sha256sum }}
+        checksum/keycloak-openid-configuration: {{ include (print $.Template.BasePath "/configmap-openid-configuration.yaml") . | sha256sum }}
         {{- if and .Values.theme.enabled (not .Values.theme.existingConfigMap) }}
         checksum/keycloak-theme: {{ include (print $.Template.BasePath "/configmap-theme.yaml") . | sha256sum }}
         {{- end }}
@@ -30,6 +31,10 @@ spec:
           args:
             - {{ if .Values.database.enabled }}start{{ else }}start-dev{{ end }}
             - --import-realm
+            {{- /* Codex currently loses the RFC 9207 `iss` parameter while relaying
+                   its loopback callback. Keep Keycloak emitting `iss`, but advertise
+                   false so the client does not require the missing relayed value. */}}
+            - --spi-well-known--openid-configuration--openid-configuration-override=/opt/keycloak/conf/openid-configuration-override.json
             {{- $features := list }}
             {{- if .Values.features.tokenExchange }}
             {{- $features = append $features "token-exchange" }}
@@ -112,6 +117,10 @@ spec:
             - name: realm-config
               mountPath: /opt/keycloak/data/import
               readOnly: true
+            - name: openid-configuration
+              mountPath: /opt/keycloak/conf/openid-configuration-override.json
+              subPath: openid-configuration-override.json
+              readOnly: true
             {{- if .Values.theme.enabled }}
             - name: keycloak-theme
               mountPath: /opt/keycloak/themes/{{ .Values.theme.name }}
@@ -128,6 +137,9 @@ spec:
         - name: realm-config
           configMap:
             name: {{ include "keycloak.fullname" . }}-realm
+        - name: openid-configuration
+          configMap:
+            name: {{ include "keycloak.fullname" . }}-openid-configuration
         {{- if .Values.theme.enabled }}
         - name: keycloak-theme
           configMap:

--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-auth-reconcile.yaml
@@ -131,6 +131,11 @@ spec:
             - name: KEYCLOAK_CLI_WEB_ORIGINS
               value: {{ join " " . | quote }}
             {{- end }}
+            {{- /* RAG ingestor M2M client — provisioned imperatively so it lands
+                   on existing realms. Default caipe-rag-ingestor; override via
+                   ragIngestorClient.clientId in values. */}}
+            - name: RAG_INGESTOR_OIDC_CLIENT_ID
+              value: {{ (.Values.ragIngestorClient).clientId | default "caipe-rag-ingestor" | quote }}
             - name: IDP_ACCESS_GROUP
               value: {{ .Values.idp.accessGroup | quote }}
             - name: IDP_ADMIN_GROUP

--- a/charts/ai-platform-engineering/charts/keycloak/templates/job-init-idp.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/templates/job-init-idp.yaml
@@ -124,6 +124,11 @@ spec:
             - name: KEYCLOAK_CLI_WEB_ORIGINS
               value: {{ join " " . | quote }}
             {{- end }}
+            {{- /* RAG ingestor M2M client — provisioned imperatively so it lands
+                   on existing realms. Default caipe-rag-ingestor; override via
+                   ragIngestorClient.clientId in values. */}}
+            - name: RAG_INGESTOR_OIDC_CLIENT_ID
+              value: {{ (.Values.ragIngestorClient).clientId | default "caipe-rag-ingestor" | quote }}
             - name: IDP_ACCESS_GROUP
               value: {{ .Values.idp.accessGroup | quote }}
             - name: IDP_ADMIN_GROUP

--- a/charts/ai-platform-engineering/charts/keycloak/values.yaml
+++ b/charts/ai-platform-engineering/charts/keycloak/values.yaml
@@ -163,6 +163,14 @@ cliClient:
     - "http://localhost:8085"
     - "http://127.0.0.1:8085"
 
+# ---------- RAG ingestor M2M OIDC client ----------
+# Machine-to-machine client used by RAG ingestors (web-ingestor, confluence-ingestor,
+# etc.) to authenticate against rag-server via client_credentials. The init-idp Job
+# creates/updates it imperatively so it lands on existing realms on upgrade.
+# rag-server validates ingestor JWTs with audience=ragIngestorClient.clientId.
+ragIngestorClient:
+  clientId: "caipe-rag-ingestor"
+
 # ---------- CAIPE platform OIDC client ----------
 # The realm import ships the `caipe-platform` confidential client with a
 # placeholder secret ("caipe-platform-dev-secret") so first-boot import works


### PR DESCRIPTION
## Summary

- Reconcile Keycloak's anonymous MCP dynamic-client-registration scope and PKCE policy.
- Support Cursor's MCP OAuth callback URI and RFC 9207 discovery compatibility.
- Ensure `offline_access` is available to the realm default role.
- Provision the `caipe-rag-ingestor` confidential client and self-audience mapper during identity bootstrap.
- Apply the reconciliation to both initial IdP setup and auth-reconcile jobs.

This PR intentionally excludes deployment-specific session-lifetime defaults and CAIPE UI value changes covered by separate work.

## Validation

- `helm lint charts/ai-platform-engineering` (passes; reports the existing missing `rag-stack` dependency as a warning)
- `jq empty` on changed Keycloak JSON files
- `sh -n` on changed Keycloak shell scripts
- `git diff --check`

Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>
