### PR TITLE
fix(ui): restore agentic app create flow

### DIFF
--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -351,6 +351,7 @@ jobs:
           # those components exist in the server markup for the mocks to drive.
           MONGODB_URI: 'mongodb://mock:27017'
           MONGODB_DATABASE: 'mock'
+          NEXTAUTH_SECRET: 'ci-nextauth-secret-for-playwright-regression-2026'
         run: npm run build
 
       - name: Start CAIPE UI server
@@ -360,6 +361,7 @@ jobs:
           NEXT_PUBLIC_SSO_ENABLED: 'true'
           MONGODB_URI: 'mongodb://mock:27017'
           MONGODB_DATABASE: 'mock'
+          NEXTAUTH_SECRET: 'ci-nextauth-secret-for-playwright-regression-2026'
         run: |
           # Run the production server, not `next dev`: React StrictMode
           # double-invokes effects only in dev, which breaks exact

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.8"
+version = "1.0.1-dev.9"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/app/(app)/apps/create/page.tsx
+++ b/ui/src/app/(app)/apps/create/page.tsx
@@ -1,0 +1,7 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+import { AgenticAppCreateGuide } from "@/components/agentic-apps/AgenticAppCreateGuide";
+
+export default function CreateAgenticAppPage() {
+  return <AgenticAppCreateGuide />;
+}

