### PR TITLE
fix(setup-caipe): pin in-cluster Ollama to the real model in LiteLLM mode

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -8488,6 +8488,21 @@ BANNER
     fi
     kubectl apply -f "$_ollama_yaml" 2>&1 \
       | grep -v "^$" | while IFS= read -r line; do log "$line"; done
+
+    # deploy/kind/ollama.yaml reads OPENAI_MODEL_NAME/EMBEDDINGS_MODEL from
+    # llm-secret. In LiteLLM proxy mode _finalize_litellm_mode has already
+    # rewritten those to the proxy aliases (caipe-chat / caipe-embeddings), so
+    # the pod would `ollama pull caipe-chat` (fails) and its readiness probe
+    # `ollama show caipe-chat` would loop forever. Pin the pod's env to the real
+    # Ollama model names instead.
+    if $LLM_VIA_LITELLM; then
+      local _real_embed="${LITELLM_EMBED_MODEL_REAL:-${EMBEDDINGS_MODEL:-}}"
+      kubectl set env deployment/ollama -n caipe --containers='*' \
+        "OPENAI_MODEL_NAME=${OLLAMA_MODEL}" \
+        ${_real_embed:+"EMBEDDINGS_MODEL=${_real_embed}"} >/dev/null 2>&1 \
+        && log "Ollama pod pinned to real model '${OLLAMA_MODEL}' (llm-secret holds the LiteLLM alias)"
+    fi
+
     log "Waiting for Ollama to be ready (model pull may take several minutes on first run)..."
     kubectl rollout status deployment/ollama -n caipe --timeout=10m 2>&1 \
       | while IFS= read -r line; do log "$line"; done


### PR DESCRIPTION
# Description

With **`--litellm`** (or the interactive *"Deploy LiteLLM proxy in front of Ollama? (recommended)"* prompt) **plus in-cluster Ollama**, the install hangs at *"Deploying in-cluster Ollama"* and eventually fails the 10-minute rollout wait.

## Root cause

`deploy/kind/ollama.yaml` wires the pod's `OPENAI_MODEL_NAME` / `EMBEDDINGS_MODEL` from `llm-secret`. But `_finalize_litellm_mode()` runs **before** `create_namespace_and_secrets` and rewrites those secret keys to the proxy **aliases** `caipe-chat` / `caipe-embeddings`. So the Ollama pod:

```
init pull-model:   ollama pull caipe-chat   →  Error: pull model manifest: file does not exist
readiness probe:   ollama show caipe-chat   →  model 'caipe-chat:latest' not found   (loops forever)
```

The pod never goes Ready → `kubectl rollout status deployment/ollama --timeout=10m` blocks the whole install. (The LiteLLM proxy `model_list` itself is fine — `caipe-chat → ollama/<real model>`.)

## Fix

After `kubectl apply -f ollama.yaml`, when `LLM_VIA_LITELLM` is set, override the deployment env (all containers) with the real names:

```
kubectl set env deployment/ollama -n caipe --containers='*' \
  OPENAI_MODEL_NAME=<OLLAMA_MODEL> [EMBEDDINGS_MODEL=<real embed model>]
```

Non-LiteLLM path is unchanged.

## Testing

- `bash -n setup-caipe.sh`
- Repro'd live: interactive Ollama + LiteLLM → `ollama pull caipe-chat` fails, pod stuck `0/1`. Applying the same `kubectl set env` override → pod pulls `qwen3:1.7b` + `nomic-embed-text`, goes `1/1 Running`.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] All code style checks pass (`bash -n`)
- [x] I have verified this change is not present in other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
