### PR TITLE
fix(setup-caipe): configure rag-server ingestor OIDC even without UI SSO

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -4207,18 +4207,28 @@ post_deploy_patches() {
       -o jsonpath='{.data.INGESTOR_OIDC_ISSUER}' 2>/dev/null | base64 -d || true)
     _rag_ingestor_client_id=$(kubectl get secret rag-ingestor-secret -n caipe \
       -o jsonpath='{.data.INGESTOR_OIDC_CLIENT_ID}' 2>/dev/null | base64 -d || true)
+    local _rag_env_args=()
+    # UI SSO provider — only when the UI is actually running SSO.
     if [[ -n "$_rag_oidc_issuer" && -n "$_rag_oidc_client_id" ]]; then
-      local _rag_env_args=(
+      _rag_env_args+=(
         "OIDC_ISSUER=$_rag_oidc_issuer"
         "OIDC_CLIENT_ID=$_rag_oidc_client_id"
         "OIDC_GROUP_CLAIM=members,groups"
       )
-      [[ -n "$_rag_ingestor_issuer" ]]    && _rag_env_args+=("INGESTOR_OIDC_ISSUER=$_rag_ingestor_issuer")
-      [[ -n "$_rag_ingestor_client_id" ]] && _rag_env_args+=("INGESTOR_OIDC_CLIENT_ID=$_rag_ingestor_client_id")
+    fi
+    # Ingestor provider — client-credentials auth for the web-ingestor, which is
+    # independent of UI SSO. Without INGESTOR_OIDC_ISSUER the rag-server auth
+    # manager builds the "ingestor" provider with issuer="" and rejects every
+    # ingestor token ("Invalid issuer"), so the UI shows "No ingestors detected"
+    # on a no-SSO install.
+    [[ -n "$_rag_ingestor_issuer" ]]    && _rag_env_args+=("INGESTOR_OIDC_ISSUER=$_rag_ingestor_issuer")
+    [[ -n "$_rag_ingestor_client_id" ]] && _rag_env_args+=("INGESTOR_OIDC_CLIENT_ID=$_rag_ingestor_client_id")
+
+    if [[ ${#_rag_env_args[@]} -gt 0 ]]; then
       kubectl set env deployment/rag-server -n caipe "${_rag_env_args[@]}" &>/dev/null \
-        && log "rag-server: OIDC providers configured (issuer=${_rag_oidc_issuer})"
+        && log "rag-server: OIDC providers configured (ui=${_rag_oidc_issuer:-off}, ingestor=${_rag_ingestor_issuer:-off})"
     else
-      log "rag-server: No OIDC config found in caipe-ui-secret — skipping OIDC patch (no-SSO deployment)"
+      log "rag-server: no OIDC config available — skipping (no SSO, no ingestor client)"
     fi
 
     # Self-signed cert: pin rag-server's OIDC discovery / JWKS to the in-cluster


### PR DESCRIPTION
# Description

A fresh **no-SSO** install (in-chart Keycloak, no upstream IdP — the default local path) shows **"No ingestors detected. Please ensure ingestor services are running"** in the RAG UI, and `caipe-rag-ingestors-webloader` heartbeats fail:

```
[rag.server.auth] Token validation failed for all providers —
  ui: Audience doesn't match; ingestor: Invalid issuer
POST /v1/ingestor/heartbeat HTTP/1.1" 401 Unauthorized
```

## Root cause

`post_deploy_patches` sets rag-server's OIDC env like this:

```bash
if [[ -n "$_rag_oidc_issuer" && -n "$_rag_oidc_client_id" ]]; then   # UI SSO configured?
  _rag_env_args=( OIDC_ISSUER=... OIDC_CLIENT_ID=... )
  [[ -n "$_rag_ingestor_issuer" ]] && _rag_env_args+=( INGESTOR_OIDC_ISSUER=... )   # <-- inside the UI-SSO gate
  kubectl set env deployment/rag-server ...
else
  log "... skipping OIDC patch (no-SSO deployment)"
fi
```

The web-ingestor authenticates to rag-server with **client credentials** (`caipe-web-ingestor` / `caipe-platform`), which is independent of UI SSO. But `INGESTOR_OIDC_ISSUER` is set only when UI SSO is on. On a no-SSO install `_rag_oidc_issuer` is empty → the whole block is skipped → rag-server's `auth.py` builds the `ingestor` provider with `issuer=""` → every ingestor token is rejected as "Invalid issuer".

## Fix

Split the two providers: `OIDC_*` (UI) stays gated on the UI SSO check; `INGESTOR_OIDC_ISSUER` / `INGESTOR_OIDC_CLIENT_ID` are applied whenever `rag-ingestor-secret` provides them.

## Testing

- `bash -n setup-caipe.sh`
- Live on Kind (no-SSO, `--rag`): webloader heartbeat 401 "Invalid issuer". `kubectl set env deployment/rag-server INGESTOR_OIDC_ISSUER=https://<domain>/realms/caipe` + restart → `POST /v1/ingestor/heartbeat -> 200 OK`, webloader `Listening for webloader commands`, RAG UI lists the ingestor.

## Related

Self-signed-cert half of the same "RAG ingestion on a local install" story (server-to-server OIDC over the self-signed ingress) folded into #2677.

## Type of Change

- [x] Bugfix

## Checklist

- [x] I have read the contributing guidelines
- [x] All code style checks pass (`bash -n`)
- [x] I have verified this change is not present in other open pull requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
