### PR TITLE
fix(workflows): validate stale tool overrides before execution

### DIFF
--- a/ui/src/app/api/workflow-configs/route.ts
+++ b/ui/src/app/api/workflow-configs/route.ts
@@ -10,15 +10,16 @@ filterAccessibleWorkflowConfigs,
 workflowAccessAllowed,
 } from "@/lib/server/workflow-cas-authz";
 import {
-buildTeamRefToSlugMap,
+  buildTeamRefToSlugMap,
 filterWorkflowConfigsByRunAccess,
 mergeWorkflowConfigsById,
 normalizeSharedWithTeamSlugs,
 reconcileWorkflowConfigAccess,
 requireWorkflowConfigRunAccess,
 requireWorkflowConfigWriteAccess,
-resolveUserTeamSlugsForWorkflow,
+  resolveUserTeamSlugsForWorkflow,
 } from "@/lib/rbac/workflow-config-rebac";
+import { assertWorkflowConfigRunnable } from "@/lib/server/workflow-step-agents";
 import type {
 CreateWorkflowConfigInput,
 StepEntry,
@@ -222,6 +223,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       updated_at: now,
     };
 
+    await assertWorkflowConfigRunnable(config);
+
     const collection = await getCollection<WorkflowConfig>("workflow_configs");
     await collection.insertOne(config);
 
@@ -324,6 +327,8 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       visibility: mergedVisibility,
       shared_with_teams: mergedSharedWithTeams,
     };
+
+    await assertWorkflowConfigRunnable(merged);
 
     await reconcileWorkflowConfigAccess(session, merged, existing);
 

--- a/ui/src/app/api/workflow-runs/route.ts
+++ b/ui/src/app/api/workflow-runs/route.ts
@@ -29,14 +29,15 @@ workflowSubjectFromSession,
 type WorkflowAuthzSession,
 } from "@/lib/server/workflow-cas-authz";
 import {
-buildTeamRefToSlugMap,
+  buildTeamRefToSlugMap,
 filterWorkflowConfigsByRunAccess,
 mergeWorkflowConfigsById,
 requireWorkflowConfigRunAccess,
 requireWorkflowConfigRunViewAccess,
 resolveUserTeamSlugsForWorkflow,
-type WorkflowConfigRebacSnapshot,
+  type WorkflowConfigRebacSnapshot,
 } from "@/lib/rbac/workflow-config-rebac";
+import { assertWorkflowConfigRunnable } from "@/lib/server/workflow-step-agents";
 import type { WorkflowConfig } from "@/types/workflow-config";
 import { NextRequest,NextResponse } from "next/server";
 
@@ -161,6 +162,8 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     user.email,
     userTeamSlugs,
   );
+
+  await assertWorkflowConfigRunnable(config);
 
   // Build auth headers for DA server calls. Prefer the incoming Bearer; fall
   // back to the session's OIDC access token so browser (cookie) sessions still

--- a/ui/src/components/workflows/StepToolOverridePicker.tsx
+++ b/ui/src/components/workflows/StepToolOverridePicker.tsx
@@ -171,6 +171,12 @@ export function StepToolOverridePicker({
     },
     [configOverride],
   );
+  const staleOverrideServers = useMemo(
+    () => Object.keys(overrideAllowedTools ?? {})
+      .filter((serverId) => !Object.prototype.hasOwnProperty.call(baseAllowedTools, serverId))
+      .sort(),
+    [baseAllowedTools, overrideAllowedTools],
+  );
   const overrideBuiltinTools = useMemo(
     () => configOverride?.builtin_tools as Record<string, { enabled?: boolean }> | undefined,
     [configOverride],
@@ -399,7 +405,19 @@ export function StepToolOverridePicker({
               Select an agent to configure tool access.
             </p>
           ) : (
-            <fieldset disabled={!!readOnly} className="space-y-3">
+            <>
+              {staleOverrideServers.length > 0 && (
+                <div
+                  role="alert"
+                  className="mb-3 flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-[11px] text-amber-700 dark:text-amber-300"
+                >
+                  <AlertTriangle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+                  <span>
+                    This saved override references unavailable server{staleOverrideServers.length !== 1 ? "s" : ""}: {staleOverrideServers.join(", ")}. Refresh the agent configuration and recreate the step override before running.
+                  </span>
+                </div>
+              )}
+              <fieldset disabled={!!readOnly} className="space-y-3">
               {/* Mode toggle */}
               <div className="flex gap-2">
                 <button
@@ -591,7 +609,8 @@ export function StepToolOverridePicker({
                   )}
                 </div>
               )}
-            </fieldset>
+              </fieldset>
+            </>
           )}
         </div>
       )}

