### PR TITLE
feat(metrics): add Tome dashboard panels

### DIFF
--- a/charts/ai-platform-engineering/data/grafana-dashboard-ai-platform.json
+++ b/charts/ai-platform-engineering/data/grafana-dashboard-ai-platform.json
@@ -252,6 +252,134 @@
       ],
       "title": "Runtime CPU Usage",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Sum across all caipe-ui replicas — each replica's gauge tracks the Tome chat SSE streams it is currently proxying.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "sum(tome_active_chat_sessions)",
+          "legendFormat": "active sessions",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tome Active Chat Sessions",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Every caipe-ui replica reports the same Mongo-derived count, so this takes max() rather than sum() to avoid over-counting.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 5
+              },
+              {
+                "color": "red",
+                "value": 20
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "editorMode": "code",
+          "expr": "max(tome_ingest_queue_depth)",
+          "legendFormat": "queued runs",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tome Ingest Queue Depth",
+      "type": "stat"
     }
   ],
   "refresh": "30s",
@@ -260,7 +388,8 @@
   "tags": [
     "caipe",
     "dynamic-agents",
-    "mcp"
+    "mcp",
+    "tome"
   ],
   "templating": {
     "list": []


### PR DESCRIPTION
## Summary

- Add a Tome active chat sessions stat panel.
- Add a Tome ingest queue depth stat panel.
- Include Tome in the dashboard's application tags.

The upstream ServiceMonitor already includes `caipe-ui`, so this PR is intentionally limited to the dashboard artifact.

## Validation

- `helm lint charts/ai-platform-engineering` (passes; reports the existing missing `rag-stack` dependency as a warning)
- `git diff --check`

Signed-off-by: Sri Aradhyula <sraradhy@cisco.com>
