### PR TITLE
fix(ui): canonicalize AgentGateway MCP targets

### DIFF
--- a/ai_platform_engineering/mcp/litellm/README.md
+++ b/ai_platform_engineering/mcp/litellm/README.md
@@ -83,7 +83,7 @@ caipe-ui:
         name: LiteLLM
         description: LiteLLM FinOps reporting tools
         transport: http
-        endpoint: http://ai-platform-engineering-litellm-mcp:8000/mcp/
+        endpoint: http://ai-platform-engineering-litellm-mcp:8000/mcp
         enabled: true
 ```
 

--- a/ui/src/app/api/internal/agentgateway/mcp-targets/__tests__/route.test.ts
+++ b/ui/src/app/api/internal/agentgateway/mcp-targets/__tests__/route.test.ts
@@ -66,7 +66,7 @@ describe("internal AgentGateway MCP targets API", () => {
             enabled: true,
             transport: "http",
             source: "manual",
-            endpoint: "http://mcp-manual-endpoint:8000/mcp",
+            endpoint: "http://mcp-manual-endpoint:8000/mcp/",
           },
           {
             _id: "gateway-loop",
@@ -131,6 +131,40 @@ describe("internal AgentGateway MCP targets API", () => {
         {
           id: "manual-endpoint-target",
           target_endpoint: "http://mcp-manual-endpoint:8000/mcp",
+          credential_sources: [],
+        },
+      ],
+    });
+  });
+
+  it("removes a trailing slash from AgentGateway upstream MCP endpoints", async () => {
+    mockGetCollection.mockResolvedValue({
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockResolvedValue([
+          {
+            _id: "configured-target",
+            enabled: true,
+            transport: "http",
+            source: "agentgateway",
+            agentgateway_target_endpoint: "https://mcp.example.test/mcp/?tenant=primary",
+          },
+        ]),
+      }),
+    });
+    const { GET } = await import("../route");
+
+    const response = await GET(
+      request({
+        headers: { authorization: "Bearer bridge-token" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      targets: [
+        {
+          id: "configured-target",
+          target_endpoint: "https://mcp.example.test/mcp?tenant=primary",
           credential_sources: [],
         },
       ],

--- a/ui/src/app/api/internal/agentgateway/mcp-targets/route.ts
+++ b/ui/src/app/api/internal/agentgateway/mcp-targets/route.ts
@@ -53,15 +53,25 @@ function isAgentGatewayEndpoint(endpoint: string): boolean {
   }
 }
 
+function canonicalAgentGatewayTargetEndpoint(endpoint: string): string {
+  // Streamable HTTP session negotiation cannot safely cross an HTTP redirect:
+  // the upstream session id belongs to the redirected URL, while AgentGateway
+  // wraps sessions against the configured target URL. FastMCP serves the
+  // canonical endpoint at `/mcp`, so remove only that path's trailing slash.
+  return endpoint.replace(/\/mcp\/(?=([?#]|$))/, "/mcp");
+}
+
 function upstreamEndpointFor(server: MCPServerConfig): string {
   const targetEndpoint =
     typeof server.agentgateway_target_endpoint === "string"
       ? server.agentgateway_target_endpoint.trim()
       : "";
-  if (targetEndpoint) return targetEndpoint;
+  if (targetEndpoint) return canonicalAgentGatewayTargetEndpoint(targetEndpoint);
 
   const endpoint = typeof server.endpoint === "string" ? server.endpoint.trim() : "";
-  return endpoint && !isAgentGatewayEndpoint(endpoint) ? endpoint : "";
+  return endpoint && !isAgentGatewayEndpoint(endpoint)
+    ? canonicalAgentGatewayTargetEndpoint(endpoint)
+    : "";
 }
 
 function toBridgeTarget(server: MCPServerConfig): AgentGatewayBridgeTarget | null {


### PR DESCRIPTION
# Description

Canonicalize terminal `/mcp/` paths to `/mcp` before the UI target bridge sends upstream endpoints to AgentGateway.

FastMCP redirects `/mcp/` to `/mcp` during initialization. Redirecting a streamable HTTP MCP initialize request causes AgentGateway to receive the upstream session ID from a different URL than the configured target; subsequent `tools/list` requests can then fail with `mcp: invalid session ID header`. This change prevents that redirect at the bridge boundary while preserving custom paths and query strings.

The LiteLLM Helm example now documents the canonical `/mcp` endpoint.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

Not applicable; this PR does not change Helm templates or values.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] New selection controls follow the [selection-control decision table](https://github.com/caipe-io/ai-platform-engineering/blob/main/docs/docs/ui/selection-controls.md), or the custom interaction is justified (not applicable)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing relevant tests pass

## Validation

- targeted AgentGateway MCP targets Jest suite: 4 tests passed
- ESLint on the changed TypeScript files: passed
- `git diff --check`: passed