### PR TITLE
fix(agentic-apps): support bounded large request bodies

### DIFF
--- a/docs/docs/features/agentic-apps.md
+++ b/docs/docs/features/agentic-apps.md
@@ -111,6 +111,8 @@ agentic_apps:
           mountPath: /apps/example-app
           preserveMountPath: false
           chrome: iframe
+          # Optional per-app limit. The default is 10 MiB; the maximum is 64 MiB.
+          maxRequestBodyBytes: 67108864
         surfaces:
           showInHub: true
           navOrder: 50
@@ -242,6 +244,14 @@ not run active health probes or use health state as an admission decision.
 Runtime connection failures return `502 upstream_unavailable`. Health-based
 launch admission is a separate follow-up.
 
-The runtime currently buffers request bodies before forwarding them. Large
-upload/import contracts need an explicit ingress limit and bounded or streaming
-BFF handling before they are advertised as supported.
+The runtime currently buffers request bodies before forwarding them. Requests
+default to a 10 MiB per-app limit and receive `413 request_body_too_large` when
+they exceed it. Set `runtime.maxRequestBodyBytes` when an application needs a
+larger upload/import contract, up to the per-app ceiling of 64 MiB. The host
+keeps one additional MiB of transport headroom so an oversized request can be
+rejected cleanly rather than forwarded as a truncated body.
+
+Every reverse proxy or ingress in front of the UI must also admit the configured
+per-app limit plus that transport headroom. For example, an app configured for
+64 MiB requests needs an upstream allowance of at least 65 MiB; otherwise the
+upstream proxy will reject the request before the app-specific limit is applied.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.4"
+version = "1.0.1-dev.5"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/next.config.ts
+++ b/ui/next.config.ts
@@ -94,6 +94,12 @@ const nextConfig: NextConfig = {
   ],
 
   experimental: {
+    // Proxy middleware must retain the body while rewriting /apps/<id> to the
+    // authenticated runtime route. Keep this aligned with the maximum allowed
+    // External App runtime limit; each app enforces its own (smaller) bound.
+    // One MiB of transport headroom lets the runtime return its own clean 413
+    // at the advertised 64 MiB per-app ceiling instead of forwarding a prefix.
+    proxyClientMaxBodySize: "65mb",
     serverActions: {
       bodySizeLimit: "2mb",
     },

--- a/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.test.ts
+++ b/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.test.ts
@@ -19,7 +19,7 @@ jest.mock("@/lib/agentic-apps/config", () => ({
   getConfiguredAgenticApp: (...args: unknown[]) => mockGetConfiguredAgenticApp(...args),
 }));
 
-import { GET } from "./route";
+import { GET, POST } from "./route";
 
 const configuredApp: ConfiguredAgenticApp = {
   manifest: {
@@ -131,6 +131,47 @@ describe("External App runtime route", () => {
     expect(response.headers.get("location")).toBe(
       "/apps/example-app/login?next=%2F",
     );
+    fetchMock.mockRestore();
+  });
+
+  it.each([
+    { scenario: "its declared length", includeContentLength: true },
+    { scenario: "the buffered body", includeContentLength: false },
+  ])("rejects an app request that exceeds $scenario", async ({ includeContentLength }) => {
+    const fetchMock = jest.spyOn(global, "fetch");
+    mockGetConfiguredAgenticApp.mockReturnValue({
+      ...configuredApp,
+      manifest: {
+        ...configuredApp.manifest,
+        runtime: {
+          ...configuredApp.manifest.runtime,
+          maxRequestBodyBytes: 4,
+        },
+        access: {
+          ...configuredApp.manifest.access,
+          policyActions: [{ action: "proxy:POST", defaultEffect: "allow" }],
+        },
+      },
+    } satisfies ConfiguredAgenticApp);
+
+    const response = await POST(
+      new NextRequest("https://host.example/api/agentic-apps/runtime/example-app/import", {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(includeContentLength ? { "content-length": "5" } : {}),
+        },
+        body: "12345",
+      }),
+      { params: Promise.resolve({ appId: "example-app", path: ["import"] }) },
+    );
+
+    expect(response.status).toBe(413);
+    expect(await response.json()).toEqual({
+      error: "request_body_too_large",
+      maxRequestBodyBytes: 4,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
     fetchMock.mockRestore();
   });
 });

--- a/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.ts
+++ b/ui/src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.ts
@@ -19,6 +19,7 @@ import {
 } from "@/lib/agentic-apps/runtime";
 import { mintAgenticAppToken } from "@/lib/agentic-apps/tokens";
 import { ApiError, getAuthenticatedUser } from "@/lib/api-middleware";
+import { DEFAULT_AGENTIC_APP_MAX_REQUEST_BODY_BYTES } from "@/types/agentic-app";
 
 const BLOCKED_RESPONSE_HEADERS = new Set([
   "connection",
@@ -124,6 +125,15 @@ async function proxyAgenticAppRequest(
     );
   }
 
+  const maxRequestBodyBytes = app.manifest.runtime.maxRequestBodyBytes
+    ?? DEFAULT_AGENTIC_APP_MAX_REQUEST_BODY_BYTES;
+  const declaredContentLength = parseContentLength(
+    request.headers.get("content-length"),
+  );
+  if (declaredContentLength !== null && declaredContentLength > maxRequestBodyBytes) {
+    return requestBodyTooLarge(maxRequestBodyBytes);
+  }
+
   const scopes = policy.requiredScopes?.length
     ? [...new Set(policy.requiredScopes)]
     : [...new Set(app.manifest.access.tokenScopes)];
@@ -147,6 +157,9 @@ async function proxyAgenticAppRequest(
   const body = shouldForwardBody(request.method)
     ? await request.arrayBuffer()
     : undefined;
+  if (body && body.byteLength > maxRequestBodyBytes) {
+    return requestBodyTooLarge(maxRequestBodyBytes);
+  }
 
   let upstream: Response;
   try {
@@ -252,6 +265,22 @@ function deriveRoles(session: Record<string, unknown>, role: string): string[] {
 
 function shouldForwardBody(method: string): boolean {
   return !["GET", "HEAD"].includes(method.toUpperCase());
+}
+
+function parseContentLength(value: string | null): number | null {
+  if (!value) return null;
+  const parsed = Number(value);
+  return Number.isSafeInteger(parsed) && parsed >= 0 ? parsed : null;
+}
+
+function requestBodyTooLarge(maxRequestBodyBytes: number): Response {
+  return Response.json(
+    {
+      error: "request_body_too_large",
+      maxRequestBodyBytes,
+    },
+    { status: 413 },
+  );
 }
 
 function isDocumentNavigation(request: Request): boolean {

--- a/ui/src/lib/agentic-apps/__tests__/config.test.ts
+++ b/ui/src/lib/agentic-apps/__tests__/config.test.ts
@@ -24,6 +24,7 @@ describe("External Apps deployment config", () => {
         expect.objectContaining({
           manifest: expect.objectContaining({
             id: "example-app",
+            runtime: expect.objectContaining({ maxRequestBodyBytes: 67108864 }),
             access: expect.objectContaining({ tokenScopes: ["example-app:read"] }),
           }),
           installation: expect.objectContaining({
@@ -33,6 +34,19 @@ describe("External Apps deployment config", () => {
         }),
       ]);
     });
+  });
+
+  it("rejects request-body limits outside the supported byte range", () => {
+    for (const invalid of [0, 1.5, 67108865]) {
+      withConfig(
+        validConfig().replace("maxRequestBodyBytes: 67108864", `maxRequestBodyBytes: ${invalid}`),
+        (path) => {
+          expect(() => loadConfiguredAgenticApps(path)).toThrow(
+            /maxRequestBodyBytes must/,
+          );
+        },
+      );
+    }
   });
 
   it("keeps the bundled Weather example compatible with the catalog parser", () => {
@@ -194,6 +208,7 @@ function validConfig(): string {
           origin: http://example-app.example.svc
           mountPath: /apps/example-app
           chrome: iframe
+          maxRequestBodyBytes: 67108864
         surfaces:
           showInHub: true
           navOrder: 50

--- a/ui/src/lib/agentic-apps/config.ts
+++ b/ui/src/lib/agentic-apps/config.ts
@@ -7,6 +7,7 @@ import type {
   AgenticAppPolicyAction,
   ConfiguredAgenticApp,
 } from "@/types/agentic-app";
+import { MAX_AGENTIC_APP_REQUEST_BODY_BYTES } from "@/types/agentic-app";
 
 const APP_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,61}[a-z0-9])?$/;
 const HTTP_METHODS = new Set(["GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"]);
@@ -178,6 +179,18 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
   }
 
   const runtimeRaw = asRecord(raw.runtime, `${path}.runtime`);
+  assertKnownKeys(
+    runtimeRaw,
+    [
+      "kind",
+      "origin",
+      "mountPath",
+      "preserveMountPath",
+      "chrome",
+      "maxRequestBodyBytes",
+    ],
+    `${path}.runtime`,
+  );
   if (runtimeRaw.kind !== "proxied-next-zone") {
     throw new Error(`${path}.runtime.kind must be "proxied-next-zone"`);
   }
@@ -252,6 +265,14 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
           }
         : {}),
       ...(runtimeRaw.chrome === "iframe" ? { chrome: "iframe" as const } : {}),
+      ...(runtimeRaw.maxRequestBodyBytes !== undefined
+        ? {
+            maxRequestBodyBytes: requiredRequestBodyLimit(
+              runtimeRaw.maxRequestBodyBytes,
+              `${path}.runtime.maxRequestBodyBytes`,
+            ),
+          }
+        : {}),
     },
     surfaces: {
       showInHub: optionalBoolean(
@@ -454,6 +475,19 @@ function requiredNumber(value: unknown, path: string): number {
     throw new Error(`${path} must be a finite number`);
   }
   return value;
+}
+
+function requiredRequestBodyLimit(value: unknown, path: string): number {
+  const result = requiredNumber(value, path);
+  if (!Number.isSafeInteger(result) || result < 1) {
+    throw new Error(`${path} must be a positive integer number of bytes`);
+  }
+  if (result > MAX_AGENTIC_APP_REQUEST_BODY_BYTES) {
+    throw new Error(
+      `${path} must not exceed ${MAX_AGENTIC_APP_REQUEST_BODY_BYTES} bytes`,
+    );
+  }
+  return result;
 }
 
 function requiredStringArray(

--- a/ui/src/types/agentic-app.ts
+++ b/ui/src/types/agentic-app.ts
@@ -1,5 +1,8 @@
 export type AgenticAppRuntimeKind = "proxied-next-zone";
 
+export const DEFAULT_AGENTIC_APP_MAX_REQUEST_BODY_BYTES = 10 * 1024 * 1024;
+export const MAX_AGENTIC_APP_REQUEST_BODY_BYTES = 64 * 1024 * 1024;
+
 export interface AgenticAppPolicyAction {
   action: string;
   description?: string;
@@ -21,6 +24,7 @@ export interface AgenticAppManifest {
     mountPath: string;
     preserveMountPath?: boolean;
     chrome?: "iframe";
+    maxRequestBodyBytes?: number;
   };
   surfaces: {
     showInHub: boolean;

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev4"
+version = "1.0.1.dev5"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Large uploads through an External App can currently reach the app as a truncated body. Next.js retains only 10 MiB by default while rewriting `/apps/<id>` through middleware, and the runtime route then forwards the retained prefix. JSON import endpoints consequently report malformed JSON instead of a useful size error.

This change makes large-body support explicit and bounded:

- raises the Next.js middleware transport ceiling to 65 MiB;
- adds `runtime.maxRequestBodyBytes` to each External App manifest, with a 10 MiB default and 64 MiB maximum;
- rejects an oversized declared or measured body with `413 request_body_too_large` before calling the app runtime; and
- documents that every upstream ingress or reverse proxy must allow the configured app limit plus transport headroom.

The 65 MiB middleware setting is a transport ceiling shared by External Apps. Each app retains its own smaller policy limit, and deployments should scope any larger ingress allowance to the application route that requires it.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

The branch uses the `prebuild/` prefix so the companion dev deployment can validate the generated CAIPE UI image before a durable release is published.

## Verification

- `npm test -- --runTestsByPath 'src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.test.ts' 'src/lib/agentic-apps/__tests__/config.test.ts --runInBand`
- `npm run lint -- --quiet`
- `npm run build`
- Confirmed the standalone build records `experimental.proxyClientMaxBodySize` as `68157440` bytes.
- `git diff --check`

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable; no matching open issue was found
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] No new selection control is introduced
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All focused tests and the production build pass
