### PR TITLE
fix(ui): keep default agent settings available without webex

### DIFF
--- a/ui/src/app/api/user/preferences/__tests__/route.test.ts
+++ b/ui/src/app/api/user/preferences/__tests__/route.test.ts
@@ -10,6 +10,7 @@ const mockEvaluateAgentAccess = jest.fn();
 const mockGetAuth = jest.fn();
 const mockGetAgentsCollection = jest.fn();
 const mockGetResolvedPlatformDefaultAgentId = jest.fn();
+const mockWebexIntegrationEnabled = jest.fn();
 const mockListWebexBotPolicies = jest.fn();
 const mockRequireAvailableWebexBotPolicy = jest.fn();
 const mockListWebexDirectUserRoutesForUser = jest.fn();
@@ -43,7 +44,7 @@ jest.mock("@/lib/mongodb", () => ({
 }));
 
 jest.mock("@/lib/integration-config", () => ({
-  getIntegrationAvailability: () => ({ slack: true, webex: false }),
+  getIntegrationAvailability: () => ({ slack: true, webex: mockWebexIntegrationEnabled() }),
 }));
 
 jest.mock("@/lib/platform-default-agent", () => ({
@@ -107,6 +108,7 @@ describe("GET /api/user/preferences", () => {
     mockGetAuth.mockResolvedValue(authedSession);
     mockGetAgentsCollection.mockResolvedValue(mockAgentsCollection);
     mockGetResolvedPlatformDefaultAgentId.mockResolvedValue("platform-agent");
+    mockWebexIntegrationEnabled.mockReturnValue(false);
     mockListWebexBotPolicies.mockResolvedValue([]);
     mockListWebexDirectUserRoutesForUser.mockResolvedValue(new Map());
   });
@@ -120,6 +122,7 @@ describe("GET /api/user/preferences", () => {
     const response = await GET(makeRequest("GET"));
 
     expect(response.status).toBe(200);
+    expect(mockListWebexBotPolicies).not.toHaveBeenCalled();
     await expect(bodyOf(response)).resolves.toMatchObject({
       success: true,
       data: {
@@ -154,6 +157,23 @@ describe("GET /api/user/preferences", () => {
     });
   });
 
+  it("keeps Web preferences available when the Webex admin service is down", async () => {
+    mockWebexIntegrationEnabled.mockReturnValue(true);
+    mockGetUserPreference.mockResolvedValue({
+      web_default_agent_id: null,
+      slack_default_agent_id: null,
+    });
+    mockListWebexBotPolicies.mockRejectedValue(new Error("Webex unavailable"));
+
+    const response = await GET(makeRequest("GET"));
+
+    expect(response.status).toBe(200);
+    await expect(bodyOf(response)).resolves.toMatchObject({
+      success: true,
+      data: { webex_bots: [] },
+    });
+  });
+
   it("rejects requests without a valid session", async () => {
     mockGetAuth.mockResolvedValue({
       user: { email: "x", name: "y", role: "user" },
@@ -167,6 +187,7 @@ describe("GET /api/user/preferences", () => {
   });
 
   it("includes an all_users bot as editable, falling back to the bot default", async () => {
+    mockWebexIntegrationEnabled.mockReturnValue(true);
     mockGetUserPreference.mockResolvedValue({ web_default_agent_id: null, slack_default_agent_id: null });
     mockListWebexBotPolicies.mockResolvedValue([ALL_USERS_BOT]);
 
@@ -189,6 +210,7 @@ describe("GET /api/user/preferences", () => {
   });
 
   it("uses the user's own route agent for an all_users bot when one exists", async () => {
+    mockWebexIntegrationEnabled.mockReturnValue(true);
     mockGetUserPreference.mockResolvedValue({ web_default_agent_id: null, slack_default_agent_id: null });
     mockListWebexBotPolicies.mockResolvedValue([ALL_USERS_BOT]);
     mockListWebexDirectUserRoutesForUser.mockResolvedValue(
@@ -205,6 +227,7 @@ describe("GET /api/user/preferences", () => {
   });
 
   it("marks an admin-denied all_users bot as not editable", async () => {
+    mockWebexIntegrationEnabled.mockReturnValue(true);
     mockGetUserPreference.mockResolvedValue({ web_default_agent_id: null, slack_default_agent_id: null });
     mockListWebexBotPolicies.mockResolvedValue([ALL_USERS_BOT]);
     mockListWebexDirectUserRoutesForUser.mockResolvedValue(
@@ -221,6 +244,7 @@ describe("GET /api/user/preferences", () => {
   });
 
   it("hides an allowlist bot the user has no active route for", async () => {
+    mockWebexIntegrationEnabled.mockReturnValue(true);
     mockGetUserPreference.mockResolvedValue({ web_default_agent_id: null, slack_default_agent_id: null });
     mockListWebexBotPolicies.mockResolvedValue([ALLOWLIST_BOT]);
 
@@ -230,6 +254,7 @@ describe("GET /api/user/preferences", () => {
   });
 
   it("shows an allowlisted bot read-only with the admin-chosen agent", async () => {
+    mockWebexIntegrationEnabled.mockReturnValue(true);
     mockGetUserPreference.mockResolvedValue({ web_default_agent_id: null, slack_default_agent_id: null });
     mockListWebexBotPolicies.mockResolvedValue([ALLOWLIST_BOT]);
     mockListWebexDirectUserRoutesForUser.mockResolvedValue(

--- a/ui/src/app/api/user/preferences/route.ts
+++ b/ui/src/app/api/user/preferences/route.ts
@@ -134,16 +134,30 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     });
   }
   const tenantId = resolveTenant(session);
+  const integrations = getIntegrationAvailability();
   const [preference, platformDefaultAgentId, webexBots] = await Promise.all([
     getUserPreference({ tenantId, userId: subject }),
     getResolvedPlatformDefaultAgentId(),
-    buildWebexBotSettings(subject),
+    // Do not make the personal Web/Slack settings page depend on the Webex
+    // service when Webex is not part of this deployment. In that case the
+    // service call can fail even though the user preferences are healthy.
+    integrations.webex
+      ? buildWebexBotSettings(subject).catch((error: unknown) => {
+          // Web and Slack preferences remain usable during a Webex admin
+          // service outage. The Webex rows will reappear on the next load.
+          console.warn(
+            "[user-preferences] Webex settings unavailable",
+            error instanceof Error ? error.message : String(error),
+          );
+          return [];
+        })
+      : Promise.resolve([]),
   ]);
   return successResponse({
     ...preference,
     webex_bots: webexBots,
     platform_default_agent_id: platformDefaultAgentId,
-    integrations: getIntegrationAvailability(),
+    integrations,
   });
 });
 

--- a/ui/src/components/chat/NewChatButton.tsx
+++ b/ui/src/components/chat/NewChatButton.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { resolveUsableChatAgent } from "@/lib/chat-agent-selection";
 import { cn } from "@/lib/utils";
 import type { DynamicAgentConfig } from "@/types/dynamic-agent";
-import { ChevronDown,Loader2,Plus,Search } from "lucide-react";
+import { Check,ChevronDown,Loader2,Plus,Search,Star } from "lucide-react";
 import React,{ useEffect,useRef,useState } from "react";
 
 interface NewChatButtonProps {
@@ -22,8 +22,10 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
   const dropdownRef = useRef<HTMLDivElement>(null);
   const searchInputRef = useRef<HTMLInputElement>(null);
   const [defaultAgentId, setDefaultAgentId] = useState<string | null>(null);
+  const [personalDefaultAgentId, setPersonalDefaultAgentId] = useState<string | null>(null);
   const [defaultAgentName, setDefaultAgentName] = useState<string>("New Chat");
   const [defaultAgentResolved, setDefaultAgentResolved] = useState(false);
+  const [savingDefaultId, setSavingDefaultId] = useState<string | null>(null);
 
   // Resolve the same usable agent as the Home composer: personal Web default,
   // platform default, then the first accessible agent. Keeping this selection
@@ -37,6 +39,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
 
         if (cancelled) return;
         setDefaultAgentId(agent.id);
+        setPersonalDefaultAgentId(agent.source === "user-default" ? agent.id : null);
         setDefaultAgentName(agent.name);
       } catch {
         if (!cancelled) {
@@ -133,6 +136,31 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
     onNewChat(agentId);
   };
 
+  const handleSetDefaultAgent = async (agent: DynamicAgentConfig) => {
+    if (savingDefaultId) return;
+    setSavingDefaultId(agent._id);
+    setError(null);
+    try {
+      const response = await fetch("/api/user/preferences", {
+        method: "PUT",
+        credentials: "same-origin",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ web_default_agent_id: agent._id }),
+      });
+      const data = await response.json() as { success?: boolean; error?: string };
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || `Failed to save default agent (HTTP ${response.status})`);
+      }
+      setDefaultAgentId(agent._id);
+      setPersonalDefaultAgentId(agent._id);
+      setDefaultAgentName(agent.name);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save default agent");
+    } finally {
+      setSavingDefaultId(null);
+    }
+  };
+
   // Auto-focus search input when dropdown opens
   useEffect(() => {
     if (dropdownOpen && searchInputRef.current) {
@@ -171,14 +199,14 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
           onClick={handleMainClick}
           disabled={!defaultAgentResolved}
           className={cn(
-            "flex-1 gap-2 bg-primary/10 hover:bg-primary/20 text-primary border border-primary/30 hover-glow",
+            "min-w-0 flex-1 gap-2 bg-primary/10 hover:bg-primary/20 text-primary border border-primary/30 hover-glow",
             "rounded-r-none border-r-0"
           )}
           variant="ghost"
           size="default"
         >
           <Plus className="h-4 w-4 shrink-0" />
-          <span className="whitespace-nowrap">{defaultAgentName}</span>
+          <span className="min-w-0 truncate" title={defaultAgentName}>{defaultAgentName}</span>
         </Button>
 
         {/* Dropdown trigger */}
@@ -238,12 +266,11 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
             )}
 
             {/* Dynamic agents list */}
-            {!loading && !error && filteredAgents.map((agent) => {
-              return (
+            {!loading && !error && filteredAgents.map((agent) => (
+              <div key={agent._id} className="flex items-center gap-1 px-1">
                 <button
-                  key={agent._id}
                   onClick={() => handleSelectAgent(agent._id)}
-                  className="w-full flex items-center gap-3 px-3 py-2 text-sm hover:bg-accent transition-colors text-left"
+                  className="min-w-0 flex-1 flex items-center gap-3 rounded-md px-2 py-2 text-left text-sm hover:bg-accent transition-colors"
                 >
                   <AgentAvatar
                     agent={agent}
@@ -251,7 +278,7 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
                     size="w-8 h-8"
                     iconSize="h-4 w-4"
                   />
-                  <div className="flex-1 min-w-0">
+                  <div className="min-w-0 flex-1">
                     <div className="font-medium truncate">{agent.name}</div>
                     {agent.description && (
                       <div className="text-xs text-muted-foreground truncate">
@@ -260,8 +287,27 @@ export function NewChatButton({ collapsed, onNewChat }: NewChatButtonProps) {
                     )}
                   </div>
                 </button>
-              );
-            })}
+                <button
+                  type="button"
+                  aria-label={personalDefaultAgentId === agent._id ? `${agent.name} is your default agent` : `Set ${agent.name} as your default agent`}
+                  title={personalDefaultAgentId === agent._id ? "Your default agent" : "Set as your default agent"}
+                  disabled={savingDefaultId !== null}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    void handleSetDefaultAgent(agent);
+                  }}
+                  className="rounded-md p-2 text-muted-foreground hover:bg-accent hover:text-primary disabled:opacity-50"
+                >
+                  {savingDefaultId === agent._id ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : personalDefaultAgentId === agent._id ? (
+                    <Check className="h-4 w-4 text-primary" />
+                  ) : (
+                    <Star className="h-4 w-4" />
+                  )}
+                </button>
+              </div>
+            ))}
 
             {/* No results */}
             {!loading && !error && filteredAgents.length === 0 && (

--- a/ui/src/components/chat/__tests__/NewChatButton.test.tsx
+++ b/ui/src/components/chat/__tests__/NewChatButton.test.tsx
@@ -13,11 +13,13 @@ jest.mock("@/components/ui/button", () => ({
 }));
 
 jest.mock("lucide-react", () => ({
+  Check: () => <span data-testid="check-icon" />,
   Plus: () => <span data-testid="plus-icon" />,
   ChevronDown: () => <span data-testid="chevron-icon" />,
   Bot: () => <span data-testid="bot-icon" />,
   Loader2: () => <span data-testid="loader-icon" />,
   Search: () => <span data-testid="search-icon" />,
+  Star: () => <span data-testid="star-icon" />,
 }));
 
 const mockFetch = jest.fn();
@@ -67,6 +69,39 @@ describe("NewChatButton", () => {
     render(<NewChatButton collapsed={false} onNewChat={jest.fn()} />);
 
     expect(await screen.findByText("Platform Helper")).toBeInTheDocument();
+  });
+
+  it("lets the user save an agent as the Web default from the new-chat menu", async () => {
+    mockResolveUsableChatAgent.mockResolvedValue({
+      id: "agent-default",
+      name: "Platform Helper",
+      source: "platform-default",
+    });
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        success: true,
+        data: [{ _id: "agent-sre", name: "SRE Agent", description: "Operations" }],
+      }),
+    });
+
+    render(<NewChatButton collapsed={false} onNewChat={jest.fn()} />);
+    const dropdownToggle = screen.getByTestId("chevron-icon").closest("button");
+    expect(dropdownToggle).not.toBeNull();
+    fireEvent.click(dropdownToggle!);
+    fireEvent.click(await screen.findByRole("button", { name: "Set SRE Agent as your default agent" }));
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/user/preferences",
+        expect.objectContaining({
+          method: "PUT",
+          body: JSON.stringify({ web_default_agent_id: "agent-sre" }),
+        }),
+      );
+    });
+    expect((await screen.findAllByText("SRE Agent")).length).toBeGreaterThanOrEqual(1);
   });
 
   it("prefers the user's web default over the platform default", async () => {

--- a/ui/src/components/settings/DefaultAgents/UserDefaultAgentsPanel.tsx
+++ b/ui/src/components/settings/DefaultAgents/UserDefaultAgentsPanel.tsx
@@ -186,6 +186,7 @@ export function UserDefaultAgentsPanel({
   const [preferenceLoading,setPreferenceLoading] = useState(true);
   const [platformDefaultId,setPlatformDefaultId] = useState<string | null>(null);
   const [loadError,setLoadError] = useState<string | null>(null);
+  const [preferenceRetryCount,setPreferenceRetryCount] = useState(0);
 
   const autoSave = useKeyedAutoSave<RowKey,string>({
     persist: persistPreference,
@@ -235,7 +236,7 @@ export function UserDefaultAgentsPanel({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [preferenceRetryCount]);
 
   const handleSelect = useCallback((key: RowKey,value: string) => {
     if (disabled || selected[key] === value) return;
@@ -278,10 +279,17 @@ export function UserDefaultAgentsPanel({
     return (
       <div className="rounded-lg border border-destructive/40 bg-destructive/10 p-3 text-sm">
         <p>Failed to load defaults: {agentsError ?? loadError}</p>
-        {agentsError ? (
+        {agentsError || loadError ? (
           <button
             className="mt-2 rounded border border-input bg-background px-2 py-1 text-xs"
-            onClick={() => void refreshAgents()}
+            onClick={() => {
+              if (agentsError) void refreshAgents();
+              if (loadError) {
+                setLoadError(null);
+                setPreferenceLoading(true);
+                setPreferenceRetryCount((count) => count + 1);
+              }
+            }}
             type="button"
           >
             Retry


### PR DESCRIPTION
# Description

Keeps the default-agent settings available when the optional Webex admin service is disabled or temporarily unavailable.

- Skip Webex bot discovery when Webex is disabled.
- Degrade Webex discovery failures to an empty Webex list instead of failing the entire preferences request.
- Add retry handling to the default-agent settings panel.
- Allow users to set their Web default agent from the new-chat agent menu.
- Preserve compact display for long default-agent names.

This is the reusable upstream portion of https://github.com/cisco-eti/ai-platform-engineering-mirror/pull/627.

## Type of Change

- [x] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Temporary Helm Charts (Optional)

Not applicable; this PR changes the UI only.

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in the UI
- [x] The existing agent picker is reused; no new base selection control is introduced
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] Targeted tests and the production UI build pass

## Validation

- npm test -- --runInBand src/app/api/user/preferences/__tests__/route.test.ts src/components/chat/__tests__/NewChatButton.test.tsx (33 tests passed)
- npm run lint
- npm run build