### PR TITLE
feat(ui): configure release notes from commit diffs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.1"
+version = "1.0.1-dev.2"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/app/api/admin/platform-config/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/platform-config/__tests__/route.test.ts
@@ -120,6 +120,9 @@ describe("admin platform-config route", () => {
 
     expect(body.data.release_notes).toEqual({
       enabled: true,
+      repository_url: null,
+      previous_commit: null,
+      latest_commit: null,
     });
   });
 
@@ -316,13 +319,72 @@ describe("admin platform-config route", () => {
       { _id: "platform_settings" },
       expect.objectContaining({
         $set: expect.objectContaining({
-          release_notes: { enabled: false },
+          release_notes: {
+            enabled: false,
+            repository_url: null,
+            previous_commit: null,
+            latest_commit: null,
+          },
         }),
       }),
       { upsert: true },
     );
     expect(collection.updateOne.mock.calls[0][1].$set).not.toHaveProperty("default_agent_id");
-    expect(body.data.release_notes).toEqual({ enabled: false });
+    expect(body.data.release_notes).toEqual({
+      enabled: false,
+      repository_url: null,
+      previous_commit: null,
+      latest_commit: null,
+    });
+  });
+
+  it("persists a GitHub commit range for release notes", async () => {
+    const collection = {
+      findOne: jest.fn().mockResolvedValue(null),
+      updateOne: jest.fn().mockResolvedValue({ acknowledged: true }),
+    };
+    mockGetCollection.mockResolvedValue(collection);
+    const { PATCH } = await import("../route");
+
+    const response = await PATCH(
+      request("/api/admin/platform-config", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          release_notes: {
+            enabled: true,
+            repository_url: "https://github.com/example/repository",
+            previous_commit: "1111111",
+            latest_commit: "2222222",
+          },
+        }),
+      }),
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.data.release_notes).toEqual({
+      enabled: true,
+      repository_url: "https://github.com/example/repository",
+      previous_commit: "1111111",
+      latest_commit: "2222222",
+    });
+  });
+
+  it("rejects an incomplete release notes commit range", async () => {
+    const { PATCH } = await import("../route");
+
+    await expect(
+      PATCH(
+        request("/api/admin/platform-config", {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            release_notes: { previous_commit: "1111111" },
+          }),
+        }),
+      ),
+    ).rejects.toMatchObject({ code: "INCOMPLETE_RELEASE_NOTES_COMPARE" });
   });
 
   it("checks coarse admin before system_config manage on updates", async () => {

--- a/ui/src/app/api/admin/platform-config/route.ts
+++ b/ui/src/app/api/admin/platform-config/route.ts
@@ -158,14 +158,79 @@ async function reconcileDefaultAgentGrant(previousAgentId: string | null, nextAg
   await writeOpenFgaTuples({ writes, deletes });
 }
 
-// Release notes is a single platform-wide on/off switch. The announcement
-// always targets the currently deployed version, and dismissal is permanent
-// per-version, so there is no version/revision/toast/CTA config to store.
-function normalizeReleaseNotesConfig(input: unknown = {}) {
+export interface ReleaseNotesNotificationConfig {
+  enabled: boolean;
+  repository_url: string | null;
+  previous_commit: string | null;
+  latest_commit: string | null;
+}
+
+function optionalTrimmedString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim() ? value.trim() : null;
+}
+
+function normalizeReleaseNotesConfig(input: unknown = {}): ReleaseNotesNotificationConfig {
   const source = isRecord(input) ? input : {};
   return {
     enabled: source.enabled !== false,
+    repository_url: optionalTrimmedString(source.repository_url),
+    previous_commit: optionalTrimmedString(source.previous_commit),
+    latest_commit: optionalTrimmedString(source.latest_commit),
   };
+}
+
+function validateReleaseNotesConfig(config: ReleaseNotesNotificationConfig): void {
+  const rangeValues = [config.repository_url, config.previous_commit, config.latest_commit];
+  const configuredValues = rangeValues.filter(Boolean).length;
+  if (configuredValues !== 0 && configuredValues !== rangeValues.length) {
+    throw new ApiError(
+      'repository_url, previous_commit, and latest_commit must all be set or all be empty',
+      400,
+      'INCOMPLETE_RELEASE_NOTES_COMPARE',
+    );
+  }
+  if (configuredValues === 0) return;
+
+  let repositoryUrl: URL;
+  try {
+    repositoryUrl = new URL(config.repository_url as string);
+  } catch {
+    throw new ApiError(
+      'release notes repository_url must be a valid GitHub repository URL',
+      400,
+      'INVALID_RELEASE_NOTES_REPOSITORY',
+    );
+  }
+  const pathParts = repositoryUrl.pathname.replace(/\.git\/?$/i, '').split('/').filter(Boolean);
+  if (
+    repositoryUrl.protocol !== 'https:' ||
+    repositoryUrl.hostname.toLowerCase() !== 'github.com' ||
+    pathParts.length !== 2 ||
+    repositoryUrl.search ||
+    repositoryUrl.hash
+  ) {
+    throw new ApiError(
+      'release notes repository_url must be an https://github.com/<owner>/<repository> URL',
+      400,
+      'INVALID_RELEASE_NOTES_REPOSITORY',
+    );
+  }
+
+  const commitPattern = /^[0-9a-f]{7,40}$/i;
+  if (!commitPattern.test(config.previous_commit as string)) {
+    throw new ApiError(
+      'release notes previous_commit must be a 7 to 40 character commit SHA',
+      400,
+      'INVALID_RELEASE_NOTES_PREVIOUS_COMMIT',
+    );
+  }
+  if (!commitPattern.test(config.latest_commit as string)) {
+    throw new ApiError(
+      'release notes latest_commit must be a 7 to 40 character commit SHA',
+      400,
+      'INVALID_RELEASE_NOTES_LATEST_COMMIT',
+    );
+  }
 }
 
 export const GET = withErrorHandler(async (request: NextRequest) => {
@@ -273,8 +338,10 @@ export const PATCH = withErrorHandler(async (request: NextRequest) => {
       : null;
     if (hasVictoropsUpdate) update.slack_victorops_escalation_agent_id = nextVictoropsAgentId;
 
-    if (body.release_notes) {
-      update.release_notes = normalizeReleaseNotesConfig(body.release_notes);
+    if (Object.prototype.hasOwnProperty.call(body, 'release_notes')) {
+      const releaseNotesConfig = normalizeReleaseNotesConfig(body.release_notes);
+      validateReleaseNotesConfig(releaseNotesConfig);
+      update.release_notes = releaseNotesConfig;
     }
 
     // Slack and Webex discovery caches are configured independently.

--- a/ui/src/app/api/release-notes/__tests__/route.test.ts
+++ b/ui/src/app/api/release-notes/__tests__/route.test.ts
@@ -3,6 +3,12 @@
  */
 import { NextRequest } from "next/server";
 
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
 const RAW_BASE = "https://raw.githubusercontent.com/caipe-io/ai-platform-engineering/main/docs/releases";
 
 const LISTING = [
@@ -76,7 +82,14 @@ async function callGet(version: string) {
 }
 
 describe("/api/release-notes", () => {
-  afterEach(() => jest.restoreAllMocks());
+  beforeEach(() => jest.clearAllMocks());
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    delete process.env.RELEASE_NOTES_GITHUB_TOKEN;
+    delete process.env.GITHUB_PERSONAL_ACCESS_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+  });
 
   it("returns the series notes with frontmatter and truncate marker stripped", async () => {
     const data = await callGet("0.5.0");
@@ -108,6 +121,85 @@ describe("/api/release-notes", () => {
     expect(data.matchedVersion).toBeNull();
     expect(data.body).toBeNull();
     expect(data.source).toBe("none");
+  });
+
+  it("builds release notes from an explicitly configured GitHub commit range", async () => {
+    jest.resetModules();
+    process.env.RELEASE_NOTES_GITHUB_TOKEN = "test-token";
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue({
+        _id: "platform_settings",
+        release_notes: {
+          repository_url: "https://github.com/example/repository",
+          previous_commit: "1111111",
+          latest_commit: "3333333",
+        },
+      }),
+    });
+    global.fetch = jest.fn(async (_url: string | URL, init?: RequestInit) => ({
+      ok: true,
+      json: async () => ({
+        commits: [
+          {
+            sha: "2222222",
+            commit: {
+              message: "feat(ui): add a useful setting (#42)",
+              committer: { date: "2026-08-14T12:00:00Z" },
+            },
+          },
+          {
+            sha: "3333333",
+            commit: {
+              message: "fix(api): handle invalid input",
+              committer: { date: "2026-08-15T12:00:00Z" },
+            },
+          },
+        ],
+      }),
+      headers: init?.headers,
+    })) as unknown as typeof fetch;
+
+    const { GET } = await import("../route");
+    const response = await GET(
+      new NextRequest("http://localhost/api/release-notes?version=1.0.0-outshift.1&compare=platform"),
+    );
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toMatchObject({
+      requestedVersion: "1.0.0-outshift.1",
+      matchedVersion: "1.0.0-outshift.1",
+      source: "github-compare",
+      date: "2026-08-15",
+      changelogUrl: "https://github.com/example/repository/compare/1111111...3333333",
+    });
+    expect(data.body).toContain("## What's New");
+    expect(data.body).toContain("add a useful setting");
+    expect(data.body).toContain("## Bug Fixes");
+    expect(global.fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/repos/example/repository/compare/1111111...3333333"),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: "Bearer test-token" }),
+      }),
+    );
+  });
+
+  it("rejects an incomplete stored GitHub compare configuration", async () => {
+    jest.resetModules();
+    mockGithub();
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue({
+        _id: "platform_settings",
+        release_notes: { previous_commit: "1111111" },
+      }),
+    });
+    const { GET } = await import("../route");
+    const response = await GET(
+      new NextRequest("http://localhost/api/release-notes?version=1.0.0-outshift.1&compare=platform"),
+    );
+
+    expect(response.status).toBe(400);
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it("returns 400 when no version is provided", async () => {

--- a/ui/src/app/api/release-notes/route.ts
+++ b/ui/src/app/api/release-notes/route.ts
@@ -2,6 +2,9 @@ import fs from "fs";
 import { NextRequest,NextResponse } from "next/server";
 import path from "path";
 
+import { getCollection } from "@/lib/mongodb";
+import { PLATFORM_CONFIG_ID } from "@/lib/platform-default-agent";
+
 export const dynamic = "force-dynamic";
 
 const GITHUB_OWNER = "cnoe-io";
@@ -17,6 +20,8 @@ const RELEASE_FILE_PATTERN = /release-(\d+)-(\d+)-(\d+)\.mdx?$/i;
 
 const LISTING_TTL_MS = 10 * 60 * 1000;
 const CONTENT_TTL_MS = 10 * 60 * 1000;
+const COMPARE_TTL_MS = 10 * 60 * 1000;
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{7,40}$/i;
 
 interface ReleaseFile {
   name: string;
@@ -35,11 +40,37 @@ interface CachedContent {
   body: string;
 }
 
+interface GithubCompareCommit {
+  sha: string;
+  commit?: {
+    message?: string;
+    author?: { date?: string | null } | null;
+    committer?: { date?: string | null } | null;
+  };
+}
+
+interface GithubComparePage {
+  commits?: GithubCompareCommit[];
+}
+
+interface CompareReleaseNotes {
+  title: string;
+  date: string;
+  body: string;
+  changelogUrl: string;
+}
+
+interface CachedCompare {
+  at: number;
+  notes: CompareReleaseNotes;
+}
+
 // Module-level caches keep us well under the unauthenticated GitHub rate limit
 // (the dialog is fetched once per user session). They are best-effort and reset
 // on cold start.
 let listingCache: CachedListing | null = null;
 const contentCache = new Map<string, CachedContent>();
+const compareCache = new Map<string, CachedCompare>();
 
 export interface ReleaseNotesResponse {
   requestedVersion: string;
@@ -47,12 +78,249 @@ export interface ReleaseNotesResponse {
   title: string | null;
   date: string | null;
   body: string | null;
-  source: "github" | "local" | "none";
+  source: "generated" | "github-compare" | "github" | "local" | "none";
+  changelogUrl: string | null;
+}
+
+interface MainIncrementReleaseNotes {
+  version: string;
+  title: string;
+  date: string;
+  body: string;
+  changelogUrl: string;
+}
+
+interface GithubRepository {
+  owner: string;
+  repository: string;
+}
+
+interface ConfiguredGithubCompare {
+  repository: GithubRepository;
+  previousCommit: string;
+  latestCommit: string;
+}
+
+function parseGithubRepositoryUrl(value: string): GithubRepository | null {
+  try {
+    const url = new URL(value);
+    const parts = url.pathname.replace(/\.git\/?$/i, "").split("/").filter(Boolean);
+    if (
+      url.protocol !== "https:" ||
+      url.hostname.toLowerCase() !== "github.com" ||
+      parts.length !== 2 ||
+      url.search ||
+      url.hash
+    ) {
+      return null;
+    }
+    return { owner: parts[0], repository: parts[1] };
+  } catch {
+    return null;
+  }
+}
+
+async function readConfiguredGithubCompare(): Promise<ConfiguredGithubCompare | null> {
+  const collection = await getCollection<{ _id: string; release_notes?: unknown }>("platform_config");
+  const document = await collection.findOne({ _id: PLATFORM_CONFIG_ID } as never);
+  if (!document?.release_notes || typeof document.release_notes !== "object") return null;
+  const config = document.release_notes as Record<string, unknown>;
+  const repositoryUrl = typeof config.repository_url === "string" ? config.repository_url.trim() : "";
+  const previousCommit = typeof config.previous_commit === "string" ? config.previous_commit.trim() : "";
+  const latestCommit = typeof config.latest_commit === "string" ? config.latest_commit.trim() : "";
+  const repository = parseGithubRepositoryUrl(repositoryUrl);
+  if (
+    !repository ||
+    !COMMIT_SHA_PATTERN.test(previousCommit) ||
+    !COMMIT_SHA_PATTERN.test(latestCommit)
+  ) {
+    return null;
+  }
+  return { repository, previousCommit, latestCommit };
+}
+
+function markdownText(value: string): string {
+  return value.replace(/([\\`*_[\]<>])/g, "\\$1");
+}
+
+function classifyCommitSubject(subject: string): {
+  category: "features" | "fixes" | "security" | "performance" | "docs" | "maintenance";
+  pullRequest: string | null;
+  scope: string | null;
+  text: string;
+} {
+  const pullRequestMatch = subject.match(/\s+\(#(\d+)\)$/);
+  const pullRequest = pullRequestMatch?.[1] ?? null;
+  const withoutPullRequest = pullRequestMatch
+    ? subject.slice(0, pullRequestMatch.index).trim()
+    : subject.trim();
+  const conventional = withoutPullRequest.match(
+    /^(feat|fix|docs|perf|security|refactor|chore|build|ci|test)(?:\(([^)]+)\))?:\s*(.+)$/i,
+  );
+  if (!conventional) {
+    return { category: "maintenance", pullRequest, scope: null, text: withoutPullRequest };
+  }
+
+  const [, rawType, scope, text] = conventional;
+  const type = rawType.toLowerCase();
+  const category =
+    type === "feat"
+      ? "features"
+      : type === "fix"
+        ? "fixes"
+        : type === "security"
+          ? "security"
+          : type === "docs"
+            ? "docs"
+            : type === "perf"
+              ? "performance"
+              : "maintenance";
+  return { category, pullRequest, scope: scope ?? null, text };
+}
+
+function renderCompareMarkdown(
+  commits: GithubCompareCommit[],
+  repository: GithubRepository,
+  previousCommit: string,
+  latestCommit: string,
+  compareUrl: string,
+): string {
+  const groups = new Map<
+    ReturnType<typeof classifyCommitSubject>["category"],
+    { heading: string; entries: string[] }
+  >([
+    ["features", { heading: "What's New", entries: [] }],
+    ["fixes", { heading: "Bug Fixes", entries: [] }],
+    ["security", { heading: "Security", entries: [] }],
+    ["performance", { heading: "Performance", entries: [] }],
+    ["docs", { heading: "Documentation", entries: [] }],
+    ["maintenance", { heading: "Maintenance", entries: [] }],
+  ]);
+
+  for (const commit of commits) {
+    const subject = commit.commit?.message?.split("\n", 1)[0]?.trim() || commit.sha;
+    const change = classifyCommitSubject(subject);
+    const scope = change.scope ? `**${markdownText(change.scope)}**: ` : "";
+    const target = change.pullRequest
+      ? `https://github.com/${repository.owner}/${repository.repository}/pull/${change.pullRequest}`
+      : `https://github.com/${repository.owner}/${repository.repository}/commit/${commit.sha}`;
+    const label = change.pullRequest ? `#${change.pullRequest}` : commit.sha.slice(0, 9);
+    groups.get(change.category)?.entries.push(
+      `- ${scope}${markdownText(change.text)} ([${label}](${target}))`,
+    );
+  }
+
+  const sections = [
+    `> Changes from \`${previousCommit.slice(0, 12)}\` through \`${latestCommit.slice(0, 12)}\`.`,
+  ];
+  for (const { heading, entries } of groups.values()) {
+    if (entries.length > 0) sections.push(`## ${heading}\n\n${entries.join("\n")}`);
+  }
+  if (commits.length === 0) {
+    sections.push("## Maintenance\n\nNo changes were found in the configured commit range.");
+  }
+  sections.push(`[Compare all changes](${compareUrl})`);
+  return sections.join("\n\n");
+}
+
+async function readGithubCompareReleaseNotes(
+  repository: GithubRepository,
+  previousCommit: string,
+  latestCommit: string,
+): Promise<CompareReleaseNotes | null> {
+  const cacheKey = `${repository.owner}/${repository.repository}:${previousCommit}...${latestCommit}`;
+  const cached = compareCache.get(cacheKey);
+  if (cached && Date.now() - cached.at < COMPARE_TTL_MS) return cached.notes;
+
+  const commits: GithubCompareCommit[] = [];
+  const compareUrl = `https://github.com/${repository.owner}/${repository.repository}/compare/${previousCommit}...${latestCommit}`;
+  // Prefer the UI's standard GitHub token. The PAT name remains a compatibility
+  // fallback for older Compose deployments.
+  const token =
+    process.env.RELEASE_NOTES_GITHUB_TOKEN?.trim() ||
+    process.env.GITHUB_TOKEN?.trim() ||
+    process.env.GITHUB_PERSONAL_ACCESS_TOKEN?.trim();
+  const headers: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "X-GitHub-Api-Version": "2022-11-28",
+  };
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  try {
+    for (let page = 1; page <= 10; page += 1) {
+      const controller = new AbortController();
+      const timeout = setTimeout(() => controller.abort(), 10000);
+      const apiUrl =
+        `https://api.github.com/repos/${encodeURIComponent(repository.owner)}/` +
+        `${encodeURIComponent(repository.repository)}/compare/${previousCommit}...${latestCommit}` +
+        `?per_page=100&page=${page}`;
+      let response: Response;
+      try {
+        response = await fetch(apiUrl, {
+          signal: controller.signal,
+          headers,
+          cache: "no-store",
+        });
+      } finally {
+        clearTimeout(timeout);
+      }
+      if (!response.ok) {
+        console.warn(
+          `[Release Notes API] GitHub compare failed for ${repository.owner}/${repository.repository}: ${response.status}`,
+        );
+        return null;
+      }
+      const payload = (await response.json()) as GithubComparePage;
+      const pageCommits = Array.isArray(payload.commits) ? payload.commits : [];
+      commits.push(
+        ...pageCommits.filter(
+          (commit): commit is GithubCompareCommit =>
+            typeof commit?.sha === "string" && COMMIT_SHA_PATTERN.test(commit.sha),
+        ),
+      );
+      if (pageCommits.length < 100) break;
+    }
+  } catch (error) {
+    console.warn("[Release Notes API] GitHub compare request failed:", error);
+    return null;
+  }
+
+  const lastCommit = commits.at(-1);
+  const dateValue = lastCommit?.commit?.committer?.date ?? lastCommit?.commit?.author?.date ?? null;
+  const notes: CompareReleaseNotes = {
+    title: `Changes ${previousCommit.slice(0, 9)} → ${latestCommit.slice(0, 9)}`,
+    date: dateValue ? dateValue.slice(0, 10) : new Date().toISOString().slice(0, 10),
+    body: renderCompareMarkdown(commits, repository, previousCommit, latestCommit, compareUrl),
+    changelogUrl: compareUrl,
+  };
+  compareCache.set(cacheKey, { at: Date.now(), notes });
+  return notes;
 }
 
 /** Strip a leading `v` and any pre-release / build suffix (`-dev.14`, `-rc.1`). */
 function baseVersion(value: string): string {
   return value.trim().replace(/^v/i, "").split(/[-+]/)[0];
+}
+
+function readMainIncrementReleaseNotes(requestedVersion: string): MainIncrementReleaseNotes | null {
+  const notesPath = path.join(process.cwd(), "public", "main-increment-release-notes.json");
+  try {
+    if (!fs.existsSync(notesPath)) return null;
+    const parsed = JSON.parse(fs.readFileSync(notesPath, "utf8")) as Partial<MainIncrementReleaseNotes>;
+    if (
+      parsed.version !== requestedVersion ||
+      typeof parsed.title !== "string" ||
+      typeof parsed.date !== "string" ||
+      typeof parsed.body !== "string" ||
+      typeof parsed.changelogUrl !== "string"
+    ) {
+      return null;
+    }
+    return parsed as MainIncrementReleaseNotes;
+  } catch (error) {
+    console.warn("[Release Notes API] Generated main increment notes are invalid:", error);
+    return null;
+  }
 }
 
 function buildReleaseFile(name: string, rawUrl: string, localPath?: string): ReleaseFile | null {
@@ -211,6 +479,7 @@ function parseFrontmatter(raw: string): { title: string | null; date: string | n
 export async function GET(request: NextRequest) {
   const requestedVersionRaw = request.nextUrl.searchParams.get("version") ?? "";
   const requestedVersion = requestedVersionRaw.trim();
+  const useConfiguredCompare = request.nextUrl.searchParams.get("compare") === "platform";
   const empty: ReleaseNotesResponse = {
     requestedVersion,
     matchedVersion: null,
@@ -218,6 +487,7 @@ export async function GET(request: NextRequest) {
     date: null,
     body: null,
     source: "none",
+    changelogUrl: null,
   };
 
   if (!requestedVersion) {
@@ -225,6 +495,40 @@ export async function GET(request: NextRequest) {
   }
 
   try {
+    if (useConfiguredCompare) {
+      const configuredCompare = await readConfiguredGithubCompare();
+      if (!configuredCompare) return NextResponse.json(empty, { status: 400 });
+      const { repository, previousCommit, latestCommit } = configuredCompare;
+      const compareNotes = await readGithubCompareReleaseNotes(
+        repository,
+        previousCommit,
+        latestCommit,
+      );
+      if (!compareNotes) return NextResponse.json(empty, { status: 502 });
+      return NextResponse.json({
+        requestedVersion,
+        matchedVersion: requestedVersion,
+        title: compareNotes.title,
+        date: compareNotes.date,
+        body: compareNotes.body,
+        source: "github-compare",
+        changelogUrl: compareNotes.changelogUrl,
+      } satisfies ReleaseNotesResponse);
+    }
+
+    const generated = readMainIncrementReleaseNotes(requestedVersion);
+    if (generated) {
+      return NextResponse.json({
+        requestedVersion,
+        matchedVersion: generated.version,
+        title: generated.title,
+        date: generated.date,
+        body: generated.body,
+        source: "generated",
+        changelogUrl: generated.changelogUrl,
+      } satisfies ReleaseNotesResponse);
+    }
+
     const files = await getReleaseFiles();
     const selected = selectRelease(files, baseVersion(requestedVersion));
     if (!selected) {
@@ -248,6 +552,7 @@ export async function GET(request: NextRequest) {
       date,
       body,
       source: content.source,
+      changelogUrl: null,
     };
     return NextResponse.json(result);
   } catch (error) {

--- a/ui/src/components/settings/ReleaseNotesPreview.tsx
+++ b/ui/src/components/settings/ReleaseNotesPreview.tsx
@@ -2,7 +2,13 @@
 
 import { ReleaseUpgradeDialog } from "@/components/release/ReleaseUpgradeDialog";
 import { Button } from "@/components/ui/button";
-import type { ReleaseMarkdown,ReleaseNote } from "@/hooks/use-release-upgrade-prompt";
+import {
+  hasConfiguredReleaseNotesCompare,
+  releaseNotesRequestUrl,
+  type ReleaseMarkdown,
+  type ReleaseNote,
+  type ReleaseNotesNotificationConfig,
+} from "@/hooks/use-release-upgrade-prompt";
 import { Eye,Loader2 } from "lucide-react";
 import { useState } from "react";
 
@@ -26,9 +32,10 @@ export function ReleaseNotesPreview({ isAdmin }: { isAdmin: boolean }): React.Re
     setLoading(true);
     setOpen(true);
     try {
-      const [versionResponse,changelogResponse] = await Promise.all([
+      const [versionResponse,changelogResponse,platformConfigResponse] = await Promise.all([
         fetch("/api/version"),
         fetch("/api/changelog"),
+        fetch("/api/admin/platform-config"),
       ]);
       const versionPayload = versionResponse.ok ? await versionResponse.json() : null;
       const nextVersion =
@@ -38,26 +45,36 @@ export function ReleaseNotesPreview({ isAdmin }: { isAdmin: boolean }): React.Re
       setVersion(nextVersion);
 
       const changelogPayload = changelogResponse.ok ? await changelogResponse.json() : null;
-      const match: ReleaseNote | null = changelogPayload?.releases?.find(
-        (item: ReleaseNote) => normalizeVersion(item.version) === nextVersion,
-      ) ?? null;
+      const platformConfigPayload = platformConfigResponse.ok
+        ? await platformConfigResponse.json()
+        : null;
+      const releaseNotesConfig: Partial<ReleaseNotesNotificationConfig> =
+        platformConfigPayload?.data?.release_notes ?? {};
+      const customCompareConfigured = hasConfiguredReleaseNotesCompare(releaseNotesConfig);
+      const match: ReleaseNote | null = customCompareConfigured
+        ? null
+        : changelogPayload?.releases?.find(
+            (item: ReleaseNote) => normalizeVersion(item.version) === nextVersion,
+          ) ?? null;
       setRelease(match);
 
       if (match) {
         setMarkdown(null);
       } else {
         const notesResponse = await fetch(
-          `/api/release-notes?version=${encodeURIComponent(nextVersion)}`,
+          releaseNotesRequestUrl(nextVersion, releaseNotesConfig),
         );
         const notesPayload = notesResponse.ok ? await notesResponse.json() : null;
         const exactMatch =
           Boolean(notesPayload?.body) &&
-          normalizeVersion(notesPayload?.matchedVersion) === baseVersion(nextVersion);
+          (customCompareConfigured ||
+            normalizeVersion(notesPayload?.matchedVersion) === baseVersion(nextVersion));
         setMarkdown(exactMatch ? {
           matchedVersion: notesPayload.matchedVersion ?? null,
           title: notesPayload.title ?? null,
           date: notesPayload.date ?? null,
           body: notesPayload.body,
+          changelogUrl: notesPayload.changelogUrl ?? null,
         } : null);
       }
     } catch (error) {

--- a/ui/src/components/settings/sections/PlatformAnnouncementsSettings.tsx
+++ b/ui/src/components/settings/sections/PlatformAnnouncementsSettings.tsx
@@ -1,27 +1,52 @@
 "use client";
 
+import { ReleaseNotesPreview } from "@/components/settings/ReleaseNotesPreview";
 import { AutoSaveStatus } from "@/components/settings/shared/AutoSaveStatus";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
 import { SettingsSwitch } from "@/components/settings/shared/SettingsSwitch";
+import { SaveButton } from "@/components/admin/shared/SaveButton";
 import { useKeyedAutoSave } from "@/hooks/use-keyed-auto-save";
+import { Input } from "@/components/ui/input";
 import { Loader2,Megaphone } from "lucide-react";
 import { useEffect,useRef,useState } from "react";
 
 type PlatformAnnouncementKey = "release-notes";
 
-async function persistPlatformAnnouncement(
-  _: PlatformAnnouncementKey,
-  value: boolean,
-): Promise<void> {
-  const response = await fetch("/api/admin/platform-config",{
-    method: "PATCH",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ release_notes: { enabled: value } }),
-  });
-  const data = await response.json();
-  if (!response.ok || !data.success) {
-    throw new Error(data.error || "Could not update platform announcements");
+interface CompareFields {
+  repositoryUrl: string;
+  previousCommit: string;
+  latestCommit: string;
+}
+
+function validateCompareFields(fields: CompareFields): string | null {
+  const values = [fields.repositoryUrl.trim(),fields.previousCommit.trim(),fields.latestCommit.trim()];
+  const configured = values.filter(Boolean).length;
+  if (configured !== 0 && configured !== 3) {
+    return "Set the repository URL and both commits, or leave all three empty.";
   }
+  if (configured === 0) return null;
+
+  try {
+    const repository = new URL(values[0]);
+    const pathParts = repository.pathname.replace(/\.git\/?$/i,"").split("/").filter(Boolean);
+    if (
+      repository.protocol !== "https:" ||
+      repository.hostname.toLowerCase() !== "github.com" ||
+      pathParts.length !== 2 ||
+      repository.search ||
+      repository.hash
+    ) {
+      return "Enter an https://github.com/<owner>/<repository> URL.";
+    }
+  } catch {
+    return "Enter an https://github.com/<owner>/<repository> URL.";
+  }
+
+  const commitPattern = /^[0-9a-f]{7,40}$/i;
+  if (!commitPattern.test(values[1]) || !commitPattern.test(values[2])) {
+    return "Enter commit SHAs containing 7 to 40 hexadecimal characters.";
+  }
+  return null;
 }
 
 export function PlatformAnnouncementsSettings({
@@ -33,6 +58,55 @@ export function PlatformAnnouncementsSettings({
   const [loading,setLoading] = useState(true);
   const [loadError,setLoadError] = useState<string | null>(null);
   const committedRef = useRef(true);
+
+  const [repositoryUrl,setRepositoryUrl] = useState("");
+  const [savedRepositoryUrl,setSavedRepositoryUrl] = useState("");
+  const [previousCommit,setPreviousCommit] = useState("");
+  const [savedPreviousCommit,setSavedPreviousCommit] = useState("");
+  const [latestCommit,setLatestCommit] = useState("");
+  const [savedLatestCommit,setSavedLatestCommit] = useState("");
+  const [savingConfig,setSavingConfig] = useState(false);
+  const [configSaveResult,setConfigSaveResult] = useState<"success" | "error" | null>(null);
+  const [configSaveError,setConfigSaveError] = useState<string | null>(null);
+  const compareRef = useRef<CompareFields>({
+    repositoryUrl: "",
+    previousCommit: "",
+    latestCommit: "",
+  });
+
+  const setCompareField = (field: keyof CompareFields,value: string): void => {
+    compareRef.current[field] = value;
+    const setters = {
+      repositoryUrl: setRepositoryUrl,
+      previousCommit: setPreviousCommit,
+      latestCommit: setLatestCommit,
+    } as const;
+    setters[field](value);
+  };
+
+  const persistPlatformAnnouncement = async (
+    _: PlatformAnnouncementKey,
+    value: boolean,
+  ): Promise<void> => {
+    const compare = compareRef.current;
+    const response = await fetch("/api/admin/platform-config",{
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        release_notes: {
+          enabled: value,
+          repository_url: compare.repositoryUrl.trim() || null,
+          previous_commit: compare.previousCommit.trim() || null,
+          latest_commit: compare.latestCommit.trim() || null,
+        },
+      }),
+    });
+    const data = await response.json();
+    if (!response.ok || !data.success) {
+      throw new Error(data.error || "Could not update platform announcements");
+    }
+  };
+
   const autoSave = useKeyedAutoSave<PlatformAnnouncementKey,boolean>({
     persist: persistPlatformAnnouncement,
     onSuccess: (_,value) => {
@@ -52,9 +126,22 @@ export function PlatformAnnouncementsSettings({
           throw new Error(data.error || "Could not load platform announcements");
         }
         if (cancelled) return;
-        const value = data.data?.release_notes?.enabled !== false;
+        const config = data.data?.release_notes;
+        const value = config?.enabled !== false;
+        const nextCompare: CompareFields = {
+          repositoryUrl: config?.repository_url?.trim() ?? "",
+          previousCommit: config?.previous_commit?.trim() ?? "",
+          latestCommit: config?.latest_commit?.trim() ?? "",
+        };
         committedRef.current = value;
+        compareRef.current = nextCompare;
         setEnabled(value);
+        setRepositoryUrl(nextCompare.repositoryUrl);
+        setSavedRepositoryUrl(nextCompare.repositoryUrl);
+        setPreviousCommit(nextCompare.previousCommit);
+        setSavedPreviousCommit(nextCompare.previousCommit);
+        setLatestCommit(nextCompare.latestCommit);
+        setSavedLatestCommit(nextCompare.latestCommit);
       })
       .catch((reason: unknown) => {
         if (!cancelled) {
@@ -73,11 +160,58 @@ export function PlatformAnnouncementsSettings({
     setEnabled(value);
     autoSave.enqueue("release-notes",value);
   };
+
   const retry = () => {
     const pendingValue = autoSave.pendingValueFor("release-notes");
     if (pendingValue !== undefined) setEnabled(pendingValue);
     autoSave.retry("release-notes");
   };
+
+  const saveCompareConfig = async (): Promise<void> => {
+    const fields = compareRef.current;
+    const validationError = validateCompareFields(fields);
+    if (validationError) {
+      setConfigSaveResult("error");
+      setConfigSaveError(validationError);
+      return;
+    }
+
+    setSavingConfig(true);
+    setConfigSaveResult(null);
+    setConfigSaveError(null);
+    try {
+      const response = await fetch("/api/admin/platform-config",{
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          release_notes: {
+            enabled,
+            repository_url: fields.repositoryUrl.trim() || null,
+            previous_commit: fields.previousCommit.trim() || null,
+            latest_commit: fields.latestCommit.trim() || null,
+          },
+        }),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error?.message || data.error || "Could not save release notes configuration");
+      }
+      setSavedRepositoryUrl(fields.repositoryUrl);
+      setSavedPreviousCommit(fields.previousCommit);
+      setSavedLatestCommit(fields.latestCommit);
+      setConfigSaveResult("success");
+    } catch (reason) {
+      setConfigSaveResult("error");
+      setConfigSaveError(reason instanceof Error ? reason.message : "Could not save release notes configuration");
+    } finally {
+      setSavingConfig(false);
+    }
+  };
+
+  const compareDirty =
+    repositoryUrl !== savedRepositoryUrl ||
+    previousCommit !== savedPreviousCommit ||
+    latestCommit !== savedLatestCommit;
 
   return (
     <SettingsCard
@@ -90,7 +224,7 @@ export function PlatformAnnouncementsSettings({
           Loading platform setting…
         </div>
       ) : (
-        <div className="space-y-3">
+        <div className="space-y-4">
           {loadError ? (
             <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm text-destructive">
               {loadError}
@@ -116,6 +250,62 @@ export function PlatformAnnouncementsSettings({
               testId="release-notes-platform-toggle"
             />
           </div>
+
+          <div className="space-y-3 rounded-lg border border-border/70 p-4">
+            <div>
+              <p className="text-sm font-medium">Optional GitHub commit diff</p>
+              <p className="mt-1 text-xs text-muted-foreground">
+                Set all three fields to show changes between two commits. This works for standard and non-standard release tags.
+                Leave them empty to use the deployed-version release notes.
+              </p>
+            </div>
+            <label className="block space-y-1 text-xs font-medium" htmlFor="release-notes-repository-url">
+              <span>Repository URL</span>
+              <Input
+                id="release-notes-repository-url"
+                value={repositoryUrl}
+                onChange={(event) => setCompareField("repositoryUrl",event.target.value)}
+                placeholder="https://github.com/example/repository"
+                disabled={readOnly}
+                spellCheck={false}
+              />
+            </label>
+            <div className="grid gap-3 sm:grid-cols-2">
+              <label className="block space-y-1 text-xs font-medium" htmlFor="release-notes-previous-commit">
+                <span>Previous upgraded commit</span>
+                <Input
+                  id="release-notes-previous-commit"
+                  value={previousCommit}
+                  onChange={(event) => setCompareField("previousCommit",event.target.value)}
+                  placeholder="Previous commit SHA"
+                  disabled={readOnly}
+                  spellCheck={false}
+                />
+              </label>
+              <label className="block space-y-1 text-xs font-medium" htmlFor="release-notes-latest-commit">
+                <span>Latest commit</span>
+                <Input
+                  id="release-notes-latest-commit"
+                  value={latestCommit}
+                  onChange={(event) => setCompareField("latestCommit",event.target.value)}
+                  placeholder="Latest commit SHA"
+                  disabled={readOnly}
+                  spellCheck={false}
+                />
+              </label>
+            </div>
+            {configSaveError ? <p className="text-xs text-destructive" role="alert">{configSaveError}</p> : null}
+            <SaveButton
+              ariaLabel="Save release notes configuration"
+              dirty={compareDirty}
+              disabled={readOnly}
+              onSave={() => void saveCompareConfig()}
+              result={configSaveResult}
+              saving={savingConfig}
+            />
+          </div>
+
+          <ReleaseNotesPreview isAdmin />
         </div>
       )}
     </SettingsCard>

--- a/ui/src/components/settings/sections/__tests__/NotificationsSettings.test.tsx
+++ b/ui/src/components/settings/sections/__tests__/NotificationsSettings.test.tsx
@@ -214,7 +214,7 @@ describe("PlatformAnnouncementsSettings",() => {
     jest.clearAllMocks();
   });
 
-  it("auto-saves only the platform release announcement flag",async () => {
+  it("auto-saves the platform release announcement flag with its compare config",async () => {
     const fetchMock = jest.fn(async (_input: RequestInfo | URL,init?: RequestInit) => {
       if (init?.method === "PATCH") return jsonResponse({ success: true,data: {} });
       return jsonResponse({
@@ -234,7 +234,54 @@ describe("PlatformAnnouncementsSettings",() => {
         "/api/admin/platform-config",
         expect.objectContaining({
           method: "PATCH",
-          body: JSON.stringify({ release_notes: { enabled: false } }),
+          body: JSON.stringify({
+            release_notes: {
+              enabled: false,
+              repository_url: null,
+              previous_commit: null,
+              latest_commit: null,
+            },
+          }),
+        }),
+      );
+    });
+  });
+
+  it("saves the optional GitHub commit range",async () => {
+    const fetchMock = jest.fn(async (_input: RequestInfo | URL,init?: RequestInit) => {
+      if (init?.method === "PATCH") return jsonResponse({ success: true,data: {} });
+      return jsonResponse({
+        success: true,
+        data: { release_notes: { enabled: true } },
+      });
+    });
+    global.fetch = fetchMock;
+    render(<PlatformAnnouncementsSettings />);
+
+    fireEvent.change(await screen.findByLabelText("Repository URL"), {
+      target: { value: "https://github.com/example/repository" },
+    });
+    fireEvent.change(screen.getByLabelText("Previous upgraded commit"), {
+      target: { value: "1111111" },
+    });
+    fireEvent.change(screen.getByLabelText("Latest commit"), {
+      target: { value: "2222222" },
+    });
+    fireEvent.click(screen.getByRole("button",{ name: "Save release notes configuration" }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/admin/platform-config",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({
+            release_notes: {
+              enabled: true,
+              repository_url: "https://github.com/example/repository",
+              previous_commit: "1111111",
+              latest_commit: "2222222",
+            },
+          }),
         }),
       );
     });

--- a/ui/src/hooks/use-release-upgrade-prompt.ts
+++ b/ui/src/hooks/use-release-upgrade-prompt.ts
@@ -22,6 +22,7 @@ export interface ReleaseMarkdown {
   title: string | null;
   date: string | null;
   body: string;
+  changelogUrl?: string | null;
 }
 
 interface ReleaseNotesResponse {
@@ -29,6 +30,8 @@ interface ReleaseNotesResponse {
   title?: string | null;
   date?: string | null;
   body?: string | null;
+  changelogUrl?: string | null;
+  source?: string | null;
 }
 
 interface SettingsResponse {
@@ -47,6 +50,9 @@ interface ChangelogResponse {
 
 export interface ReleaseNotesNotificationConfig {
   enabled: boolean;
+  repository_url: string | null;
+  previous_commit: string | null;
+  latest_commit: string | null;
 }
 
 interface PlatformConfigResponse {
@@ -91,6 +97,33 @@ function sessionSkipKey(version: string): string {
   return `release-notes:${version}:skip`;
 }
 
+export function hasConfiguredReleaseNotesCompare(
+  config?: Partial<ReleaseNotesNotificationConfig> | null,
+): config is Partial<ReleaseNotesNotificationConfig> & {
+  repository_url: string;
+  previous_commit: string;
+  latest_commit: string;
+} {
+  return Boolean(
+    config?.repository_url?.trim() &&
+      config.previous_commit?.trim() &&
+      config.latest_commit?.trim(),
+  );
+}
+
+export function releaseNotesRequestUrl(
+  version: string,
+  config?: Partial<ReleaseNotesNotificationConfig> | null,
+): string {
+  const params = new URLSearchParams({ version });
+  if (hasConfiguredReleaseNotesCompare(config)) {
+    // The API resolves the stored platform config server-side so callers
+    // cannot use the UI server's GitHub token to compare an arbitrary repo.
+    params.set("compare", "platform");
+  }
+  return `/api/release-notes?${params.toString()}`;
+}
+
 function notificationsEnabledFromSettings(settings: SettingsResponse | null): boolean {
   // User-scoped opt-out. Defaults to enabled unless the user has explicitly
   // turned release note notifications off for their own account.
@@ -110,6 +143,7 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
   const deployedReleaseVersion = useMemo(() => resolvePromptVersion(versionInfo), [versionInfo]);
 
   const [releaseVersion, setReleaseVersion] = useState<string | null>(null);
+  const [announcementId, setAnnouncementId] = useState<string | null>(null);
   const [release, setRelease] = useState<ReleaseNote | null>(null);
   const [releaseMarkdown, setReleaseMarkdown] = useState<ReleaseMarkdown | null>(null);
   const [open, setOpen] = useState(false);
@@ -158,10 +192,12 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
         // Platform-wide switch (admin) AND the per-user opt-out (Admin →
         // General) must both be on, and we must know which version is deployed.
         const platformEnabled = platformConfigPayload?.data?.release_notes?.enabled !== false;
+        const releaseNotesConfig = platformConfigPayload?.data?.release_notes;
         const userNotificationsEnabled = notificationsEnabledFromSettings(settingsPayload);
 
         if (!platformEnabled || !userNotificationsEnabled || !deployedReleaseVersion) {
           setReleaseVersion(null);
+          setAnnouncementId(null);
           setRelease(null);
           setReleaseMarkdown(null);
           setOpen(false);
@@ -169,12 +205,17 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
         }
 
         const activeReleaseVersion = deployedReleaseVersion;
+        const customCompareConfigured = hasConfiguredReleaseNotesCompare(releaseNotesConfig);
+        const activeAnnouncementId = customCompareConfigured
+          ? `${activeReleaseVersion}:${releaseNotesConfig.latest_commit}`
+          : activeReleaseVersion;
         setReleaseVersion(activeReleaseVersion);
+        setAnnouncementId(activeAnnouncementId);
 
         const skippedThisSession =
           typeof window !== "undefined" &&
-          window.sessionStorage.getItem(sessionSkipKey(activeReleaseVersion)) === "true";
-        const permanentlyDismissedVersion = permanentlyDismissed.includes(activeReleaseVersion);
+          window.sessionStorage.getItem(sessionSkipKey(activeAnnouncementId)) === "true";
+        const permanentlyDismissedVersion = permanentlyDismissed.includes(activeAnnouncementId);
 
         if (skippedThisSession || permanentlyDismissedVersion) {
           setRelease(null);
@@ -183,30 +224,34 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
           return;
         }
 
-        const matchingRelease =
-          changelogPayload?.releases?.find((item) => normalizeVersion(item.version) === activeReleaseVersion) ??
-          null;
+        const matchingRelease = customCompareConfigured
+          ? null
+          : changelogPayload?.releases?.find(
+              (item) => normalizeVersion(item.version) === activeReleaseVersion,
+            ) ?? null;
         setRelease(matchingRelease);
 
         try {
-          const notesResponse = await fetch(
-            `/api/release-notes?version=${encodeURIComponent(activeReleaseVersion)}`,
-          );
+          const notesResponse = await fetch(releaseNotesRequestUrl(activeReleaseVersion, releaseNotesConfig));
           const notesPayload: ReleaseNotesResponse | null = notesResponse.ok
             ? await notesResponse.json()
             : null;
           if (!cancelled) {
             const hasExactChangelog = Boolean(matchingRelease);
+            const hasConfiguredCompareNotes =
+              customCompareConfigured && notesPayload?.source === "github-compare";
             const hasExactCuratedNotes =
               Boolean(notesPayload?.body) &&
-              normalizeVersion(notesPayload?.matchedVersion) === baseVersion(activeReleaseVersion);
+              (normalizeVersion(notesPayload?.matchedVersion) === activeReleaseVersion ||
+                normalizeVersion(notesPayload?.matchedVersion) === baseVersion(activeReleaseVersion));
             setReleaseMarkdown(
-              !hasExactChangelog && hasExactCuratedNotes
+              (hasConfiguredCompareNotes || !hasExactChangelog) && hasExactCuratedNotes
                 ? {
                     matchedVersion: notesPayload.matchedVersion ?? null,
                     title: notesPayload.title ?? null,
                     date: notesPayload.date ?? null,
                     body: notesPayload.body,
+                    changelogUrl: notesPayload.changelogUrl ?? null,
                   }
                 : null,
             );
@@ -238,21 +283,21 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
   }, [adminLoading, deployedReleaseVersion, isAdmin, session, status, versionLoading]);
 
   const skipUntilNextLogin = useCallback(() => {
-    if (releaseVersion && typeof window !== "undefined") {
-      window.sessionStorage.setItem(sessionSkipKey(releaseVersion), "true");
+    if (announcementId && typeof window !== "undefined") {
+      window.sessionStorage.setItem(sessionSkipKey(announcementId), "true");
     }
     setOpen(false);
-  }, [releaseVersion]);
+  }, [announcementId]);
 
   const dismissPermanently = useCallback(async () => {
-    if (!releaseVersion) {
+    if (!announcementId) {
       setOpen(false);
       return;
     }
 
-    const nextDismissed = Array.from(new Set([...dismissedVersions, releaseVersion]));
+    const nextDismissed = Array.from(new Set([...dismissedVersions, announcementId]));
     if (typeof window !== "undefined") {
-      window.sessionStorage.setItem(sessionSkipKey(releaseVersion), "true");
+      window.sessionStorage.setItem(sessionSkipKey(announcementId), "true");
     }
     setOpen(false);
     setIsDismissing(true);
@@ -273,7 +318,7 @@ export function useReleaseUpgradePrompt(): ReleaseUpgradePromptState {
     } finally {
       setIsDismissing(false);
     }
-  }, [dismissedVersions, releaseVersion]);
+  }, [announcementId, dismissedVersions]);
 
   return {
     open,

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev1"
+version = "1.0.1.dev2"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Summary
- restore the release-notes popup entry point in the current settings architecture
- allow administrators to configure a GitHub repository and two commit SHAs
- render the configured compare range for standard and non-standard release tags

## Why
The current upstream settings retained the release-notes toggle and preview, but the preview no longer honored an explicitly configured commit range. This made mirror tags such as `1.0.0-outshift.1` fall back to version-based notes or show nothing.

## Behavior
- all three compare fields are required together and validated
- private repositories use `RELEASE_NOTES_GITHUB_TOKEN`, `GITHUB_TOKEN`, or `GITHUB_PERSONAL_ACCESS_TOKEN`
- when configured, the popup uses the GitHub compare API and includes a compare link
- when not configured, existing deployed-version release notes behavior remains

## Validation
- focused API/UI tests: 66 passed
- UI lint: passed
- `git diff --check`: passed

This ports the feature already present in the CAIPE mirror and complements mirror PR #626.