### PR TITLE
fix(setup-caipe): make Langfuse tracing non-fatal and pin the chart

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -171,6 +171,12 @@ RAG_INGESTOR_OIDC_ISSUER=""
 RAG_INGESTOR_OIDC_CLIENT_ID=""
 LANGFUSE_PUBLIC_KEY=""
 LANGFUSE_SECRET_KEY=""
+# Langfuse Helm chart version. Pinned to the last 1.x release on purpose: the
+# 2.x line hard-requires cert-manager + the ClickHouse operator (ClickHouseCluster
+# / KeeperCluster CRs, ~15 extra pods, 100Gi+ PVCs) and bumps the minimum
+# Kubernetes version — far too heavy for a first-install laptop stack. 1.5.41
+# bundles ClickHouse + MinIO as plain pods. Override with LANGFUSE_CHART_VERSION.
+LANGFUSE_CHART_VERSION="${LANGFUSE_CHART_VERSION:-1.5.41}"
 PF_PIDS=()
 AUTO_YES=false
 NON_INTERACTIVE=false
@@ -3754,7 +3760,15 @@ deploy_langfuse() {
   minio_pw=$(openssl rand -hex 16)
   log "Generated Langfuse secrets"
 
-  helm upgrade --install langfuse langfuse/langfuse -n langfuse \
+  # Pin the chart version (LANGFUSE_CHART_VERSION) and DO NOT swallow stderr: a
+  # failed langfuse install must be visible and must return non-zero so the
+  # caller can continue without tracing instead of aborting the whole install
+  # under `set -e`. (Prior behaviour: `&>/dev/null` + unguarded call meant an
+  # optional observability add-on silently killed the entire deploy.)
+  local _lf_log
+  _lf_log=$(mktemp)
+  if ! helm upgrade --install langfuse langfuse/langfuse -n langfuse \
+    --version "$LANGFUSE_CHART_VERSION" \
     --set langfuse.salt.value="$salt" \
     --set langfuse.encryptionKey.value="$enc_key" \
     --set langfuse.nextauth.secret.value="$nextauth_secret" \
@@ -3764,10 +3778,16 @@ deploy_langfuse() {
     --set s3.accessKeyId.value=minio \
     --set s3.secretAccessKey.value="$minio_pw" \
     --set s3.auth.rootUser=minio \
-    --set s3.auth.rootPassword="$minio_pw" &>/dev/null
-  log "Langfuse Helm release deployed"
+    --set s3.auth.rootPassword="$minio_pw" >"$_lf_log" 2>&1; then
+    err "Langfuse Helm install failed (chart ${LANGFUSE_CHART_VERSION}):"
+    sed 's/^/    /' "$_lf_log" >&2
+    rm -f "$_lf_log"
+    return 1
+  fi
+  rm -f "$_lf_log"
+  log "Langfuse Helm release deployed (chart ${LANGFUSE_CHART_VERSION})"
 
-  wait_for_pods langfuse 420
+  wait_for_pods langfuse 420 || return 1
 }
 
 create_langfuse_api_keys() {
@@ -8355,8 +8375,17 @@ BANNER
   fi
 
   if $ENABLE_TRACING; then
-    deploy_langfuse
-    create_langfuse_api_keys
+    # Non-fatal: using these functions as an `if` condition disables `set -e`
+    # inside them, so a Langfuse failure degrades to "tracing off" instead of
+    # aborting the core platform deploy (deploy_langfuse returns non-zero on a
+    # helm/rollout failure).
+    if deploy_langfuse && create_langfuse_api_keys; then
+      log "Langfuse tracing ready"
+    else
+      warn "Langfuse tracing setup failed — continuing WITHOUT tracing; the core platform is unaffected."
+      warn "Resolve the error above and re-run, or set LANGFUSE_CHART_VERSION to a working chart."
+      ENABLE_TRACING=false
+    fi
   fi
 
   if $INJECT_CORPORATE_CA; then


### PR DESCRIPTION
# Description

`deploy_langfuse` ran `helm upgrade --install langfuse langfuse/langfuse` **unpinned**, with output sent to `/dev/null` and the call **unguarded**. Under `set -euo pipefail` a failed Langfuse install therefore **silently aborted the entire installer** — before the core CAIPE chart was ever deployed.

This is now easy to hit: the current `langfuse/langfuse` 2.x chart hard-requires cert-manager **and** the ClickHouse operator (`ClickHouseCluster` / `KeeperCluster` CRs), so `helm upgrade` fails at render time on a plain cluster:

```
Error: execution error at (langfuse/templates/validations.yaml:107:8):
ClickHouse operator CRDs not found ... Install the ClickHouse operator ... before installing this chart
```

## Changes

- **Pin** `LANGFUSE_CHART_VERSION` to `1.5.41` — the last release that runs without the ClickHouse operator / cert-manager (bundles ClickHouse + MinIO as plain pods). Overridable via the env var.
- Stop redirecting the `helm` output to `/dev/null`; capture it and print it on failure. `deploy_langfuse` now **returns non-zero** on a helm/rollout failure.
- Run the tracing block in `main()` as an `if` condition (which disables `set -e` inside it); on failure `warn`, set `ENABLE_TRACING=false`, and **continue the core install**.

## Testing

- `bash -n setup-caipe.sh`
- Forced failure (`LANGFUSE_CHART_VERSION=9.9.9-nope … --tracing`): install prints the error and proceeds instead of exiting.
- Full non-interactive install on Kind: log shows `✗ Timeout waiting for pods in langfuse` → `continuing WITHOUT tracing` → `deploy_caipe` runs to completion (previously died at the Langfuse step).
- Real `helm upgrade --install langfuse … --version 1.5.41` deploys on Kind.

Follow-up (separate issue): opt-in Langfuse 2.x path (cert-manager + clickhouse-operator, Kind-tuned).

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] All code style checks pass (`bash -n`)
- [x] I have verified this change is not present in other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
