### PR TITLE
fix(setup-caipe): set litellm drop_params so Ollama embeddings work

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -5616,6 +5616,12 @@ data:
   config.yaml: |
     model_list:
 ${model_list_yaml}
+    litellm_settings:
+      # Ollama's embedding + chat APIs reject OpenAI-only params the langchain
+      # OpenAI client always sends (e.g. encoding_format: base64), which
+      # otherwise 400s the RAG server's startup embedding test. Drop unsupported
+      # params instead of forwarding them.
+      drop_params: true
 ${general_yaml}
 ---
 apiVersion: apps/v1


### PR DESCRIPTION
# Description

With **`--litellm`** and **in-cluster Ollama**, the RAG server never becomes healthy — its startup embedding test 400s:

```
openai.BadRequestError: 400 - litellm.UnsupportedParamsError:
Setting {'encoding_format': 'base64'} is not supported by ollama.
To drop it from the call, set `litellm.drop_params = True`.
```

The langchain OpenAI embeddings client always sends `encoding_format: base64`. It routes through the LiteLLM proxy → Ollama, which rejects the param → LiteLLM raises `UnsupportedParamsError` → RAG server shuts down → auto-heal restarts it every 30s → permanent churn, install stalls in `ensure_healthy`.

## Fix

Add `litellm_settings.drop_params: true` to the generated `litellm-config` ConfigMap so LiteLLM strips OpenAI-only params before forwarding to Ollama (also covers chat-side params some Ollama models reject).

## Testing

- `bash -n setup-caipe.sh`
- Repro'd live on Kind (`--rag --litellm`, Ollama `qwen3:1.7b` + `nomic-embed-text`): RAG server crash-looped on the 400. Patching the running `litellm-config` with `drop_params: true` + restarting the proxy → `====== Initialization tests completed successfully ======`, `rag-server` `1/1 Running`.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] All code style checks pass (`bash -n`)
- [x] I have verified this change is not present in other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