--- a/ui/src/components/agentic-apps/AgenticAppCreateGuide.tsx
+++ b/ui/src/components/agentic-apps/AgenticAppCreateGuide.tsx
@@ -1,0 +1,76 @@
+// assisted-by Codex Codex-sonnet-4-6
+
+const STEPS = [
+  {
+    title: "Choose the runtime",
+    body: "Start with a separate process or container and expose health, API, and optional /embed fragment endpoints.",
+  },
+  {
+    title: "Declare the manifest",
+    body: "Define the app ID, /apps/* mount path, RBAC, token scopes, agents, data access, and health check.",
+  },
+  {
+    title: "Pick the render mode",
+    body: "Use a CAIPE-owned integrated page for native shell UX, then call proxied app APIs for data and AG-UI layout intent.",
+  },
+  {
+    title: "Install as admin",
+    body: "Enable the app from host configuration first; admin-installed catalog and policy editing can replace static config later.",
+  },
+];
+
+export function AgenticAppCreateGuide() {
+  return (
+    <main className="flex-1 overflow-y-auto bg-slate-950 px-6 py-8 text-slate-100">
+      <div className="mx-auto flex max-w-6xl flex-col gap-8">
+        <section className="rounded-3xl border border-violet-300/20 bg-gradient-to-br from-violet-500/15 via-cyan-400/10 to-slate-900 p-8 shadow-2xl shadow-violet-950/30">
+          <p className="text-sm font-semibold uppercase tracking-[0.24em] text-violet-200">
+            Agentic app builder
+          </p>
+          <h1 className="mt-3 text-4xl font-semibold tracking-tight text-white">
+            Create or add your app
+          </h1>
+          <p className="mt-4 max-w-3xl text-base leading-7 text-slate-300">
+            Use this guide to turn a team-owned agentic UI into a trusted CAIPE app:
+            separate runtime, explicit manifest, host-owned auth, and integrated
+            rendering where the CAIPE shell stays visible.
+          </p>
+        </section>
+
+        <section className="grid gap-5 md:grid-cols-2">
+          {STEPS.map((step, index) => (
+            <article
+              key={step.title}
+              className="rounded-3xl border border-white/10 bg-slate-900/75 p-6 shadow-xl shadow-slate-950/30"
+            >
+              <div className="flex h-10 w-10 items-center justify-center rounded-2xl border border-cyan-200/20 bg-cyan-300/10 text-sm font-semibold text-cyan-100">
+                {index + 1}
+              </div>
+              <h2 className="mt-5 text-xl font-semibold text-white">{step.title}</h2>
+              <p className="mt-3 text-sm leading-6 text-slate-300">{step.body}</p>
+            </article>
+          ))}
+        </section>
+
+        <section className="rounded-3xl border border-white/10 bg-slate-900/75 p-6">
+          <h2 className="text-xl font-semibold text-white">Starter contract</h2>
+          <pre className="mt-5 overflow-auto rounded-2xl border border-cyan-300/20 bg-slate-950/80 p-4 text-xs leading-5 text-cyan-100">
+{`{
+  "id": "my-agentic-app",
+  "runtime": {
+    "kind": "proxied-next-zone",
+    "origin": "http://localhost:3020",
+    "mountPath": "/apps/my-agentic-app"
+  },
+  "access": {
+    "roles": ["user"],
+    "tokenScopes": ["agents:invoke"]
+  },
+  "health": { "endpoint": "/healthz" }
+}`}
+          </pre>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/ui/src/components/agentic-apps/AgenticAppsHub.tsx
+++ b/ui/src/components/agentic-apps/AgenticAppsHub.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { ArrowUpRight, LayoutGrid, LoaderCircle, Search } from "lucide-react";
+import { ArrowUpRight, LayoutGrid, LoaderCircle, Plus, Search } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
+import Link from "next/link";
 
 import type { PublicAgenticApp } from "@/types/agentic-app";
 
@@ -61,18 +62,28 @@ export function AgenticAppsHub(): React.ReactElement {
     <main className="flex-1 overflow-y-auto bg-background px-6 py-8">
       <div className="mx-auto flex max-w-6xl flex-col gap-6">
         <header>
-          <div className="flex items-center gap-3">
-            <span className="rounded-xl bg-primary/10 p-2 text-primary">
-              <LayoutGrid className="h-6 w-6" aria-hidden />
-            </span>
-            <div>
-              <h1 className="text-3xl font-semibold tracking-tight">Apps</h1>
-              <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
-                Open web applications registered by your platform team. Each app runs
-                independently while CAIPE provides sign-in, navigation, and a secure
-                same-origin connection.
-              </p>
+          <div className="flex items-center justify-between gap-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <span className="rounded-xl bg-primary/10 p-2 text-primary">
+                <LayoutGrid className="h-6 w-6" aria-hidden />
+              </span>
+              <div>
+                <h1 className="text-3xl font-semibold tracking-tight">Apps</h1>
+                <p className="mt-1 max-w-3xl text-sm text-muted-foreground">
+                  Open web applications registered by your platform team. Each app runs
+                  independently while CAIPE provides sign-in, navigation, and a secure
+                  same-origin connection.
+                </p>
+              </div>
             </div>
+            <Link
+              href="/apps/create"
+              className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-primary/30 bg-primary/10 text-primary shadow-sm transition hover:bg-primary/20"
+              aria-label="Create or add your app"
+              title="Create or add your app"
+            >
+              <Plus className="h-5 w-5" aria-hidden />
+            </Link>
           </div>
         </header>
 
@@ -109,6 +120,14 @@ export function AgenticAppsHub(): React.ReactElement {
                 <h2 className="text-lg font-semibold">No Apps are configured</h2>
                 <p className="mt-2 text-sm text-muted-foreground">
                   An operator can add an app through the deployment-owned catalog.
+                </p>
+                <p className="mt-5 text-sm text-muted-foreground">
+                  Start with{" "}
+                  <Link className="font-semibold text-primary" href="/apps/create">
+                    Create or add your app
+                  </Link>{" "}
+                  to choose a manifest, runtime, access policy, and integrated
+                  rendering mode.
                 </p>
               </section>
             ) : visibleApps.length === 0 ? (

--- a/ui/src/components/agentic-apps/__tests__/AgenticAppsHub.test.tsx
+++ b/ui/src/components/agentic-apps/__tests__/AgenticAppsHub.test.tsx
@@ -1,0 +1,39 @@
+import { render, screen, waitFor } from "@testing-library/react";
+
+import { AgenticAppsHub } from "../AgenticAppsHub";
+
+jest.mock("@/lib/api-client", () => ({
+  apiClient: {
+    getSettings: jest.fn().mockResolvedValue({ preferences: {} }),
+  },
+}));
+
+describe("AgenticAppsHub", () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [] }),
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it("keeps the create/add flow discoverable when no apps are configured", async () => {
+    render(<AgenticAppsHub />);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByRole("link", { name: "Create or add your app" }),
+      ).toHaveLength(2);
+    });
+
+    for (const link of screen.getAllByRole("link", { name: "Create or add your app" })) {
+      expect(link).toHaveAttribute("href", "/apps/create");
+    }
+  });
+});

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -70,16 +70,23 @@ function titleCaseRouteSegment(segment: string): string {
 export function getApplicationBreadcrumbs(
   pathname: string,
 ): WorkspaceBreadcrumbItem[] {
-  const section = pathname.split("/").filter(Boolean)[0];
+  const segments = pathname.split("/").filter(Boolean);
+  const section = segments[0];
   if (!section) return [];
 
-  return [
+  const breadcrumbs: WorkspaceBreadcrumbItem[] = [
     { label: "Home",href: "/" },
     {
       label: APPLICATION_SECTION_LABELS[section] ?? titleCaseRouteSegment(section),
       href: `/${section}`,
     },
   ];
+
+  if (section === "apps" && segments[1] === "create") {
+    breadcrumbs.push({ label: "Create App" });
+  }
+
+  return breadcrumbs;
 }
 
 export function AppHeader() {

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -327,7 +327,7 @@ jest.mock('@/lib/utils', () => ({
 // Imports — after mocks
 // ============================================================================
 
-import { AppHeader } from '../AppHeader'
+import { AppHeader, getApplicationBreadcrumbs } from '../AppHeader'
 import { ApplicationNavigationRail } from '../ApplicationNavigation'
 import { HeaderBreadcrumbSlotProvider } from '../HeaderBreadcrumbSlot'
 import { WorkspaceHierarchicalNavigationList } from '../WorkspaceNavigation'
@@ -549,6 +549,14 @@ describe('AppHeader — application chrome', () => {
       const breadcrumb = within(slot).getByRole('navigation', { name: 'Breadcrumb' })
       expect(within(breadcrumb).getByText('Home')).toHaveAttribute('href', '/')
       expect(within(breadcrumb).getByText('Skills')).toHaveAttribute('href', '/skills')
+    })
+
+    it('provides a Create App breadcrumb for the app creation guide', () => {
+      expect(getApplicationBreadcrumbs('/apps/create')).toEqual([
+        { label: 'Home', href: '/' },
+        { label: 'Apps', href: '/apps' },
+        { label: 'Create App' },
+      ])
     })
 
     it('does not repeat Home as a breadcrumb on the Home route', () => {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev8"
+version = "1.0.1.dev9"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
## Description

Restore the agentic app creation flow that was removed from the app catalog during upstream sync PR [#585](https://github.com/cisco-eti/ai-platform-engineering-mirror/pull/585).

This restores:
- The header “Create or add your app” CTA.
- The empty-state link to `/apps/create`.
- Create App breadcrumb handling.
- Regression coverage for the restored entry points.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] Existing PR context has been referenced ([#585](https://github.com/cisco-eti/ai-platform-engineering-mirror/pull/585)).
- [x] All code style checks pass.
- [x] New code is covered by automated tests.

## Validation

- Focused Jest tests: 65 passed.
- Targeted ESLint: passed.
- TypeScript check: passed.
- Full production build is currently blocked by the pre-existing invalid route export `__resetKeycloakHealthSummaryCacheForTests` in `api/admin/keycloak/migration-health/summary/route.ts`.