### PR TITLE
fix(setup-caipe): backfill dynamic-agents AUTHZ_SERVICE_URL for the 1.0.0 chart

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -4261,6 +4261,24 @@ post_deploy_patches() {
       && log "caipe-ui: NODE_TLS_REJECT_UNAUTHORIZED=0 (self-signed cert, local dev only)"
   fi
 
+  # ── 6c. dynamic-agents: point CAS agent-use checks at the BFF ──
+  # The 1.0.0 chart's dynamic-agents deployment ships no AUTHZ_SERVICE_URL, so
+  # every RBAC-gated agent call hits `AUTHZ_SERVICE_URL is not configured` and
+  # returns 503 PDP_UNAVAILABLE (chat + agent-builder test are unusable). main
+  # (-> 1.0.1) adds the env with a `http://<release>-caipe-ui:3000` default;
+  # backfill it here for 1.0.0. Harmless once the chart sets it.
+  if $ENABLE_RBAC_RUNTIME; then
+    local _cur_authz
+    _cur_authz=$(kubectl get deployment caipe-dynamic-agents -n caipe \
+      -o jsonpath='{.spec.template.spec.containers[0].env[?(@.name=="AUTHZ_SERVICE_URL")].value}' \
+      2>/dev/null || true)
+    if [[ -z "$_cur_authz" ]]; then
+      kubectl set env deployment/caipe-dynamic-agents -n caipe \
+        AUTHZ_SERVICE_URL="http://caipe-caipe-ui:3000" &>/dev/null \
+        && log "dynamic-agents: AUTHZ_SERVICE_URL set to http://caipe-caipe-ui:3000 (1.0.0 chart gap)"
+    fi
+  fi
+
   # ── 7. MongoDB for dynamic-agents ──
   # The dynamic-agents chart defaults MONGODB_URI to localhost:27017 (no-op
   # default). Setup deploys a bitnami/mongodb instance (if none exists) and


### PR DESCRIPTION
# Description

On any RBAC install of the **`1.0.0`** chart, agent chat and the agent-builder test return **503**:

```
[dynamic_agents] CAS agent-use decision unavailable for agent=hello-world: AUTHZ_SERVICE_URL is not configured
INFO: POST /api/v1/chat/stream/start HTTP/1.1 503 Service Unavailable
[caipe-ui] Backend error: 503 { code: "PDP_UNAVAILABLE" }
```

`dynamic_agents/src/dynamic_agents/auth/authz.py` calls `{AUTHZ_SERVICE_URL}/api/authz/v1/decisions` for CAS agent-use decisions and raises `RuntimeError("AUTHZ_SERVICE_URL is not configured")` (→ deny → 503) when it's unset. The **`1.0.0` chart's `dynamic-agents/templates/deployment.yaml` never sets that env var** (verified against the `1.0.0` tag). `main` (commit `6667d13dc`, → `1.0.1`) added it with a `http://<release>-caipe-ui:3000` default.

## Fix

In `post_deploy_patches`, when `ENABLE_RBAC_RUNTIME` and the deployment has no `AUTHZ_SERVICE_URL`, `kubectl set env` it to `http://caipe-caipe-ui:3000` (the BFF service; release is always `caipe`). No-op once the chart sets it, so this is safe to keep past `1.0.1`.

## Testing

- `bash -n setup-caipe.sh`
- Live on Kind (`1.0.0`, `--rag --litellm`, RBAC): agent chat → 503 `PDP_UNAVAILABLE`. `kubectl set env deploy/caipe-dynamic-agents AUTHZ_SERVICE_URL=http://caipe-caipe-ui:3000` → pod restarts clean, no more `AUTHZ_SERVICE_URL is not configured`, chat works.

## Related

- Chart-side (this repo): #ISSUE — `1.0.0` dynamic-agents deployment missing `AUTHZ_SERVICE_URL`; fixed on `main`, needs a `1.0.1` cut.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] All code style checks pass (`bash -n`)
- [x] I have verified this change is not present in other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
