### PR TITLE
fix(setup-caipe): extend the ingress hostAlias to rag-server + web-ingestor

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -4280,9 +4280,18 @@ post_deploy_patches() {
       _ningx_ip=$(kubectl get svc ingress-nginx-controller -n ingress-nginx \
         -o jsonpath='{.spec.clusterIP}' 2>/dev/null || true)
       if [[ -n "$_ningx_ip" ]]; then
-        kubectl patch deploy caipe-caipe-ui -n caipe --type=merge \
-          -p "{\"spec\":{\"template\":{\"spec\":{\"hostAliases\":[{\"ip\":\"${_ningx_ip}\",\"hostnames\":[\"${CAIPE_DOMAIN}\"]}]}}}}" &>/dev/null \
-          && log "caipe-ui hostAliases: ${CAIPE_DOMAIN} -> ${_ningx_ip} (in-cluster ingress; fixes SSO callback)"
+        # caipe-ui isn't the only pod that calls the public host server-side:
+        # the RAG server and the web-ingestor fetch OIDC tokens from the issuer
+        # URL Keycloak advertises (KC_HOSTNAME = the public domain). Without this
+        # they resolve the host to a public/loopback IP and never reach the
+        # in-cluster ingress. rag-stack deployments are absent when RAG is off —
+        # patch is best-effort.
+        local _d
+        for _d in caipe-caipe-ui rag-server caipe-rag-ingestors-webloader; do
+          kubectl patch deploy "$_d" -n caipe --type=merge \
+            -p "{\"spec\":{\"template\":{\"spec\":{\"hostAliases\":[{\"ip\":\"${_ningx_ip}\",\"hostnames\":[\"${CAIPE_DOMAIN}\"]}]}}}}" &>/dev/null \
+            && log "${_d} hostAliases: ${CAIPE_DOMAIN} -> ${_ningx_ip} (in-cluster ingress)"
+        done
       fi
     fi
 


### PR DESCRIPTION
# Description

The hostAlias that pins the public domain to the in-cluster ingress ClusterIP (so server-side OIDC calls hairpin correctly on Kind) was applied to **`caipe-caipe-ui` only**.

`rag-server` and `caipe-rag-ingestors-webloader` also make server-side calls to the issuer URL Keycloak advertises (`KC_HOSTNAME` = the public domain), so on a Kind install they can't reach the ingress:

```
Cannot connect to host <domain>:443  [Connect call failed ('127.0.0.1', 443)]
```

(Pre-existing — with the old `*.local.me` default it surfaced as `TLSV1_UNRECOGNIZED_NAME` against the real public host instead.)

## Fix

Apply the same hostAlias patch to `rag-server` and `caipe-rag-ingestors-webloader` (best-effort — those deployments are absent when RAG is disabled).

## Known follow-up

Even with the hostAlias, the web-ingestor then fails OIDC with `SSL: CERTIFICATE_VERIFY_FAILED` against the self-signed local cert — it needs the self-signed CA trusted in the pod, or an in-cluster HTTP token URL. Tracked separately; not blocking (web-ingestor is the crawl-on-startup helper, RAG query/retrieval is unaffected).

## Testing

- `bash -n setup-caipe.sh`
- Live on Kind (`--rag --litellm`, domain `caipe.localtest.me`): webloader crash-looped on `Connect call failed ('127.0.0.1', 443)`. Applying the same hostAlias patch to the webloader → gets past the connection failure to the (separate) cert-verification error.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] All code style checks pass (`bash -n`)
- [x] I have verified this change is not present in other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