--- a/ui/src/lib/server/__tests__/workflow-step-agents.test.ts
+++ b/ui/src/lib/server/__tests__/workflow-step-agents.test.ts
@@ -1,0 +1,120 @@
+/**
+ * @jest-environment node
+ */
+
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+import type { WorkflowConfig, WorkflowStep } from "@/types/workflow-config";
+import { assertWorkflowConfigRunnable } from "../workflow-step-agents";
+
+function step(configOverride?: Record<string, unknown> | null): WorkflowStep {
+  return {
+    type: "step",
+    display_text: "Run step",
+    agent_id: "agent-a",
+    prompt: "Do the thing",
+    on_error: "abort",
+    config_override: configOverride,
+  };
+}
+
+function config(configOverride?: Record<string, unknown> | null): WorkflowConfig {
+  return {
+    _id: "workflow-a",
+    name: "Workflow A",
+    steps: [step(configOverride)],
+    owner_id: "owner@example.com",
+    visibility: "private",
+    created_at: new Date(),
+    updated_at: new Date(),
+  };
+}
+
+function mockAgents(agents: Array<Record<string, unknown>>): void {
+  const toArray = jest.fn().mockResolvedValue(agents);
+  const project = jest.fn().mockReturnValue({ toArray });
+  mockGetCollection.mockResolvedValue({
+    find: jest.fn().mockReturnValue({ project }),
+  });
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("assertWorkflowConfigRunnable", () => {
+  it("allows a tool override that is a subset of the base agent", async () => {
+    mockAgents([
+      {
+        _id: "agent-a",
+        allowed_tools: { "mcp-primary": ["search", "get"] },
+      },
+    ]);
+
+    await expect(
+      assertWorkflowConfigRunnable(
+        config({ allowed_tools: { "mcp-primary": ["search"] } }),
+      ),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects a stale server ID before the workflow can run", async () => {
+    mockAgents([
+      {
+        _id: "agent-a",
+        allowed_tools: { "mcp-primary": true },
+      },
+    ]);
+
+    await expect(
+      assertWorkflowConfigRunnable(config({ allowed_tools: { primary: false } })),
+    ).rejects.toMatchObject({
+      statusCode: 400,
+      code: "WORKFLOW_TOOL_OVERRIDE_INVALID",
+      message: expect.stringContaining("unknown server(s): primary"),
+    });
+  });
+
+  it("rejects tools that are not present in a list-based base server", async () => {
+    mockAgents([
+      {
+        _id: "agent-a",
+        allowed_tools: { "mcp-primary": ["search"] },
+      },
+    ]);
+
+    await expect(
+      assertWorkflowConfigRunnable(
+        config({ allowed_tools: { "mcp-primary": ["delete"] } }),
+      ),
+    ).rejects.toThrow("unknown tools: delete");
+  });
+
+  it("rejects re-enabling a server disabled on the base agent", async () => {
+    mockAgents([
+      {
+        _id: "agent-a",
+        allowed_tools: { "mcp-primary": false },
+      },
+    ]);
+
+    await expect(
+      assertWorkflowConfigRunnable(
+        config({ allowed_tools: { "mcp-primary": ["search"] } }),
+      ),
+    ).rejects.toThrow("server is disabled on the base agent");
+  });
+
+  it("rejects missing workflow agents", async () => {
+    mockAgents([]);
+
+    await expect(assertWorkflowConfigRunnable(config())).rejects.toMatchObject({
+      statusCode: 400,
+      code: "WORKFLOW_AGENT_NOT_FOUND",
+    });
+  });
+});

--- a/ui/src/lib/server/workflow-step-agents.ts
+++ b/ui/src/lib/server/workflow-step-agents.ts
@@ -1,6 +1,32 @@
 import { ApiError } from "@/lib/api-middleware";
 import { getCollection } from "@/lib/mongodb";
-import type { WorkflowConfig, WorkflowStep } from "@/types/workflow-config";
+import {
+  flattenStepEntries,
+  type WorkflowConfig,
+  type WorkflowStep,
+} from "@/types/workflow-config";
+
+type AgentToolConfig = {
+  _id: string;
+  allowed_tools?: Record<string, string[] | boolean>;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isAllowedToolsValue(value: unknown): value is string[] | boolean {
+  return value === true || value === false ||
+    (Array.isArray(value) && value.every((tool) => typeof tool === "string"));
+}
+
+async function loadWorkflowAgents(agentIds: string[]): Promise<AgentToolConfig[]> {
+  const agentCol = await getCollection<AgentToolConfig>("dynamic_agents");
+  return (await agentCol
+    .find({ _id: { $in: agentIds } })
+    .project({ _id: 1, allowed_tools: 1 })
+    .toArray()) as AgentToolConfig[];
+}
 
 /**
  * Fail fast when a workflow references dynamic agent IDs that are not in MongoDB.
@@ -33,6 +59,112 @@ export async function assertWorkflowStepAgentsExist(config: WorkflowConfig): Pro
         "Open the workflow in the editor, select each step, and choose an agent from the catalog " +
         "(or update config/app-config.yaml for config-driven workflows and restart the UI).",
       400,
+    );
+  }
+}
+
+/**
+ * Validate workflow agent references and per-step allowed_tools overrides
+ * before a workflow is persisted or started.
+ *
+ * Dynamic Agents deliberately reject overrides that add a server or tool to
+ * the base agent. Checking the same contract at the UI boundary turns an
+ * asynchronous step failure into an actionable save/run error and catches
+ * stale server IDs after an MCP server rename.
+ */
+export async function assertWorkflowConfigRunnable(config: WorkflowConfig): Promise<void> {
+  const flatSteps = flattenStepEntries(config.steps ?? []);
+  const agentIds = [
+    ...new Set(
+      flatSteps
+        .map(({ step }) => step.agent_id)
+        .filter((id): id is string => Boolean(id?.trim())),
+    ),
+  ];
+
+  if (agentIds.length === 0) {
+    return;
+  }
+
+  const agents = await loadWorkflowAgents(agentIds);
+  const agentsById = new Map(agents.map((agent) => [String(agent._id), agent]));
+  const missing = agentIds.filter((id) => !agentsById.has(id));
+
+  if (missing.length > 0) {
+    throw new ApiError(
+      `This workflow references agent(s) that do not exist: ${missing.join(", ")}. ` +
+        "Open the workflow in the editor, select each step, and choose an agent from the catalog " +
+        "(or update config/app-config.yaml for config-driven workflows and restart the UI).",
+      400,
+      "WORKFLOW_AGENT_NOT_FOUND",
+    );
+  }
+
+  const violations: string[] = [];
+  for (const { index, step } of flatSteps) {
+    const rawOverride = step.config_override?.allowed_tools;
+    if (rawOverride === undefined || rawOverride === null) {
+      continue;
+    }
+
+    const agent = agentsById.get(step.agent_id);
+    if (!agent) continue;
+
+    if (!isRecord(rawOverride)) {
+      violations.push(
+        `step ${index} ("${step.display_text}") has an allowed_tools override that must be an object`,
+      );
+      continue;
+    }
+
+    const baseAllowedTools = isRecord(agent.allowed_tools) ? agent.allowed_tools : {};
+    const unknownServers: string[] = [];
+    const invalidTools: string[] = [];
+
+    for (const [serverId, overrideValue] of Object.entries(rawOverride)) {
+      if (!Object.prototype.hasOwnProperty.call(baseAllowedTools, serverId)) {
+        unknownServers.push(serverId);
+        continue;
+      }
+
+      if (!isAllowedToolsValue(overrideValue)) {
+        invalidTools.push(`${serverId} (value must be true, false, or a string array)`);
+        continue;
+      }
+
+      const baseValue = baseAllowedTools[serverId];
+      if (baseValue === false && overrideValue !== false) {
+        invalidTools.push(`${serverId} (server is disabled on the base agent)`);
+        continue;
+      }
+
+      if (Array.isArray(baseValue) && Array.isArray(overrideValue)) {
+        const extraTools = overrideValue.filter((tool) => !baseValue.includes(tool));
+        if (extraTools.length > 0) {
+          invalidTools.push(`${serverId} (unknown tools: ${extraTools.join(", ")})`);
+        }
+      }
+    }
+
+    if (unknownServers.length > 0 || invalidTools.length > 0) {
+      const availableServers = Object.keys(baseAllowedTools).sort();
+      const details = [
+        unknownServers.length > 0 ? `unknown server(s): ${unknownServers.sort().join(", ")}` : null,
+        invalidTools.length > 0 ? `invalid server/tool selection(s): ${invalidTools.join("; ")}` : null,
+      ].filter((detail): detail is string => detail !== null);
+      violations.push(
+        `step ${index} ("${step.display_text}", agent "${step.agent_id}"): ${details.join("; ")}. ` +
+          `Available base servers: ${availableServers.length > 0 ? availableServers.join(", ") : "none"}`,
+      );
+    }
+  }
+
+  if (violations.length > 0) {
+    throw new ApiError(
+      "Workflow tool access validation failed. Refresh the agent configuration and recreate the " +
+        `step override(s): ${violations.join(" | ")}`,
+      400,
+      "WORKFLOW_TOOL_OVERRIDE_INVALID",
     );
   }
 }


### PR DESCRIPTION
## Description

Prevent workflow runs from failing asynchronously when a persisted per-step `allowed_tools` override no longer matches the selected dynamic agent's current configuration.

This can happen after an MCP server ID rename or when an agent's tool configuration changes. Dynamic Agents correctly enforce the subset rule at execution time, but the workflow UI previously allowed stale overrides to persist until the first run.

## Changes

- Validate workflow agent references and per-step `allowed_tools` overrides against the current dynamic-agent configuration before saving or starting a run.
- Return actionable 400 errors for missing agents, unknown servers, disabled-server re-enables, malformed values, and tools outside a list-based base server.
- Show a warning in the workflow editor when a saved override references an unavailable server ID.
- Add unit coverage for valid subsets and each invalid override category.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Verification

- Focused workflow/API tests: 14 passed
- TypeScript check: passed
- Targeted ESLint: passed
- Next.js production build: passed
