### PR TITLE
fix(agentic-apps): restore contextual assistant overlay

### DIFF
--- a/.github/workflows/caipe-ui-tests.yml
+++ b/.github/workflows/caipe-ui-tests.yml
@@ -352,6 +352,9 @@ jobs:
           MONGODB_URI: 'mongodb://mock:27017'
           MONGODB_DATABASE: 'mock'
           NEXTAUTH_SECRET: 'ci-nextauth-secret-for-playwright-regression-2026'
+          CAIPE_UNSAFE_RBAC_BYPASS: 'true'
+          CAIPE_CREDENTIALS_ENABLED: 'true'
+          CAIPE_USER_CONNECTIONS_ENABLED: 'true'
         run: npm run build
 
       - name: Start CAIPE UI server
@@ -362,6 +365,9 @@ jobs:
           MONGODB_URI: 'mongodb://mock:27017'
           MONGODB_DATABASE: 'mock'
           NEXTAUTH_SECRET: 'ci-nextauth-secret-for-playwright-regression-2026'
+          CAIPE_UNSAFE_RBAC_BYPASS: 'true'
+          CAIPE_CREDENTIALS_ENABLED: 'true'
+          CAIPE_USER_CONNECTIONS_ENABLED: 'true'
         run: |
           # Run the production server, not `next dev`: React StrictMode
           # double-invokes effects only in dev, which breaks exact
@@ -393,6 +399,11 @@ jobs:
           CAIPE_UI_BASE_URL: http://localhost:3000
           WORKFLOWS_ENABLED: 'true'
           NEXTAUTH_SECRET: 'ci-nextauth-secret-for-playwright-regression-2026'
+          # The mocked credentials specs exercise protected personal pages. In
+          # this isolated browser lane, use the explicit test-only bypass so
+          # they do not require a live OpenFGA service; authorization remains
+          # covered by the route mocks and the live RBAC lane.
+          CAIPE_UNSAFE_RBAC_BYPASS: 'true'
         run: |
           # Run every mocked-RBAC spec under e2e/rbac/, excluding the
           # *-live.spec.ts files (those need live Keycloak/OpenFGA infra and

--- a/ui/e2e/rbac/_credentials-browser-fixtures.ts
+++ b/ui/e2e/rbac/_credentials-browser-fixtures.ts
@@ -232,6 +232,18 @@ function credentialSecretsHandler(
       return true;
     }
 
+    if (path === "/api/dynamic-agents/teams" && method === "GET") {
+      await fulfillJson(route, {
+        success: true,
+        data: DEFAULT_CREDENTIAL_TEAMS.map((team) => ({
+          _id: team._id,
+          slug: team.slug,
+          name: team.name,
+        })),
+      });
+      return true;
+    }
+
     if (path === "/api/admin/credentials/secrets" && method === "GET") {
       await fulfillJson(route, { success: true, data: state.secrets });
       return true;

--- a/ui/e2e/rbac/chat-deprecated-agent.spec.ts
+++ b/ui/e2e/rbac/chat-deprecated-agent.spec.ts
@@ -436,6 +436,7 @@ test.describe("mocked RBAC e2e — deprecated / unlinked agent conversations", (
     await page.getByRole("button", { name: /Resume with default agent/i }).click();
 
     await expect(page.getByText("Agent No Longer Available")).not.toBeVisible({ timeout: 8_000 });
+    await expect.poll(() => capturedBody, { timeout: 20_000 }).not.toBeNull();
     expect(capturedBody).toMatchObject({
       participants: expect.arrayContaining([
         expect.objectContaining({ type: "agent", id: DEFAULT_AGENT_ID }),

--- a/ui/e2e/rbac/chat-navigation-regression.spec.ts
+++ b/ui/e2e/rbac/chat-navigation-regression.spec.ts
@@ -176,7 +176,7 @@ test.describe("mocked RBAC e2e — chat navigation regression", () => {
     });
 
     await page.goto("/chat", { waitUntil: "domcontentloaded" });
-    await expect(page).toHaveURL(/\/chat\/rbac-slow-list-conv$/);
+    await expect(page).toHaveURL(/\/chat\/rbac-slow-list-conv$/, { timeout: 20_000 });
     await expectChatComposerReady(page);
 
     expect(createCallCount).toBe(0);

--- a/ui/e2e/rbac/chat-navigation-regression.spec.ts
+++ b/ui/e2e/rbac/chat-navigation-regression.spec.ts
@@ -149,7 +149,7 @@ test.describe("mocked RBAC e2e — chat navigation regression", () => {
     await expect(dialog.getByText(SHARED_OWNER_EMAIL)).toBeVisible();
     await expect(dialog.getByText("Share Link")).toBeVisible();
     await expect(dialog.locator('input[readonly]').first()).toHaveValue(`${env.baseUrl}/chat/${conversationId}`);
-    await expect(dialog.getByText("Can edit")).toBeVisible();
+    await expect(dialog.getByText("Can edit", { exact: true })).toBeVisible();
     await expect(dialog.getByPlaceholder("Search by email or team name...")).toHaveCount(0);
     await expect(dialog.getByRole("switch", { name: "Share with everyone" })).toHaveCount(0);
   });

--- a/ui/e2e/rbac/chat-navigation-regression.spec.ts
+++ b/ui/e2e/rbac/chat-navigation-regression.spec.ts
@@ -65,7 +65,7 @@ test.describe("mocked RBAC e2e — chat navigation regression", () => {
 
     for (let i = 0; i < 3; i += 1) {
       await page.goto("/chat", { waitUntil: "domcontentloaded" });
-      await expect(page).toHaveURL(/\/chat\/rbac-resume-conv$/);
+      await expect(page).toHaveURL(/\/chat\/rbac-resume-conv$/, { timeout: 20_000 });
     }
 
     await dismissReleaseUpgradeDialog(page);

--- a/ui/e2e/rbac/chat-workflow-run-card-hitl.spec.ts
+++ b/ui/e2e/rbac/chat-workflow-run-card-hitl.spec.ts
@@ -261,7 +261,9 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
 
     // Field labels should be visible
     await expect(page.getByText("Key Type")).toBeVisible();
-    await expect(page.getByText("Model")).toBeVisible();
+    await expect(
+      page.locator("label").filter({ hasText: /^Model\*?$/ }),
+    ).toBeVisible();
 
     // Submit button should be present
     await expect(page.getByRole("button", { name: /submit/i })).toBeVisible();
@@ -380,7 +382,6 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
     };
 
     let resumeCallBody: unknown = null;
-    let pollCount = 0;
 
     await installChatWorkflowMocks(page, env, waitingRun);
 
@@ -393,8 +394,7 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
     await page.route("**/api/workflow-runs**", async (route) => {
       const url = new URL(route.request().url());
       if (route.request().method() === "GET" && url.searchParams.get("run_id") === RUN_ID) {
-        pollCount++;
-        const fixture = pollCount > 1 ? resumedRun : waitingRun;
+        const fixture = resumeCallBody ? resumedRun : waitingRun;
         await route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -402,7 +402,7 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
         });
         return;
       }
-      await route.continue();
+      await route.fallback();
     });
 
     await installTestSession(page, env, {
@@ -419,7 +419,7 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
     await expect(page.getByText("Confirm to proceed")).toBeVisible();
 
     // Fill in the confirmation field
-    await page.getByLabel("Confirmation").fill("yes");
+    await page.getByPlaceholder("Enter confirmation...").fill("yes");
 
     // Submit
     await page.getByRole("button", { name: /submit/i }).click();
@@ -432,7 +432,7 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
 
     // After resume, card transitions to running state (form disappears)
     await expect(page.getByText("Confirm to proceed")).not.toBeVisible({ timeout: 5000 });
-    await expect(page.getByText("Running")).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText("Running", { exact: true })).toBeVisible({ timeout: 5000 });
   });
 
   test("shows normal compact card for running workflow (no form)", async ({ page }) => {
@@ -471,8 +471,8 @@ test.describe("mocked RBAC e2e — WorkflowRunCard HITL inline form", () => {
     await expectChatComposerReady(page);
 
     // Compact card shown
-    await expect(page.getByText("Global SRE workflow")).toBeVisible();
-    await expect(page.getByText("Running")).toBeVisible();
+    await expect(page.getByText("Global SRE workflow", { exact: true })).toBeVisible();
+    await expect(page.getByText("Running", { exact: true })).toBeVisible();
 
     // No input form visible
     await expect(page.getByRole("button", { name: /submit/i })).not.toBeVisible();

--- a/ui/e2e/rbac/mcp-caller-scoped-credentials.spec.ts
+++ b/ui/e2e/rbac/mcp-caller-scoped-credentials.spec.ts
@@ -230,10 +230,13 @@ test.describe("RBAC e2e — caller-scoped MCP credentials", () => {
       await expect(page.getByText(/cannot access Jira without your Atlassian connection/i)).toBeVisible();
 
       await installCredentialsBrowserMocks(page);
-      await connectLink.click({ force: true });
-
-      await expect(page).toHaveURL(/\/credentials\/connections$/);
-      await expect(page.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
+      const connectedAppsPage = await Promise.all([
+        page.waitForEvent("popup"),
+        connectLink.click({ force: true }),
+      ]).then(([popup]) => popup);
+      await connectedAppsPage.waitForLoadState("domcontentloaded");
+      await expect(connectedAppsPage).toHaveURL(/\/credentials\/connections$/);
+      await expect(connectedAppsPage.getByRole("heading", { name: "Connected Apps" })).toBeVisible();
     });
   });
 });

--- a/ui/e2e/rbac/org-secret-ownership.spec.ts
+++ b/ui/e2e/rbac/org-secret-ownership.spec.ts
@@ -65,15 +65,15 @@ test.describe("org-level secret ownership", () => {
     const createRequests: Array<Record<string, unknown>> = [];
     await page.route("**/api/credentials/secrets", async (route) => {
       if (route.request().method() === "POST") {
-        const body = await route.request().postDataJSON().catch(() => null);
+        const body = route.request().postDataJSON();
         createRequests.push(body as Record<string, unknown>);
       }
-      await route.continue();
+      await route.fallback();
     });
 
     await page.getByRole("button", { name: /add secret/i }).click();
     await page.getByLabel(/name/i).fill("Org-level test secret");
-    await page.getByLabel(/value/i).fill("raw-token-value");
+    await page.getByRole("textbox", { name: "Secret value" }).fill("raw-token-value");
     await page.getByLabel(/Save as organization secret/i).check();
     await page.getByRole("button", { name: /save/i }).click();
 
@@ -102,15 +102,15 @@ test.describe("org-level secret ownership", () => {
     const createRequests: Array<Record<string, unknown>> = [];
     await page.route("**/api/credentials/secrets", async (route) => {
       if (route.request().method() === "POST") {
-        const body = await route.request().postDataJSON().catch(() => null);
+        const body = route.request().postDataJSON();
         createRequests.push(body as Record<string, unknown>);
       }
-      await route.continue();
+      await route.fallback();
     });
 
     await page.getByRole("button", { name: /add secret/i }).click();
     await page.getByLabel(/name/i).fill("Personal test secret");
-    await page.getByLabel(/value/i).fill("raw-token-value");
+    await page.getByRole("textbox", { name: "Secret value" }).fill("raw-token-value");
     // intentionally leave the org checkbox unchecked
     await page.getByRole("button", { name: /save/i }).click();
 

--- a/ui/e2e/rbac/provider-connection-display.spec.ts
+++ b/ui/e2e/rbac/provider-connection-display.spec.ts
@@ -81,7 +81,7 @@ test.describe("RBAC e2e — provider connection display and cleanup", () => {
       await expect(page.getByText("Atlassian Cloud")).toBeVisible();
       await expect(page.getByText("cisco-eti")).toBeVisible();
       await expect(page.getByText("healthy")).toBeVisible();
-      await expect(page.getByText(/refreshed 30m ago/i)).toBeVisible();
+      await expect(page.getByText(/refreshed \d+m ago/i)).toBeVisible();
       await expect(page.getByText("legacy-site")).toHaveCount(0);
       await expect(page.getByText("expired")).toHaveCount(0);
     });
@@ -119,7 +119,7 @@ test.describe("RBAC e2e — provider connection display and cleanup", () => {
       });
       await gotoConnectedAppsWorkspace(page);
 
-      await expect(page.getByText("CO2 Dev")).toBeVisible();
+      await expect(page.getByText("CO2 Dev", { exact: true })).toBeVisible();
       // Health pill stays green (usable now), not the amber "expiring soon".
       await expect(
         page.locator("table").getByText("no auto-renew", { exact: true }),

--- a/ui/src/components/agentic-apps/AgenticAppAssistantOverlay.tsx
+++ b/ui/src/components/agentic-apps/AgenticAppAssistantOverlay.tsx
@@ -1,0 +1,213 @@
+"use client";
+
+import { Bot, MessageCircle, Sparkles, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import { ChatPanel } from "@/components/chat/DynamicAgentChatPanel";
+import { buildAssistantClientContext } from "@/lib/agentic-apps/assistant-context";
+import { cn } from "@/lib/utils";
+import type { AgenticAppAssistantContextRecord } from "@/types/agentic-app";
+
+const DEFAULT_PANEL_SIZE = { width: 720, height: 780 };
+const MIN_PANEL_SIZE = { width: 480, height: 560 };
+const MAX_PANEL_SIZE = { width: 1180, height: 940 };
+const GLASS_MODE_STORAGE_KEY = "agentic-app-assistant-glass";
+
+export interface AgenticAppAssistantOverlayProps {
+  appId: string;
+  appName: string;
+  assistantLabel?: string;
+  assistantAgentName?: string;
+  activeContext: AgenticAppAssistantContextRecord | null;
+  onClearContext: () => void;
+  assistantAgentId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function AgenticAppAssistantOverlay({
+  appId,
+  appName,
+  assistantLabel,
+  assistantAgentName,
+  activeContext,
+  onClearContext,
+  assistantAgentId,
+  open,
+  onOpenChange,
+}: AgenticAppAssistantOverlayProps): React.ReactElement {
+  const bubbleLabel = (assistantLabel?.trim() || "Ask CAIPE").slice(0, 32);
+  const headerTitle = (
+    assistantAgentName?.trim() || `CAIPE assistant for ${appName}`
+  ).slice(0, 64);
+  const [panelSize, setPanelSize] = useState(DEFAULT_PANEL_SIZE);
+  const [glassMode, setGlassMode] = useState(readStoredGlassMode);
+  const clientContext = useMemo(
+    () => buildAssistantClientContext(activeContext),
+    [activeContext],
+  );
+
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(GLASS_MODE_STORAGE_KEY, String(glassMode));
+    }
+  }, [glassMode]);
+
+  const handleResizeStart = useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      event.preventDefault();
+      const startPoint = { x: event.clientX, y: event.clientY };
+      const startSize = panelSize;
+      document.body.style.cursor = "nwse-resize";
+      document.body.style.userSelect = "none";
+
+      function handlePointerMove(moveEvent: PointerEvent): void {
+        setPanelSize(
+          clampPanelSize({
+            width: startSize.width + (startPoint.x - moveEvent.clientX),
+            height: startSize.height + (startPoint.y - moveEvent.clientY),
+          }),
+        );
+      }
+
+      function handlePointerUp(): void {
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+        window.removeEventListener("pointermove", handlePointerMove);
+        window.removeEventListener("pointerup", handlePointerUp);
+      }
+
+      window.addEventListener("pointermove", handlePointerMove);
+      window.addEventListener("pointerup", handlePointerUp);
+    },
+    [panelSize],
+  );
+
+  return (
+    <div className="pointer-events-none fixed bottom-6 right-6 z-40 flex flex-col items-end gap-3">
+      {open ? (
+        <section
+          aria-label={headerTitle}
+          className={cn(
+            "pointer-events-auto relative flex flex-col overflow-hidden rounded-3xl border shadow-2xl transition-colors",
+            glassMode
+              ? "border-cyan-200/55 bg-cyan-950/30 shadow-[0_24px_120px_rgba(34,211,238,0.22),inset_0_1px_0_rgba(255,255,255,0.18),inset_0_0_64px_rgba(34,211,238,0.10)] ring-1 ring-cyan-200/45 backdrop-blur-3xl backdrop-saturate-200"
+              : "border-cyan-300/20 bg-slate-950/95 shadow-cyan-950/40",
+          )}
+          style={{
+            width: `min(${panelSize.width}px, calc(100vw - 2rem))`,
+            height: `min(${panelSize.height}px, calc(100vh - 7rem))`,
+          }}
+        >
+          <button
+            type="button"
+            aria-label={`Resize ${bubbleLabel} assistant`}
+            onPointerDown={handleResizeStart}
+            className="absolute left-3 top-3 z-10 flex h-10 w-10 cursor-nwse-resize touch-none items-center justify-center rounded-full border border-cyan-200/30 bg-slate-950/35 shadow-lg backdrop-blur-md transition hover:border-cyan-200/60 hover:bg-cyan-300/10"
+          >
+            <span className="absolute h-7 w-7 rounded-full border border-cyan-200/30" aria-hidden />
+            <span className="absolute h-4 w-4 rounded-full border border-cyan-300/40" aria-hidden />
+            <span className="h-1.5 w-1.5 rounded-full bg-cyan-200 shadow-[0_0_14px_rgba(34,211,238,0.8)]" aria-hidden />
+          </button>
+
+          <header className="flex items-center justify-between gap-3 border-b border-white/10 bg-cyan-950/30 py-3 pl-16 pr-4 backdrop-blur-3xl">
+            <div className="flex min-w-0 items-center gap-2">
+              <span className="rounded-full bg-cyan-300/15 p-2 text-cyan-100">
+                <Bot className="h-4 w-4" aria-hidden />
+              </span>
+              <div className="min-w-0">
+                <h2 className="truncate text-sm font-semibold text-white">{headerTitle}</h2>
+                <p className="truncate text-xs text-slate-400">
+                  {activeContext
+                    ? `${activeContext.route} context active`
+                    : `Waiting for ${appId} context`}
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                aria-label={glassMode ? "Disable translucent assistant mode" : "Enable translucent assistant mode"}
+                aria-pressed={glassMode}
+                onClick={() => setGlassMode((value) => !value)}
+                className={cn(
+                  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1.5 text-[11px] font-medium transition",
+                  glassMode
+                    ? "border-cyan-200/70 bg-cyan-300/25 text-cyan-50"
+                    : "border-white/10 bg-slate-950/40 text-slate-300 hover:text-white",
+                )}
+              >
+                <Sparkles className="h-3.5 w-3.5" aria-hidden /> Glass
+              </button>
+              <button
+                type="button"
+                className="rounded-full p-2 text-slate-400 transition hover:bg-white/10 hover:text-white"
+                aria-label="Close assistant"
+                onClick={() => onOpenChange(false)}
+              >
+                <X className="h-4 w-4" aria-hidden />
+              </button>
+            </div>
+          </header>
+
+          <div className="border-b border-white/10 bg-cyan-300/15 px-4 py-3 text-xs text-slate-300 backdrop-blur-2xl">
+            {activeContext ? (
+              <div className="space-y-2">
+                <div className="flex items-center justify-between gap-3">
+                  <span className="font-medium text-cyan-100">
+                    {activeContext.title ?? "Published app context"}
+                  </span>
+                  <button
+                    type="button"
+                    className="rounded-full border border-white/10 px-2 py-1 text-[11px] text-slate-200 transition hover:bg-white/10"
+                    onClick={onClearContext}
+                  >
+                    Clear context
+                  </button>
+                </div>
+                {activeContext.summary ? (
+                  <p className="line-clamp-2 text-slate-400">{activeContext.summary}</p>
+                ) : null}
+              </div>
+            ) : (
+              <p>App context is treated as untrusted data, not instructions.</p>
+            )}
+          </div>
+
+          <div className="min-h-0 flex-1 [&>div]:bg-transparent">
+            <ChatPanel agentId={assistantAgentId} clientContext={clientContext} />
+          </div>
+        </section>
+      ) : null}
+
+      <button
+        type="button"
+        aria-label={`Open ${bubbleLabel}`}
+        className="pointer-events-auto inline-flex items-center gap-2 rounded-full border border-cyan-200/30 bg-cyan-300 px-4 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-cyan-950/30 transition hover:bg-cyan-200"
+        onClick={() => onOpenChange(!open)}
+      >
+        <MessageCircle className="h-4 w-4" aria-hidden />
+        {bubbleLabel}
+        {activeContext ? (
+          <span className="rounded-full bg-slate-950/15 px-2 py-0.5 text-xs">context</span>
+        ) : null}
+      </button>
+    </div>
+  );
+}
+
+function clampPanelSize(size: { width: number; height: number }): {
+  width: number;
+  height: number;
+} {
+  return {
+    width: Math.max(MIN_PANEL_SIZE.width, Math.min(MAX_PANEL_SIZE.width, size.width)),
+    height: Math.max(MIN_PANEL_SIZE.height, Math.min(MAX_PANEL_SIZE.height, size.height)),
+  };
+}
+
+function readStoredGlassMode(): boolean {
+  if (typeof window === "undefined") return true;
+  const raw = window.localStorage.getItem(GLASS_MODE_STORAGE_KEY);
+  return raw === null ? true : raw === "true";
+}

--- a/ui/src/components/agentic-apps/AgenticAppAssistantOverlay.tsx
+++ b/ui/src/components/agentic-apps/AgenticAppAssistantOverlay.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { Bot, MessageCircle, Sparkles, X } from "lucide-react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { Bot, LoaderCircle, MessageCircle, Sparkles, X } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ChatPanel } from "@/components/chat/DynamicAgentChatPanel";
 import { buildAssistantClientContext } from "@/lib/agentic-apps/assistant-context";
 import { cn } from "@/lib/utils";
+import { useChatStore } from "@/store/chat-store";
 import type { AgenticAppAssistantContextRecord } from "@/types/agentic-app";
 
 const DEFAULT_PANEL_SIZE = { width: 720, height: 780 };
@@ -42,6 +43,21 @@ export function AgenticAppAssistantOverlay({
   ).slice(0, 64);
   const [panelSize, setPanelSize] = useState(DEFAULT_PANEL_SIZE);
   const [glassMode, setGlassMode] = useState(readStoredGlassMode);
+  const [assistantConversation, setAssistantConversation] = useState<{
+    agentId: string;
+    id: string;
+  } | null>(null);
+  const [conversationError, setConversationError] = useState<{
+    agentId: string;
+    message: string;
+  } | null>(null);
+  const previousActiveConversationRef = useRef<string | null | undefined>(undefined);
+  const conversationRequestRef = useRef<{
+    agentId: string;
+    promise: Promise<string>;
+  } | null>(null);
+  const createConversation = useChatStore((state) => state.createConversation);
+  const setActiveConversation = useChatStore((state) => state.setActiveConversation);
   const clientContext = useMemo(
     () => buildAssistantClientContext(activeContext),
     [activeContext],
@@ -52,6 +68,65 @@ export function AgenticAppAssistantOverlay({
       window.localStorage.setItem(GLASS_MODE_STORAGE_KEY, String(glassMode));
     }
   }, [glassMode]);
+
+  useEffect(() => {
+    if (!open) return;
+    previousActiveConversationRef.current = useChatStore.getState().activeConversationId;
+    return () => {
+      setActiveConversation(previousActiveConversationRef.current ?? null);
+      previousActiveConversationRef.current = undefined;
+    };
+  }, [open, setActiveConversation]);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    const previousActiveConversation = previousActiveConversationRef.current ?? null;
+
+    if (assistantConversation?.agentId === assistantAgentId) {
+      setActiveConversation(assistantConversation.id);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    let request = conversationRequestRef.current;
+    if (!request || request.agentId !== assistantAgentId) {
+      request = {
+        agentId: assistantAgentId,
+        promise: createConversation(assistantAgentId),
+      };
+      conversationRequestRef.current = request;
+    }
+
+    request.promise
+      .then((id) => {
+        if (cancelled) {
+          setActiveConversation(previousActiveConversation);
+          return;
+        }
+        setAssistantConversation({ agentId: assistantAgentId, id });
+        setActiveConversation(id);
+      })
+      .catch((error: unknown) => {
+        if (!cancelled) {
+          setConversationError({
+            agentId: assistantAgentId,
+            message: error instanceof Error ? error.message : "Could not start assistant chat",
+          });
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    assistantAgentId,
+    assistantConversation,
+    createConversation,
+    open,
+    setActiveConversation,
+  ]);
 
   const handleResizeStart = useCallback(
     (event: React.PointerEvent<HTMLButtonElement>) => {
@@ -175,7 +250,23 @@ export function AgenticAppAssistantOverlay({
           </div>
 
           <div className="min-h-0 flex-1 [&>div]:bg-transparent">
-            <ChatPanel agentId={assistantAgentId} clientContext={clientContext} />
+            {assistantConversation?.agentId === assistantAgentId ? (
+              <ChatPanel
+                key={assistantConversation.id}
+                conversationId={assistantConversation.id}
+                agentId={assistantAgentId}
+                clientContext={clientContext}
+              />
+            ) : conversationError?.agentId === assistantAgentId ? (
+              <div className="flex h-full items-center justify-center p-6 text-center text-sm text-red-200">
+                {conversationError.message}
+              </div>
+            ) : (
+              <div className="flex h-full items-center justify-center gap-2 text-sm text-slate-300">
+                <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden />
+                Starting {bubbleLabel}…
+              </div>
+            )}
           </div>
         </section>
       ) : null}

--- a/ui/src/components/agentic-apps/AgenticAppAssistantOverlay.tsx
+++ b/ui/src/components/agentic-apps/AgenticAppAssistantOverlay.tsx
@@ -1,18 +1,20 @@
 "use client";
 
-import { Bot, LoaderCircle, MessageCircle, Sparkles, X } from "lucide-react";
+import { Bot, LoaderCircle, MessageCircle, Plus, Sparkles, Trash2, X } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { ChatPanel } from "@/components/chat/DynamicAgentChatPanel";
 import { buildAssistantClientContext } from "@/lib/agentic-apps/assistant-context";
 import { cn } from "@/lib/utils";
 import { useChatStore } from "@/store/chat-store";
+import type { Conversation } from "@/types/a2a";
 import type { AgenticAppAssistantContextRecord } from "@/types/agentic-app";
 
 const DEFAULT_PANEL_SIZE = { width: 720, height: 780 };
 const MIN_PANEL_SIZE = { width: 480, height: 560 };
 const MAX_PANEL_SIZE = { width: 1180, height: 940 };
 const GLASS_MODE_STORAGE_KEY = "agentic-app-assistant-glass";
+const AGENTIC_APP_CONVERSATION_KIND = "agentic-app";
 
 export interface AgenticAppAssistantOverlayProps {
   appId: string;
@@ -51,13 +53,29 @@ export function AgenticAppAssistantOverlay({
     agentId: string;
     message: string;
   } | null>(null);
+  const [conversationActionPending, setConversationActionPending] = useState(false);
   const previousActiveConversationRef = useRef<string | null | undefined>(undefined);
   const conversationRequestRef = useRef<{
-    agentId: string;
+    key: string;
     promise: Promise<string>;
   } | null>(null);
   const createConversation = useChatStore((state) => state.createConversation);
+  const deleteConversation = useChatStore((state) => state.deleteConversation);
+  const loadConversationsFromServer = useChatStore(
+    (state) => state.loadConversationsFromServer,
+  );
+  const loadMessagesFromServer = useChatStore((state) => state.loadMessagesFromServer);
   const setActiveConversation = useChatStore((state) => state.setActiveConversation);
+  const conversationKey = `${appId}:${assistantAgentId}`;
+  const conversationTitle = `${appName} Assistant`.slice(0, 120);
+  const conversationMetadata = useMemo(
+    () => ({
+      conversation_surface: AGENTIC_APP_CONVERSATION_KIND,
+      agentic_app_id: appId,
+      agentic_app_agent_id: assistantAgentId,
+    }),
+    [appId, assistantAgentId],
+  );
   const clientContext = useMemo(
     () => buildAssistantClientContext(activeContext),
     [activeContext],
@@ -78,6 +96,36 @@ export function AgenticAppAssistantOverlay({
     };
   }, [open, setActiveConversation]);
 
+  const createAppConversation = useCallback(
+    () =>
+      createConversation(assistantAgentId, {
+        title: conversationTitle,
+        metadata: conversationMetadata,
+      }),
+    [assistantAgentId, conversationMetadata, conversationTitle, createConversation],
+  );
+
+  const findOrCreateAppConversation = useCallback(async (): Promise<string> => {
+    await loadConversationsFromServer();
+    const existing = findLatestAppConversation(
+      useChatStore.getState().conversations,
+      appId,
+      assistantAgentId,
+    );
+    if (!existing) return createAppConversation();
+
+    setActiveConversation(existing.id);
+    await loadMessagesFromServer(existing.id);
+    return existing.id;
+  }, [
+    appId,
+    assistantAgentId,
+    createAppConversation,
+    loadConversationsFromServer,
+    loadMessagesFromServer,
+    setActiveConversation,
+  ]);
+
   useEffect(() => {
     if (!open) return;
     let cancelled = false;
@@ -91,10 +139,10 @@ export function AgenticAppAssistantOverlay({
     }
 
     let request = conversationRequestRef.current;
-    if (!request || request.agentId !== assistantAgentId) {
+    if (!request || request.key !== conversationKey) {
       request = {
-        agentId: assistantAgentId,
-        promise: createConversation(assistantAgentId),
+        key: conversationKey,
+        promise: findOrCreateAppConversation(),
       };
       conversationRequestRef.current = request;
     }
@@ -123,8 +171,70 @@ export function AgenticAppAssistantOverlay({
   }, [
     assistantAgentId,
     assistantConversation,
-    createConversation,
+    conversationKey,
+    findOrCreateAppConversation,
     open,
+    setActiveConversation,
+  ]);
+
+  const handleNewChat = useCallback(async (): Promise<void> => {
+    if (conversationActionPending) return;
+    setConversationActionPending(true);
+    setConversationError(null);
+    try {
+      const id = await createAppConversation();
+      conversationRequestRef.current = { key: conversationKey, promise: Promise.resolve(id) };
+      setAssistantConversation({ agentId: assistantAgentId, id });
+      setActiveConversation(id);
+    } catch (error: unknown) {
+      setConversationError({
+        agentId: assistantAgentId,
+        message: error instanceof Error ? error.message : "Could not start a new chat",
+      });
+    } finally {
+      setConversationActionPending(false);
+    }
+  }, [
+    assistantAgentId,
+    conversationActionPending,
+    conversationKey,
+    createAppConversation,
+    setActiveConversation,
+  ]);
+
+  const handleClearChat = useCallback(async (): Promise<void> => {
+    if (!assistantConversation || conversationActionPending) return;
+    if (
+      !window.confirm(
+        "Clear this chat? The current conversation will move to Trash and a new chat will start.",
+      )
+    ) {
+      return;
+    }
+
+    setConversationActionPending(true);
+    setConversationError(null);
+    try {
+      await deleteConversation(assistantConversation.id);
+      const id = await createAppConversation();
+      conversationRequestRef.current = { key: conversationKey, promise: Promise.resolve(id) };
+      setAssistantConversation({ agentId: assistantAgentId, id });
+      setActiveConversation(id);
+    } catch (error: unknown) {
+      setConversationError({
+        agentId: assistantAgentId,
+        message: error instanceof Error ? error.message : "Could not clear this chat",
+      });
+    } finally {
+      setConversationActionPending(false);
+    }
+  }, [
+    assistantAgentId,
+    assistantConversation,
+    conversationActionPending,
+    conversationKey,
+    createAppConversation,
+    deleteConversation,
     setActiveConversation,
   ]);
 
@@ -200,6 +310,30 @@ export function AgenticAppAssistantOverlay({
               </div>
             </div>
             <div className="flex items-center gap-2">
+              <button
+                type="button"
+                aria-label="Start new assistant chat"
+                title="New chat"
+                disabled={conversationActionPending}
+                onClick={() => void handleNewChat()}
+                className="rounded-full p-2 text-slate-400 transition hover:bg-white/10 hover:text-white disabled:cursor-wait disabled:opacity-50"
+              >
+                {conversationActionPending ? (
+                  <LoaderCircle className="h-4 w-4 animate-spin" aria-hidden />
+                ) : (
+                  <Plus className="h-4 w-4" aria-hidden />
+                )}
+              </button>
+              <button
+                type="button"
+                aria-label="Clear assistant chat"
+                title="Clear chat"
+                disabled={!assistantConversation || conversationActionPending}
+                onClick={() => void handleClearChat()}
+                className="rounded-full p-2 text-slate-400 transition hover:bg-red-400/10 hover:text-red-200 disabled:cursor-not-allowed disabled:opacity-40"
+              >
+                <Trash2 className="h-4 w-4" aria-hidden />
+              </button>
               <button
                 type="button"
                 aria-label={glassMode ? "Disable translucent assistant mode" : "Enable translucent assistant mode"}
@@ -295,6 +429,24 @@ function clampPanelSize(size: { width: number; height: number }): {
     width: Math.max(MIN_PANEL_SIZE.width, Math.min(MAX_PANEL_SIZE.width, size.width)),
     height: Math.max(MIN_PANEL_SIZE.height, Math.min(MAX_PANEL_SIZE.height, size.height)),
   };
+}
+
+function findLatestAppConversation(
+  conversations: Conversation[],
+  appId: string,
+  agentId: string,
+): Conversation | null {
+  return conversations.reduce<Conversation | null>((latest, conversation) => {
+    const metadata = conversation.metadata;
+    if (
+      metadata?.conversation_surface !== AGENTIC_APP_CONVERSATION_KIND
+      || metadata.agentic_app_id !== appId
+      || metadata.agentic_app_agent_id !== agentId
+    ) {
+      return latest;
+    }
+    return !latest || conversation.updatedAt > latest.updatedAt ? conversation : latest;
+  }, null);
 }
 
 function readStoredGlassMode(): boolean {

--- a/ui/src/components/agentic-apps/AgenticAppShell.tsx
+++ b/ui/src/components/agentic-apps/AgenticAppShell.tsx
@@ -3,10 +3,19 @@
 import { ArrowLeft, LoaderCircle } from "lucide-react";
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
+import { AgenticAppAssistantOverlay } from "@/components/agentic-apps/AgenticAppAssistantOverlay";
+import { validateAssistantContextMessage } from "@/lib/agentic-apps/assistant-context";
 import { buildAgenticAppPublicPath } from "@/lib/agentic-apps/runtime";
-import type { PublicAgenticApp } from "@/types/agentic-app";
+import {
+  resolveUsableChatAgent,
+  type ResolvedChatAgent,
+} from "@/lib/chat-agent-selection";
+import type {
+  AgenticAppAssistantContextRecord,
+  PublicAgenticApp,
+} from "@/types/agentic-app";
 
 type ShellState =
   | { status: "loading" }
@@ -22,6 +31,21 @@ export function AgenticAppShell({
 }): React.ReactElement {
   const searchParams = useSearchParams();
   const [state, setState] = useState<ShellState>({ status: "loading" });
+  const [assistantContext, setAssistantContext] =
+    useState<AgenticAppAssistantContextRecord | null>(null);
+  const [assistantOpen, setAssistantOpen] = useState(false);
+  const [assistantBinding, setAssistantBinding] = useState<{
+    bindingKey: string;
+    agent: ResolvedChatAgent;
+  } | null>(null);
+  const iframeRef = useRef<HTMLIFrameElement | null>(null);
+
+  const requestedAgentId = state.status === "ready" ? state.app.assistantAgentId : undefined;
+  const assistantBindingKey = `${appId}:${requestedAgentId ?? "default"}`;
+  const assistantAgent =
+    assistantBinding?.bindingKey === assistantBindingKey ? assistantBinding.agent : null;
+  const assistantConfigured =
+    state.status === "ready" && state.app.assistantEnabled !== false;
 
   useEffect(() => {
     let cancelled = false;
@@ -61,6 +85,58 @@ export function AgenticAppShell({
     };
   }, [appId]);
 
+  useEffect(() => {
+    let cancelled = false;
+    if (!assistantConfigured) return () => undefined;
+
+    resolveUsableChatAgent({
+      requestedAgentId,
+      requireAvailableAgent: true,
+    })
+      .then((agent) => {
+        if (!cancelled) setAssistantBinding({ bindingKey: assistantBindingKey, agent });
+      })
+      .catch((error: unknown) => {
+        console.warn(
+          `[AgenticAppShell] Contextual assistant unavailable for ${appId}:`,
+          error instanceof Error ? error.message : String(error),
+        );
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [appId, assistantBindingKey, assistantConfigured, requestedAgentId]);
+
+  useEffect(() => {
+    if (!assistantConfigured) return;
+
+    function onMessage(event: MessageEvent): void {
+      const expectedSource = iframeRef.current?.contentWindow ?? null;
+      if (event.origin !== window.location.origin || event.source !== expectedSource) return;
+
+      if (isAssistantOpenMessage(event.data, appId)) {
+        setAssistantOpen(true);
+        return;
+      }
+
+      const result = validateAssistantContextMessage({
+        message: event.data,
+        appId,
+        origin: event.origin,
+        expectedOrigin: window.location.origin,
+        source: event.source,
+        expectedSource,
+        maxBytes:
+          state.status === "ready" ? state.app.assistantMaxContextBytes : undefined,
+      });
+      if (result.ok) setAssistantContext(result.record);
+    }
+
+    window.addEventListener("message", onMessage);
+    return () => window.removeEventListener("message", onMessage);
+  }, [appId, assistantConfigured, state]);
+
   if (state.status === "loading") {
     return (
       <div className="flex flex-1 items-center justify-center">
@@ -95,11 +171,38 @@ export function AgenticAppShell({
         <span className="truncate text-sm font-medium">{state.app.displayName}</span>
       </div>
       <iframe
+        ref={iframeRef}
         className="min-h-0 flex-1 border-0 bg-background"
         src={runtimePath}
         title={state.app.displayName}
         allow="clipboard-read; clipboard-write"
       />
+      {assistantConfigured && assistantAgent ? (
+        <AgenticAppAssistantOverlay
+          appId={state.app.appId}
+          appName={state.app.displayName}
+          assistantLabel={state.app.assistantLabel}
+          assistantAgentName={state.app.assistantAgentName}
+          activeContext={assistantContext}
+          onClearContext={() => setAssistantContext(null)}
+          assistantAgentId={assistantAgent.id}
+          open={assistantOpen}
+          onOpenChange={setAssistantOpen}
+        />
+      ) : null}
     </div>
+  );
+}
+
+function isAssistantOpenMessage(message: unknown, appId: string): boolean {
+  return (
+    typeof message === "object" &&
+    message !== null &&
+    "type" in message &&
+    "version" in message &&
+    "appId" in message &&
+    message.type === "caipe.agenticApp.assistant.open.v1" &&
+    message.version === "1.0" &&
+    message.appId === appId
   );
 }

--- a/ui/src/components/agentic-apps/__tests__/AgenticAppAssistantOverlay.test.tsx
+++ b/ui/src/components/agentic-apps/__tests__/AgenticAppAssistantOverlay.test.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+
+import { AgenticAppAssistantOverlay } from "../AgenticAppAssistantOverlay";
+
+jest.mock("@/components/chat/DynamicAgentChatPanel", () => ({
+  ChatPanel: ({ clientContext }: { clientContext?: Record<string, unknown> }) => (
+    <div data-testid="chat-panel" data-context={JSON.stringify(clientContext ?? {})} />
+  ),
+}));
+
+describe("AgenticAppAssistantOverlay", () => {
+  beforeEach(() => window.localStorage.clear());
+
+  it("renders a floating launcher and opens the glass chat panel", () => {
+    const onOpenChange = jest.fn();
+    const { rerender } = render(
+      <AgenticAppAssistantOverlay
+        appId="example-app"
+        appName="Example App"
+        activeContext={null}
+        onClearContext={jest.fn()}
+        assistantAgentId="agent-example"
+        open={false}
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Open Ask CAIPE" }));
+    expect(onOpenChange).toHaveBeenCalledWith(true);
+
+    rerender(
+      <AgenticAppAssistantOverlay
+        appId="example-app"
+        appName="Example App"
+        assistantLabel="Ask Example"
+        assistantAgentName="Example Assistant"
+        activeContext={null}
+        onClearContext={jest.fn()}
+        assistantAgentId="agent-example"
+        open
+        onOpenChange={onOpenChange}
+      />,
+    );
+
+    expect(screen.getByRole("region", { name: "Example Assistant" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Disable translucent assistant mode" }))
+      .toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByTestId("chat-panel")).toBeInTheDocument();
+  });
+
+  it("passes validated app context into the chat panel", () => {
+    render(
+      <AgenticAppAssistantOverlay
+        appId="example-app"
+        appName="Example App"
+        activeContext={{
+          contextId: "context-1",
+          appId: "example-app",
+          sessionId: "browser-session",
+          schemaVersion: "1.0",
+          route: "/reports",
+          payloadSizeBytes: 100,
+          validationStatus: "accepted",
+          createdAt: "2026-01-01T00:00:00.000Z",
+          expiresAt: "2026-01-01T00:10:00.000Z",
+          title: "Current report",
+        }}
+        onClearContext={jest.fn()}
+        assistantAgentId="agent-example"
+        open
+        onOpenChange={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId("chat-panel")).toHaveAttribute(
+      "data-context",
+      expect.stringContaining('"appId":"example-app"'),
+    );
+    expect(screen.getByText("Current report")).toBeInTheDocument();
+  });
+});

--- a/ui/src/components/agentic-apps/__tests__/AgenticAppAssistantOverlay.test.tsx
+++ b/ui/src/components/agentic-apps/__tests__/AgenticAppAssistantOverlay.test.tsx
@@ -1,17 +1,54 @@
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { useChatStore } from "@/store/chat-store";
 
 import { AgenticAppAssistantOverlay } from "../AgenticAppAssistantOverlay";
 
+const mockCreateConversation = jest.fn();
+const mockSetActiveConversation = jest.fn();
+const mockChatStoreState = {
+  activeConversationId: "previous-conversation",
+  createConversation: mockCreateConversation,
+  setActiveConversation: mockSetActiveConversation,
+};
+
+jest.mock("@/store/chat-store", () => ({ useChatStore: jest.fn() }));
+
 jest.mock("@/components/chat/DynamicAgentChatPanel", () => ({
-  ChatPanel: ({ clientContext }: { clientContext?: Record<string, unknown> }) => (
-    <div data-testid="chat-panel" data-context={JSON.stringify(clientContext ?? {})} />
+  ChatPanel: ({
+    conversationId,
+    agentId,
+    clientContext,
+  }: {
+    conversationId?: string;
+    agentId: string;
+    clientContext?: Record<string, unknown>;
+  }) => (
+    <div
+      data-testid="chat-panel"
+      data-conversation-id={conversationId}
+      data-agent-id={agentId}
+      data-context={JSON.stringify(clientContext ?? {})}
+    />
   ),
 }));
 
 describe("AgenticAppAssistantOverlay", () => {
-  beforeEach(() => window.localStorage.clear());
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    mockChatStoreState.activeConversationId = "previous-conversation";
+    mockCreateConversation.mockResolvedValue("assistant-conversation");
+    const mockUseChatStore = useChatStore as unknown as jest.Mock & {
+      getState: () => typeof mockChatStoreState;
+    };
+    mockUseChatStore.mockImplementation(
+      (selector: (state: typeof mockChatStoreState) => unknown) => selector(mockChatStoreState),
+    );
+    mockUseChatStore.getState = () => mockChatStoreState;
+  });
 
-  it("renders a floating launcher and opens the glass chat panel", () => {
+  it("renders a floating launcher and opens an isolated glass chat panel", async () => {
     const onOpenChange = jest.fn();
     const { rerender } = render(
       <AgenticAppAssistantOverlay
@@ -45,11 +82,15 @@ describe("AgenticAppAssistantOverlay", () => {
     expect(screen.getByRole("region", { name: "Example Assistant" })).toBeInTheDocument();
     expect(screen.getByRole("button", { name: "Disable translucent assistant mode" }))
       .toHaveAttribute("aria-pressed", "true");
-    expect(screen.getByTestId("chat-panel")).toBeInTheDocument();
+    expect(screen.getByText("Starting Ask Example…")).toBeInTheDocument();
+    expect(mockCreateConversation).toHaveBeenCalledWith("agent-example");
+    const chat = await screen.findByTestId("chat-panel");
+    expect(chat).toHaveAttribute("data-conversation-id", "assistant-conversation");
+    expect(chat).toHaveAttribute("data-agent-id", "agent-example");
   });
 
-  it("passes validated app context into the chat panel", () => {
-    render(
+  it("passes validated app context into the chat panel and restores the prior chat", async () => {
+    const { unmount } = render(
       <AgenticAppAssistantOverlay
         appId="example-app"
         appName="Example App"
@@ -72,10 +113,15 @@ describe("AgenticAppAssistantOverlay", () => {
       />,
     );
 
-    expect(screen.getByTestId("chat-panel")).toHaveAttribute(
+    expect(await screen.findByTestId("chat-panel")).toHaveAttribute(
       "data-context",
       expect.stringContaining('"appId":"example-app"'),
     );
     expect(screen.getByText("Current report")).toBeInTheDocument();
+
+    unmount();
+    await waitFor(() => {
+      expect(mockSetActiveConversation).toHaveBeenCalledWith("previous-conversation");
+    });
   });
 });

--- a/ui/src/components/agentic-apps/__tests__/AgenticAppAssistantOverlay.test.tsx
+++ b/ui/src/components/agentic-apps/__tests__/AgenticAppAssistantOverlay.test.tsx
@@ -1,14 +1,30 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 
 import { useChatStore } from "@/store/chat-store";
+import type { Conversation } from "@/types/a2a";
 
 import { AgenticAppAssistantOverlay } from "../AgenticAppAssistantOverlay";
 
 const mockCreateConversation = jest.fn();
+const mockDeleteConversation = jest.fn();
+const mockLoadConversationsFromServer = jest.fn();
+const mockLoadMessagesFromServer = jest.fn();
 const mockSetActiveConversation = jest.fn();
-const mockChatStoreState = {
+const mockChatStoreState: {
+  activeConversationId: string | null;
+  conversations: Conversation[];
+  createConversation: typeof mockCreateConversation;
+  deleteConversation: typeof mockDeleteConversation;
+  loadConversationsFromServer: typeof mockLoadConversationsFromServer;
+  loadMessagesFromServer: typeof mockLoadMessagesFromServer;
+  setActiveConversation: typeof mockSetActiveConversation;
+} = {
   activeConversationId: "previous-conversation",
+  conversations: [],
   createConversation: mockCreateConversation,
+  deleteConversation: mockDeleteConversation,
+  loadConversationsFromServer: mockLoadConversationsFromServer,
+  loadMessagesFromServer: mockLoadMessagesFromServer,
   setActiveConversation: mockSetActiveConversation,
 };
 
@@ -38,7 +54,11 @@ describe("AgenticAppAssistantOverlay", () => {
     jest.clearAllMocks();
     window.localStorage.clear();
     mockChatStoreState.activeConversationId = "previous-conversation";
+    mockChatStoreState.conversations = [];
     mockCreateConversation.mockResolvedValue("assistant-conversation");
+    mockDeleteConversation.mockResolvedValue(undefined);
+    mockLoadConversationsFromServer.mockResolvedValue(undefined);
+    mockLoadMessagesFromServer.mockResolvedValue(undefined);
     const mockUseChatStore = useChatStore as unknown as jest.Mock & {
       getState: () => typeof mockChatStoreState;
     };
@@ -47,6 +67,8 @@ describe("AgenticAppAssistantOverlay", () => {
     );
     mockUseChatStore.getState = () => mockChatStoreState;
   });
+
+  afterEach(() => jest.restoreAllMocks());
 
   it("renders a floating launcher and opens an isolated glass chat panel", async () => {
     const onOpenChange = jest.fn();
@@ -83,7 +105,16 @@ describe("AgenticAppAssistantOverlay", () => {
     expect(screen.getByRole("button", { name: "Disable translucent assistant mode" }))
       .toHaveAttribute("aria-pressed", "true");
     expect(screen.getByText("Starting Ask Example…")).toBeInTheDocument();
-    expect(mockCreateConversation).toHaveBeenCalledWith("agent-example");
+    await waitFor(() => {
+      expect(mockCreateConversation).toHaveBeenCalledWith("agent-example", {
+        title: "Example App Assistant",
+        metadata: {
+          conversation_surface: "agentic-app",
+          agentic_app_id: "example-app",
+          agentic_app_agent_id: "agent-example",
+        },
+      });
+    });
     const chat = await screen.findByTestId("chat-panel");
     expect(chat).toHaveAttribute("data-conversation-id", "assistant-conversation");
     expect(chat).toHaveAttribute("data-agent-id", "agent-example");
@@ -124,4 +155,90 @@ describe("AgenticAppAssistantOverlay", () => {
       expect(mockSetActiveConversation).toHaveBeenCalledWith("previous-conversation");
     });
   });
+
+  it("restores the latest matching app conversation from chat history", async () => {
+    mockChatStoreState.conversations = [
+      makeConversation("older", "2026-01-01T00:00:00.000Z"),
+      makeConversation("latest", "2026-02-01T00:00:00.000Z"),
+    ];
+
+    renderExampleOverlay();
+
+    expect(await screen.findByTestId("chat-panel")).toHaveAttribute(
+      "data-conversation-id",
+      "latest",
+    );
+    expect(mockCreateConversation).not.toHaveBeenCalled();
+    expect(mockLoadMessagesFromServer).toHaveBeenCalledWith("latest");
+  });
+
+  it("starts a new chat while retaining the prior conversation in history", async () => {
+    mockCreateConversation
+      .mockResolvedValueOnce("assistant-conversation")
+      .mockResolvedValueOnce("new-assistant-conversation");
+    renderExampleOverlay();
+    await screen.findByTestId("chat-panel");
+
+    fireEvent.click(screen.getByRole("button", { name: "Start new assistant chat" }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("chat-panel")).toHaveAttribute(
+        "data-conversation-id",
+        "new-assistant-conversation",
+      );
+    });
+    expect(mockDeleteConversation).not.toHaveBeenCalled();
+  });
+
+  it("moves a cleared chat to Trash before starting a replacement", async () => {
+    jest.spyOn(window, "confirm").mockReturnValue(true);
+    mockCreateConversation
+      .mockResolvedValueOnce("assistant-conversation")
+      .mockResolvedValueOnce("replacement-conversation");
+    renderExampleOverlay();
+    await screen.findByTestId("chat-panel");
+
+    fireEvent.click(screen.getByRole("button", { name: "Clear assistant chat" }));
+
+    await waitFor(() => {
+      expect(mockDeleteConversation).toHaveBeenCalledWith("assistant-conversation");
+      expect(screen.getByTestId("chat-panel")).toHaveAttribute(
+        "data-conversation-id",
+        "replacement-conversation",
+      );
+    });
+  });
 });
+
+function renderExampleOverlay() {
+  return render(
+    <AgenticAppAssistantOverlay
+      appId="example-app"
+      appName="Example App"
+      assistantLabel="Ask Example"
+      assistantAgentName="Example Assistant"
+      activeContext={null}
+      onClearContext={jest.fn()}
+      assistantAgentId="agent-example"
+      open
+      onOpenChange={jest.fn()}
+    />,
+  );
+}
+
+function makeConversation(id: string, updatedAt: string): Conversation {
+  return {
+    id,
+    title: "Example App Assistant",
+    createdAt: new Date(updatedAt),
+    updatedAt: new Date(updatedAt),
+    messages: [],
+    streamEvents: [],
+    participants: [{ type: "agent", id: "agent-example" }],
+    metadata: {
+      conversation_surface: "agentic-app",
+      agentic_app_id: "example-app",
+      agentic_app_agent_id: "agent-example",
+    },
+  };
+}

--- a/ui/src/components/agentic-apps/__tests__/AgenticAppShell.test.tsx
+++ b/ui/src/components/agentic-apps/__tests__/AgenticAppShell.test.tsx
@@ -1,0 +1,160 @@
+import { act, render, screen, waitFor } from "@testing-library/react";
+
+import { AgenticAppShell } from "../AgenticAppShell";
+
+const mockResolveUsableChatAgent = jest.fn();
+
+jest.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+jest.mock("@/lib/chat-agent-selection", () => ({
+  resolveUsableChatAgent: (options: unknown) => mockResolveUsableChatAgent(options),
+}));
+
+jest.mock("../AgenticAppAssistantOverlay", () => ({
+  AgenticAppAssistantOverlay: ({
+    assistantLabel,
+    activeContext,
+    open,
+  }: {
+    assistantLabel?: string;
+    activeContext: { title?: string } | null;
+    open: boolean;
+  }) => (
+    <div
+      data-testid="assistant-overlay"
+      data-open={String(open)}
+      data-context={activeContext?.title ?? ""}
+    >
+      {assistantLabel ?? "Ask CAIPE"}
+    </div>
+  ),
+}));
+
+function app(overrides: Record<string, unknown> = {}) {
+  return {
+    appId: "example-app",
+    displayName: "Example App",
+    description: "Example description",
+    href: "/apps/example-app",
+    canLaunch: true,
+    blockedReasons: [],
+    categories: [],
+    capabilities: [],
+    assistantEnabled: true,
+    ...overrides,
+  };
+}
+
+describe("AgenticAppShell", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        items: [
+          app({
+            assistantAgentId: "agent-example",
+            assistantAgentName: "Example Agent",
+            assistantLabel: "Ask Example",
+          }),
+        ],
+      }),
+    }) as jest.Mock;
+    mockResolveUsableChatAgent.mockResolvedValue({
+      id: "agent-example",
+      name: "Example Agent",
+      source: "configured",
+    });
+  });
+
+  it("renders the app and its configured assistant", async () => {
+    render(<AgenticAppShell appId="example-app" path={[]} />);
+
+    expect(await screen.findByTitle("Example App")).toHaveAttribute(
+      "src",
+      "/apps/example-app",
+    );
+    expect(await screen.findByTestId("assistant-overlay")).toHaveTextContent("Ask Example");
+    expect(mockResolveUsableChatAgent).toHaveBeenCalledWith({
+      requestedAgentId: "agent-example",
+      requireAvailableAgent: true,
+    });
+  });
+
+  it("opens the assistant and accepts context from its own iframe", async () => {
+    render(<AgenticAppShell appId="example-app" path={[]} />);
+
+    const iframe = (await screen.findByTitle("Example App")) as HTMLIFrameElement;
+    const overlay = await screen.findByTestId("assistant-overlay");
+    expect(overlay).toHaveAttribute("data-open", "false");
+
+    act(() => {
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: window.location.origin,
+          source: iframe.contentWindow,
+          data: {
+            type: "caipe.agenticApp.context.v1",
+            version: "1.0",
+            appId: "example-app",
+            context: { route: "/", title: "Selected dashboard context" },
+          },
+        }),
+      );
+      window.dispatchEvent(
+        new MessageEvent("message", {
+          origin: window.location.origin,
+          source: iframe.contentWindow,
+          data: {
+            type: "caipe.agenticApp.assistant.open.v1",
+            version: "1.0",
+            appId: "example-app",
+          },
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(overlay).toHaveAttribute("data-open", "true");
+      expect(overlay).toHaveAttribute("data-context", "Selected dashboard context");
+    });
+  });
+
+  it("uses an authorized default agent when the app does not specify one", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [app()] }),
+    });
+    mockResolveUsableChatAgent.mockResolvedValue({
+      id: "agent-default",
+      name: "Default Agent",
+      source: "platform-default",
+    });
+
+    render(<AgenticAppShell appId="example-app" path={[]} />);
+
+    expect(await screen.findByTestId("assistant-overlay")).toHaveTextContent("Ask CAIPE");
+    expect(mockResolveUsableChatAgent).toHaveBeenCalledWith({
+      requestedAgentId: undefined,
+      requireAvailableAgent: true,
+    });
+  });
+
+  it("does not resolve or render an assistant when the app disables it", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ items: [app({ assistantEnabled: false })] }),
+    });
+
+    render(<AgenticAppShell appId="example-app" path={[]} />);
+
+    expect(await screen.findByTitle("Example App")).toBeInTheDocument();
+    await waitFor(() => expect(mockResolveUsableChatAgent).not.toHaveBeenCalled());
+    expect(screen.queryByTestId("assistant-overlay")).not.toBeInTheDocument();
+  });
+});

--- a/ui/src/components/chat/ChatContainer.tsx
+++ b/ui/src/components/chat/ChatContainer.tsx
@@ -377,8 +377,8 @@ export function ChatContainer() {
   // participant (participants: []). Treat them the same as conversations whose
   // agent was later deleted: show the full chat history in read-only mode with
   // an "agent deleted" banner and a CTA to start a new conversation.
-  const effectiveAgentId = selectedAgentId ?? relinkedAgentId ?? "deprecated-supervisor-agent";
-  const isAgentGone = agentNotFound || (!selectedAgentId && !relinkedAgentId);
+  const effectiveAgentId = relinkedAgentId ?? selectedAgentId ?? "deprecated-supervisor-agent";
+  const isAgentGone = !relinkedAgentId && (agentNotFound || !selectedAgentId);
   const handleAgentRelinked = (agentId: string) => {
     fetchedAgentRef.current = { uuid, agentId };
     setRelinkedAgentId(agentId);

--- a/ui/src/components/chat/ChatContainer.tsx
+++ b/ui/src/components/chat/ChatContainer.tsx
@@ -31,6 +31,7 @@ export function ChatContainer() {
   const [agentInfo, setAgentInfo] = useState<DynamicAgentConfig | null>(null);
   // Track when a dynamic agent has been deleted but conversation still references it
   const [agentNotFound, setAgentNotFound] = useState(false);
+  const [relinkedAgentId, setRelinkedAgentId] = useState<string | null>(null);
 
   // Only subscribe to stable functions — NOT to `conversations`.
   const { setActiveConversation, loadMessagesFromServer } = useChatStore();
@@ -92,6 +93,7 @@ export function ChatContainer() {
       setError(null);
       setAccessLevel(null);
       setAgentNotFound(false);
+      setRelinkedAgentId(null);
       // Don't reset agentInfo - let the agent fetch effect handle it
     }
   }, [uuid, storageMode]);
@@ -375,10 +377,11 @@ export function ChatContainer() {
   // participant (participants: []). Treat them the same as conversations whose
   // agent was later deleted: show the full chat history in read-only mode with
   // an "agent deleted" banner and a CTA to start a new conversation.
-  const effectiveAgentId = selectedAgentId ?? "deprecated-supervisor-agent";
-  const isAgentGone = agentNotFound || !selectedAgentId;
+  const effectiveAgentId = selectedAgentId ?? relinkedAgentId ?? "deprecated-supervisor-agent";
+  const isAgentGone = agentNotFound || (!selectedAgentId && !relinkedAgentId);
   const handleAgentRelinked = (agentId: string) => {
     fetchedAgentRef.current = { uuid, agentId };
+    setRelinkedAgentId(agentId);
     setAgentInfo(null);
     setAgentNotFound(false);
   };

--- a/ui/src/components/chat/ChatContainer.tsx
+++ b/ui/src/components/chat/ChatContainer.tsx
@@ -294,6 +294,8 @@ export function ChatContainer() {
     }
 
     fetchedAgentRef.current = { uuid, agentId: selectedAgentId };
+    setAgentNotFound(false);
+    let cancelled = false;
 
     async function fetchAgentInfo() {
       try {
@@ -301,25 +303,32 @@ export function ChatContainer() {
         if (response.ok) {
           const data = await response.json();
           const agent = data.data as DynamicAgentConfig;
+          if (cancelled) return;
           setAgentInfo(agent);
           setAgentNotFound(false);
         } else if (response.status === 404) {
           console.warn(`[ChatContainer] Agent ${selectedAgentId} not found (deleted)`);
+          if (cancelled) return;
           setAgentInfo(null);
           setAgentNotFound(true);
         } else {
           console.error(`[ChatContainer] Failed to fetch agent info: ${response.status}`);
+          if (cancelled) return;
           setAgentInfo(null);
           setAgentNotFound(false);
         }
       } catch (err) {
         console.error("Failed to fetch agent info:", err);
+        if (cancelled) return;
         setAgentInfo(null);
         setAgentNotFound(false);
       }
     }
 
     fetchAgentInfo();
+    return () => {
+      cancelled = true;
+    };
     // Note: agentInfo in deps intentionally triggers re-fetch when agentInfo becomes null
     // (e.g., on page refresh or after navigating away and back)
   }, [uuid, selectedAgentId, agentInfo]);

--- a/ui/src/components/chat/ChatContainer.tsx
+++ b/ui/src/components/chat/ChatContainer.tsx
@@ -377,6 +377,11 @@ export function ChatContainer() {
   // an "agent deleted" banner and a CTA to start a new conversation.
   const effectiveAgentId = selectedAgentId ?? "deprecated-supervisor-agent";
   const isAgentGone = agentNotFound || !selectedAgentId;
+  const handleAgentRelinked = (agentId: string) => {
+    fetchedAgentRef.current = { uuid, agentId };
+    setAgentInfo(null);
+    setAgentNotFound(false);
+  };
 
   return (
     <ChatView
@@ -387,6 +392,7 @@ export function ChatContainer() {
       readOnly={isReadOnly}
       readOnlyReason={readOnlyReason}
       isLoadingMessages={isLoadingMessages}
+      onAgentRelinked={handleAgentRelinked}
     />
   );
 }

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -210,6 +210,7 @@ export function ChatPanel({
   // then reload the page so ChatContainer picks up the new participants.
   const handleStartNewConversation = useCallback(async () => {
     if (!conversationId) return;
+    setHasRelinkedAgent(true);
     try {
       const agentId = await resolveUsableChatAgentId();
       const newParticipants = buildParticipants(agentId);
@@ -226,6 +227,7 @@ export function ChatPanel({
       }));
       onAgentRelinked?.(agentId);
     } catch (err) {
+      setHasRelinkedAgent(false);
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
   }, [conversationId, onAgentRelinked, toast]);
@@ -251,6 +253,7 @@ export function ChatPanel({
 
   const handleResumeWithChosenAgent = useCallback(async () => {
     if (!conversationId || !chosenAgentId) return;
+    setHasRelinkedAgent(true);
     try {
       const newParticipants = buildParticipants(chosenAgentId);
       await apiClient.updateConversation(conversationId, { participants: newParticipants });
@@ -262,6 +265,7 @@ export function ChatPanel({
       }));
       onAgentRelinked?.(chosenAgentId);
     } catch (err) {
+      setHasRelinkedAgent(false);
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
   }, [conversationId, chosenAgentId, onAgentRelinked, toast]);

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -224,7 +224,7 @@ export function ChatPanel({
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
-  }, [conversationId, onAgentRelinked, router, toast]);
+  }, [conversationId, onAgentRelinked, toast]);
 
   // "Choose agent" picker state — loaded lazily when the deprecated-agent banner is shown.
   const [showAgentPicker, setShowAgentPicker] = useState(false);
@@ -259,7 +259,7 @@ export function ChatPanel({
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
-  }, [conversationId, chosenAgentId, onAgentRelinked, router, toast]);
+  }, [conversationId, chosenAgentId, onAgentRelinked, toast]);
 
   // Slash command registry
   const slashCommands = useSlashCommands(agentSkills);

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -223,7 +223,6 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(agentId);
-      router.refresh();
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
@@ -259,7 +258,6 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(chosenAgentId);
-      router.refresh();
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -128,6 +128,9 @@ export function ChatPanel({
   }, [session?.user?.name]);
 
   const [input, setInput] = useState("");
+  const [hasRelinkedAgent, setHasRelinkedAgent] = useState(false);
+  const panelReadOnly = readOnly && !hasRelinkedAgent;
+  const panelReadOnlyReason = hasRelinkedAgent ? undefined : readOnlyReason;
   const [copiedId, setCopiedId] = useState<string | null>(null);
   const [queuedMessages, setQueuedMessages] = useState<QueuedMessage[]>([]);
   // Files staged in the composer for the next turn (multimodal input).
@@ -221,6 +224,7 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(agentId);
+      setHasRelinkedAgent(true);
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
@@ -256,6 +260,7 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(chosenAgentId);
+      setHasRelinkedAgent(true);
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
@@ -1151,13 +1156,13 @@ export function ChatPanel({
   // through the normal pipeline rather than duplicating it there.
   const pendingFirstMessageSentRef = useRef(false);
   useEffect(() => {
-    if (pendingFirstMessageSentRef.current || readOnly) return;
+    if (pendingFirstMessageSentRef.current || panelReadOnly) return;
     const pending = takePendingFirstMessage(conversationId);
     if (pending) {
       pendingFirstMessageSentRef.current = true;
       void submitMessage(pending.text, pending.files);
     }
-  }, [conversationId, readOnly, submitMessage]);
+  }, [conversationId, panelReadOnly, submitMessage]);
 
   // Handle queued messages after streaming completes
   useEffect(() => {
@@ -2031,22 +2036,22 @@ export function ChatPanel({
       </AnimatePresence>
 
       {/* Input Area - Fixed bottom, doesn't scroll */}
-      {readOnly ? (
-        <div className={`border-t border-border shrink-0 ${readOnlyReason === 'agent_deleted' || readOnlyReason === 'agent_disabled' ? 'bg-red-500/10' : 'bg-amber-500/10'}`}>
+      {panelReadOnly ? (
+        <div className={`border-t border-border shrink-0 ${panelReadOnlyReason === 'agent_deleted' || panelReadOnlyReason === 'agent_disabled' ? 'bg-red-500/10' : 'bg-amber-500/10'}`}>
           <div className="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
-            <div className={`flex items-center gap-2 ${readOnlyReason === 'agent_deleted' || readOnlyReason === 'agent_disabled' ? 'text-red-700 dark:text-red-400' : 'text-amber-700 dark:text-amber-400'}`}>
+            <div className={`flex items-center gap-2 ${panelReadOnlyReason === 'agent_deleted' || panelReadOnlyReason === 'agent_disabled' ? 'text-red-700 dark:text-red-400' : 'text-amber-700 dark:text-amber-400'}`}>
               <ShieldCheck className="h-4 w-4 shrink-0" />
-              {readOnlyReason === 'admin_audit' ? (
+              {panelReadOnlyReason === 'admin_audit' ? (
                 <>
                   <span className="text-sm font-medium">Read-Only Audit Mode</span>
                   <span className="text-xs text-amber-600 dark:text-amber-500">— You are viewing this conversation as an admin auditor.</span>
                 </>
-              ) : readOnlyReason === 'agent_deleted' ? (
+              ) : panelReadOnlyReason === 'agent_deleted' ? (
                 <>
                   <span className="text-sm font-medium">Agent No Longer Available</span>
                   <span className="text-xs text-red-600 dark:text-red-500">— This agent has been deprecated or deleted. You can view the history but cannot send new messages.</span>
                 </>
-              ) : readOnlyReason === 'agent_disabled' ? (
+              ) : panelReadOnlyReason === 'agent_disabled' ? (
                 <>
                   <span className="text-sm font-medium">Agent Disabled</span>
                   <span className="text-xs text-red-600 dark:text-red-500">— This agent has been disabled by an administrator. You can view the history but cannot send new messages.</span>
@@ -2058,7 +2063,7 @@ export function ChatPanel({
                 </>
               )}
             </div>
-            {readOnlyReason === 'admin_audit' ? (
+            {panelReadOnlyReason === 'admin_audit' ? (
             <NavigationProgressLink
               href="/admin/insights/feedback"
               className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-md bg-amber-600/20 text-amber-700 dark:text-amber-300 hover:bg-amber-600/30 transition-colors"
@@ -2066,7 +2071,7 @@ export function ChatPanel({
               <ArrowLeft className="h-3 w-3" />
               Back to Feedback
             </NavigationProgressLink>
-            ) : (readOnlyReason === 'agent_deleted' || readOnlyReason === 'agent_disabled') ? (
+            ) : (panelReadOnlyReason === 'agent_deleted' || panelReadOnlyReason === 'agent_disabled') ? (
             <div className="flex items-center gap-2 flex-wrap">
               {showAgentPicker ? (
                 <>

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -216,6 +216,7 @@ export function ChatPanel({
       await apiClient.updateConversation(conversationId, {
         participants: newParticipants,
       });
+      setHasRelinkedAgent(true);
       // Patch the Zustand store in-place so ChatContainer sees the new participants
       // immediately — it skips the API fetch when the conversation is already cached.
       useChatStore.setState((state) => ({
@@ -224,7 +225,6 @@ export function ChatPanel({
         ),
       }));
       onAgentRelinked?.(agentId);
-      setHasRelinkedAgent(true);
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
@@ -254,13 +254,13 @@ export function ChatPanel({
     try {
       const newParticipants = buildParticipants(chosenAgentId);
       await apiClient.updateConversation(conversationId, { participants: newParticipants });
+      setHasRelinkedAgent(true);
       useChatStore.setState((state) => ({
         conversations: state.conversations.map((c) =>
           c.id === conversationId ? { ...c, participants: newParticipants } : c,
         ),
       }));
       onAgentRelinked?.(chosenAgentId);
-      setHasRelinkedAgent(true);
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -61,9 +61,19 @@ interface ChatPanelProps {
   agentId: string; // Mandatory for Dynamic Agents
   agent?: DynamicAgentConfig | null; // Full agent config object
   isLoadingMessages?: boolean; // Whether messages are still loading (show skeleton)
+  /** Bounded, host-validated metadata attached to each app-assistant turn. */
+  clientContext?: Record<string, unknown>;
 }
 
-export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, agent, isLoadingMessages }: ChatPanelProps) {
+export function ChatPanel({
+  conversationId,
+  readOnly,
+  readOnlyReason,
+  agentId,
+  agent,
+  isLoadingMessages,
+  clientContext: suppliedClientContext,
+}: ChatPanelProps) {
   // Derive display values from agent object
   const agentGradient = agent?.ui?.gradient_theme ?? null;
   const agentCustomTheme = agent?.ui?.custom_theme_config ?? null;
@@ -1037,6 +1047,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
     const conv = getActiveConversation();
     const clientContext: Record<string, unknown> = {
       source: "webui",
+      ...suppliedClientContext,
       ...(conv?.sharing && { chat_sharing: conv.sharing }),
     };
     clearStreamEvents(convId);
@@ -1131,7 +1142,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
       });
       setConversationStreaming(convId, null);
     }
-  }, [isThisConversationStreaming, activeConversationId, accessToken, agentId, agentProtocol, getActiveConversation, createConversation, clearStreamEvents, addMessage, appendToMessage, updateMessage, setConversationStreaming, buildStreamCallbacks, finalizeStreamLoop, session?.user, showAuthErrorToast, toast]);
+  }, [isThisConversationStreaming, activeConversationId, accessToken, agentId, agentProtocol, getActiveConversation, createConversation, clearStreamEvents, addMessage, appendToMessage, updateMessage, setConversationStreaming, buildStreamCallbacks, finalizeStreamLoop, session?.user, showAuthErrorToast, suppliedClientContext, toast]);
 
   // The Home page hero composer creates a conversation and navigates here
   // before a message can be sent (this panel only mounts once a conversation
@@ -1455,6 +1466,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
     const conv = getActiveConversation();
     const clientContext: Record<string, unknown> = {
       source: "webui",
+      ...suppliedClientContext,
       ...(conv?.sharing && { chat_sharing: conv.sharing }),
     };
 
@@ -1497,7 +1509,8 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
     }
   }, [pendingUserInput, activeConversationId, accessToken, agentProtocol, addMessage, updateMessage,
       appendToMessage, addStreamEvent, setConversationStreaming,
-      clearStreamEvents, getActiveConversation, buildStreamCallbacks, finalizeStreamLoop]);
+      clearStreamEvents, getActiveConversation, buildStreamCallbacks, finalizeStreamLoop,
+      suppliedClientContext]);
 
   // Handle tool approval decisions (approve/reject/edit)
   // Shows cards sequentially; only resumes after all tools are decided.
@@ -1554,7 +1567,10 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
       accessToken,
     });
 
-    const clientContext: Record<string, unknown> = { source: "webui" };
+    const clientContext: Record<string, unknown> = {
+      source: "webui",
+      ...suppliedClientContext,
+    };
 
     // Build resume payload using the format expected by the runtime.
     let resumePayload: Record<string, unknown>;
@@ -1613,7 +1629,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
     }
   }, [pendingToolApproval, activeConversationId, accessToken, agentProtocol, addMessage, updateMessage,
       addStreamEvent, setConversationStreaming, clearStreamEvents, getActiveConversation,
-      buildStreamCallbacks, finalizeStreamLoop]);
+      buildStreamCallbacks, finalizeStreamLoop, suppliedClientContext]);
 
   // Handle slash command detection in input
   const handleInputChange = useCallback((e: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -61,6 +61,8 @@ interface ChatPanelProps {
   agentId: string; // Mandatory for Dynamic Agents
   agent?: DynamicAgentConfig | null; // Full agent config object
   isLoadingMessages?: boolean; // Whether messages are still loading (show skeleton)
+  /** Called after a deprecated conversation is linked to a usable agent. */
+  onAgentRelinked?: (agentId: string) => void;
   /** Bounded, host-validated metadata attached to each app-assistant turn. */
   clientContext?: Record<string, unknown>;
 }
@@ -72,6 +74,7 @@ export function ChatPanel({
   agentId,
   agent,
   isLoadingMessages,
+  onAgentRelinked,
   clientContext: suppliedClientContext,
 }: ChatPanelProps) {
   // Derive display values from agent object
@@ -219,11 +222,12 @@ export function ChatPanel({
           c.id === conversationId ? { ...c, participants: newParticipants } : c,
         ),
       }));
+      onAgentRelinked?.(agentId);
       router.refresh();
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
-  }, [conversationId, router, toast]);
+  }, [conversationId, onAgentRelinked, router, toast]);
 
   // "Choose agent" picker state — loaded lazily when the deprecated-agent banner is shown.
   const [showAgentPicker, setShowAgentPicker] = useState(false);
@@ -254,11 +258,12 @@ export function ChatPanel({
           c.id === conversationId ? { ...c, participants: newParticipants } : c,
         ),
       }));
+      onAgentRelinked?.(chosenAgentId);
       router.refresh();
     } catch (err) {
       toast(`Could not resume conversation: ${(err as Error).message}`, "error", 8000);
     }
-  }, [conversationId, chosenAgentId, router, toast]);
+  }, [conversationId, chosenAgentId, onAgentRelinked, router, toast]);
 
   // Slash command registry
   const slashCommands = useSlashCommands(agentSkills);

--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -28,7 +28,6 @@ import { resolveUsableChatAgentId } from "@/lib/chat-agent-selection";
 import { AgentPicker } from "@/components/ui/agent-picker";
 import { signIn,useSession } from "next-auth/react";
 import { NavigationProgressLink } from "@/components/layout/NavigationProgressLink";
-import { useRouter } from "next/navigation";
 import Image from "next/image";
 import React,{ useCallback,useEffect,useMemo,useRef,useState } from "react";
 import TextareaAutosize from "react-textarea-autosize";
@@ -84,7 +83,6 @@ export function ChatPanel({
   const agentSkills = agent?.skills;
   const { data: session } = useSession();
   const { toast } = useToast();
-  const router = useRouter();
   const autoScrollEnabled = useFeatureFlagStore((s) => s.flags.autoScroll ?? true);
   const showTimestamps = useFeatureFlagStore((s) => s.flags.showTimestamps ?? false);
 

--- a/ui/src/components/chat/DynamicAgentChatView.tsx
+++ b/ui/src/components/chat/DynamicAgentChatView.tsx
@@ -22,6 +22,8 @@ interface ChatViewProps {
   readOnlyReason?: "admin_audit" | "shared_readonly";
   /** Whether messages are still loading (show skeleton) */
   isLoadingMessages?: boolean;
+  /** Called after a deprecated conversation is linked to a usable agent. */
+  onAgentRelinked?: (agentId: string) => void;
 }
 
 /**
@@ -36,6 +38,7 @@ export function ChatView({
   readOnly,
   readOnlyReason,
   isLoadingMessages,
+  onAgentRelinked,
 }: ChatViewProps) {
   const [contextPanelCollapsed, setContextPanelCollapsed] = useState(true);
   const [isAnimating, setIsAnimating] = useState(false);
@@ -71,6 +74,7 @@ export function ChatView({
             agentId={selectedAgentId}
             agent={agent}
             isLoadingMessages={isLoadingMessages}
+            onAgentRelinked={onAgentRelinked}
           />
         </div>
       </ResizablePanel>

--- a/ui/src/components/chat/ShareDialog.tsx
+++ b/ui/src/components/chat/ShareDialog.tsx
@@ -177,7 +177,14 @@ export function ShareDialog({
     // object on every store update. Re-running this effect for that identity
     // would refetch the sharing endpoint indefinitely while the dialog is
     // open. The conversation id is the stable boundary for a new snapshot.
-  }, [open, conversationId, canManageSharing, applySharingSnapshot, loadSharingInfo]);
+  }, [
+    open,
+    conversationId,
+    canManageSharing,
+    initialSharing,
+    applySharingSnapshot,
+    loadSharingInfo,
+  ]);
 
   // Search users and teams as they type
   useEffect(() => {

--- a/ui/src/components/chat/ShareDialog.tsx
+++ b/ui/src/components/chat/ShareDialog.tsx
@@ -8,7 +8,7 @@ import { useChatStore } from "@/store/chat-store";
 import type { UserPublicInfo } from "@/types/mongodb";
 import type { Team } from "@/types/teams";
 import { Check,Copy,Mail,Trash2,Users,X } from "lucide-react";
-import { useCallback,useEffect,useState } from "react";
+import { useCallback,useEffect,useRef,useState } from "react";
 import { createPortal } from "react-dom";
 
 type SharePermission = 'view' | 'comment';
@@ -77,6 +77,7 @@ export function ShareDialog({
   const [userPermissions, setUserPermissions] = useState<Record<string, SharePermission>>({});
   const [teamPermissions, setTeamPermissions] = useState<Record<string, SharePermission>>({});
   const [defaultPermission, setDefaultPermission] = useState<SharePermission>('comment');
+  const loadedShareKey = useRef<string | null>(null);
 
   const shareUrl = `${typeof window !== 'undefined' ? window.location.origin : ''}/chat/${conversationId}`;
   const sharedByLabel = sharedBy?.trim();
@@ -163,11 +164,20 @@ export function ShareDialog({
 
   // Load current sharing info
   useEffect(() => {
-    if (open) {
-      applySharingSnapshot(initialSharing);
-      void loadSharingInfo();
+    if (!open) {
+      loadedShareKey.current = null;
+      return;
     }
-  }, [open, canManageSharing, initialSharing, applySharingSnapshot, loadSharingInfo]);
+    const shareKey = `${conversationId}:${canManageSharing ? "owner" : "viewer"}`;
+    if (loadedShareKey.current === shareKey) return;
+    loadedShareKey.current = shareKey;
+    applySharingSnapshot(initialSharing);
+    void loadSharingInfo();
+    // `initialSharing` is assembled by the chat parent and may be a new
+    // object on every store update. Re-running this effect for that identity
+    // would refetch the sharing endpoint indefinitely while the dialog is
+    // open. The conversation id is the stable boundary for a new snapshot.
+  }, [open, conversationId, canManageSharing, applySharingSnapshot, loadSharingInfo]);
 
   // Search users and teams as they type
   useEffect(() => {

--- a/ui/src/lib/agentic-apps/__tests__/assistant-context.test.ts
+++ b/ui/src/lib/agentic-apps/__tests__/assistant-context.test.ts
@@ -1,0 +1,68 @@
+/** @jest-environment node */
+
+import { validateAssistantContextMessage } from "../assistant-context";
+
+function message(context: Record<string, unknown> = { route: "/" }) {
+  return {
+    type: "caipe.agenticApp.context.v1",
+    version: "1.0",
+    appId: "example-app",
+    context,
+  };
+}
+
+describe("agentic app assistant context", () => {
+  it("accepts bounded context for the expected app and origin", () => {
+    const result = validateAssistantContextMessage({
+      message: message({ route: "/reports", title: "Report" }),
+      appId: "example-app",
+      origin: "https://grid.example.com",
+      expectedOrigin: "https://grid.example.com",
+      now: new Date("2026-01-01T00:00:00.000Z"),
+    });
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        ok: true,
+        record: expect.objectContaining({
+          appId: "example-app",
+          route: "/reports",
+          title: "Report",
+        }),
+      }),
+    );
+  });
+
+  it("rejects cross-origin, cross-app, oversized, and secret-like context", () => {
+    expect(
+      validateAssistantContextMessage({
+        message: message(),
+        appId: "example-app",
+        origin: "https://other.example.com",
+        expectedOrigin: "https://grid.example.com",
+      }),
+    ).toEqual({ ok: false, reasonCode: "invalid_origin" });
+
+    expect(
+      validateAssistantContextMessage({
+        message: { ...message(), appId: "other-app" },
+        appId: "example-app",
+      }),
+    ).toEqual({ ok: false, reasonCode: "app_mismatch" });
+
+    expect(
+      validateAssistantContextMessage({
+        message: message({ route: "/", summary: "too large" }),
+        appId: "example-app",
+        maxBytes: 8,
+      }),
+    ).toEqual({ ok: false, reasonCode: "payload_too_large" });
+
+    expect(
+      validateAssistantContextMessage({
+        message: message({ route: "/", apiKey: "example" }),
+        appId: "example-app",
+      }),
+    ).toEqual({ ok: false, reasonCode: "secret_like_context" });
+  });
+});

--- a/ui/src/lib/agentic-apps/__tests__/config.test.ts
+++ b/ui/src/lib/agentic-apps/__tests__/config.test.ts
@@ -84,7 +84,7 @@ describe("External Apps deployment config", () => {
       )
       .replace(
         "        health:\n          endpoint: /health",
-        "        assistant:\n          enabled: false\n        health:\n          endpoint: /health\n          timeoutMs: 2000\n          blockLaunchWhen: [degraded, unreachable]",
+        "        assistant:\n          enabled: false\n          agentId: agent-example\n          label: Ask Example\n          agentName: Example Assistant\n        health:\n          endpoint: /health\n          timeoutMs: 2000\n          blockLaunchWhen: [degraded, unreachable]",
       )
       .replace(
         "      runtime_origin_override: http://example-app.example.svc",
@@ -97,6 +97,12 @@ describe("External Apps deployment config", () => {
           manifest: expect.objectContaining({
             id: "example-app",
             surfaces: expect.objectContaining({ showInHub: true, navOrder: 50 }),
+            assistant: {
+              enabled: false,
+              agentId: "agent-example",
+              label: "Ask Example",
+              agentName: "Example Assistant",
+            },
             health: { endpoint: "/health", timeoutMs: 2000 },
           }),
           installation: expect.objectContaining({ enabled: true, visible: true }),

--- a/ui/src/lib/agentic-apps/__tests__/config.test.ts
+++ b/ui/src/lib/agentic-apps/__tests__/config.test.ts
@@ -84,7 +84,7 @@ describe("External Apps deployment config", () => {
       )
       .replace(
         "        health:\n          endpoint: /health",
-        "        assistant:\n          enabled: false\n          agentId: agent-example\n          label: Ask Example\n          agentName: Example Assistant\n        health:\n          endpoint: /health\n          timeoutMs: 2000\n          blockLaunchWhen: [degraded, unreachable]",
+        "        assistant:\n          enabled: false\n          agentId: agent-example\n          label: Ask Example\n          name: Example Assistant\n          contextEndpoint: /api/context\n        health:\n          endpoint: /health\n          timeoutMs: 2000\n          blockLaunchWhen: [degraded, unreachable]",
       )
       .replace(
         "      runtime_origin_override: http://example-app.example.svc",

--- a/ui/src/lib/agentic-apps/__tests__/security.test.ts
+++ b/ui/src/lib/agentic-apps/__tests__/security.test.ts
@@ -174,7 +174,11 @@ describe("External Apps security contracts", () => {
 
   it("keeps private runtime coordinates out of the public catalog", () => {
     const publicApp = buildPublicAgenticApp(app, true);
-    expect(publicApp).toEqual(expect.objectContaining({ appId: "example-app", href: "/apps/example-app" }));
+    expect(publicApp).toEqual(expect.objectContaining({
+      appId: "example-app",
+      href: "/apps/example-app",
+      assistantEnabled: true,
+    }));
     expect(JSON.stringify(publicApp)).not.toContain("example.svc");
     expect(publicApp).not.toHaveProperty("runtime");
     expect(publicApp).not.toHaveProperty("origin");

--- a/ui/src/lib/agentic-apps/assistant-context.ts
+++ b/ui/src/lib/agentic-apps/assistant-context.ts
@@ -1,0 +1,161 @@
+import type { AgenticAppAssistantContextRecord } from "@/types/agentic-app";
+
+export const ASSISTANT_CONTEXT_MESSAGE_TYPE = "caipe.agenticApp.context.v1";
+export const ASSISTANT_CONTEXT_SCHEMA_VERSION = "1.0";
+export const DEFAULT_ASSISTANT_CONTEXT_TTL_MS = 10 * 60 * 1000;
+export const DEFAULT_ASSISTANT_CONTEXT_MAX_BYTES = 16 * 1024;
+
+export type AssistantContextValidationInput = {
+  message: unknown;
+  appId: string;
+  origin?: string;
+  expectedOrigin?: string;
+  source?: MessageEventSource | null;
+  expectedSource?: MessageEventSource | null;
+  maxBytes?: number;
+  ttlMs?: number;
+  now?: Date;
+};
+
+export type AssistantContextValidationResult =
+  | { ok: true; record: AgenticAppAssistantContextRecord }
+  | { ok: false; reasonCode: string };
+
+const SECRET_KEY_PATTERN = /(api[_-]?key|authorization|cookie|password|secret|token)/i;
+const SECRET_VALUE_PATTERN = /(bearer\s+[a-z0-9._-]+|eyJ[a-zA-Z0-9_-]+\.[a-zA-Z0-9_-]+\.)/i;
+
+export function validateAssistantContextMessage(
+  input: AssistantContextValidationInput,
+): AssistantContextValidationResult {
+  if (input.expectedOrigin && input.origin !== input.expectedOrigin) {
+    return { ok: false, reasonCode: "invalid_origin" };
+  }
+  if (input.expectedSource && input.source !== input.expectedSource) {
+    return { ok: false, reasonCode: "invalid_source" };
+  }
+  if (!isRecord(input.message)) {
+    return { ok: false, reasonCode: "invalid_message" };
+  }
+  if (input.message.type !== ASSISTANT_CONTEXT_MESSAGE_TYPE) {
+    return { ok: false, reasonCode: "invalid_type" };
+  }
+  if (input.message.version !== ASSISTANT_CONTEXT_SCHEMA_VERSION) {
+    return { ok: false, reasonCode: "unsupported_version" };
+  }
+  if (input.message.appId !== input.appId) {
+    return { ok: false, reasonCode: "app_mismatch" };
+  }
+  if (!isRecord(input.message.context)) {
+    return { ok: false, reasonCode: "invalid_context" };
+  }
+
+  const context = input.message.context;
+  if (typeof context.route !== "string" || !context.route.startsWith("/")) {
+    return { ok: false, reasonCode: "invalid_route" };
+  }
+  for (const key of ["title", "summary", "selection"] as const) {
+    if (context[key] !== undefined && typeof context[key] !== "string") {
+      return { ok: false, reasonCode: `invalid_${key}` };
+    }
+  }
+  if (
+    context.suggestedPrompts !== undefined &&
+    (!Array.isArray(context.suggestedPrompts) ||
+      !context.suggestedPrompts.every((entry) => typeof entry === "string"))
+  ) {
+    return { ok: false, reasonCode: "invalid_suggested_prompts" };
+  }
+  if (
+    context.resourceRefs !== undefined &&
+    (!Array.isArray(context.resourceRefs) ||
+      !context.resourceRefs.every(
+        (entry) =>
+          isRecord(entry) &&
+          Object.values(entry).every((value) => typeof value === "string"),
+      ))
+  ) {
+    return { ok: false, reasonCode: "invalid_resource_refs" };
+  }
+
+  const payloadSizeBytes = byteLength(input.message);
+  if (payloadSizeBytes > (input.maxBytes ?? DEFAULT_ASSISTANT_CONTEXT_MAX_BYTES)) {
+    return { ok: false, reasonCode: "payload_too_large" };
+  }
+  if (containsSecretLikeValue(input.message)) {
+    return { ok: false, reasonCode: "secret_like_context" };
+  }
+
+  const now = input.now ?? new Date();
+  const ttlMs = input.ttlMs ?? DEFAULT_ASSISTANT_CONTEXT_TTL_MS;
+  return {
+    ok: true,
+    record: {
+      contextId: createContextId(),
+      appId: input.appId,
+      sessionId: "browser-session",
+      schemaVersion: ASSISTANT_CONTEXT_SCHEMA_VERSION,
+      route: context.route,
+      payloadSizeBytes,
+      validationStatus: "accepted",
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + ttlMs).toISOString(),
+      ...(typeof context.title === "string" ? { title: context.title.slice(0, 240) } : {}),
+      ...(typeof context.summary === "string"
+        ? { summary: context.summary.slice(0, 4096) }
+        : {}),
+      ...(typeof context.selection === "string"
+        ? { selection: context.selection.slice(0, 2048) }
+        : {}),
+      ...(Array.isArray(context.resourceRefs)
+        ? { resourceRefs: context.resourceRefs.slice(0, 20) }
+        : {}),
+      ...(Array.isArray(context.suggestedPrompts)
+        ? { suggestedPrompts: context.suggestedPrompts.slice(0, 8) }
+        : {}),
+    },
+  };
+}
+
+export function buildAssistantClientContext(
+  record: AgenticAppAssistantContextRecord | null,
+): Record<string, unknown> | undefined {
+  if (!record) return undefined;
+  return {
+    source: "agentic_app_context",
+    trust: "untrusted_user_visible_data",
+    appId: record.appId,
+    route: record.route,
+    title: record.title,
+    summary: record.summary,
+    selection: record.selection,
+    resourceRefs: record.resourceRefs,
+    contextId: record.contextId,
+    expiresAt: record.expiresAt,
+  };
+}
+
+function byteLength(value: unknown): number {
+  return new TextEncoder().encode(JSON.stringify(value)).byteLength;
+}
+
+function containsSecretLikeValue(value: unknown): boolean {
+  if (isRecord(value)) {
+    return Object.entries(value).some(
+      ([key, entry]) =>
+        SECRET_KEY_PATTERN.test(key) || containsSecretLikeValue(entry),
+    );
+  }
+  if (Array.isArray(value)) {
+    return value.some((entry) => containsSecretLikeValue(entry));
+  }
+  return typeof value === "string" && SECRET_VALUE_PATTERN.test(value);
+}
+
+function createContextId(): string {
+  return globalThis.crypto?.randomUUID?.()
+    ?? `ctx_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/ui/src/lib/agentic-apps/config.ts
+++ b/ui/src/lib/agentic-apps/config.ts
@@ -259,9 +259,21 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
         "suggestions",
         "label",
         "agentName",
+        // Deployment manifests used these names before the public schema was
+        // finalized. Accept them so existing app-specific assistants survive
+        // config validation and serialization.
+        "name",
+        "contextEndpoint",
       ],
       `${path}.assistant`,
     );
+    if (
+      assistantRaw.agentName !== undefined
+      && assistantRaw.name !== undefined
+      && assistantRaw.agentName !== assistantRaw.name
+    ) {
+      throw new Error(`${path}.assistant.agentName and ${path}.assistant.name must match`);
+    }
   }
 
   return {
@@ -357,7 +369,7 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
               : {}),
             ...(assistantRaw.maxContextBytes !== undefined
               ? {
-                  maxContextBytes: requiredNumber(
+                  maxContextBytes: requiredAssistantContextLimit(
                     assistantRaw.maxContextBytes,
                     `${path}.assistant.maxContextBytes`,
                   ),
@@ -389,10 +401,10 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
                   ),
                 }
               : {}),
-            ...(assistantRaw.agentName !== undefined
+            ...(assistantRaw.agentName !== undefined || assistantRaw.name !== undefined
               ? {
                   agentName: requiredBoundedString(
-                    assistantRaw.agentName,
+                    assistantRaw.agentName ?? assistantRaw.name,
                     `${path}.assistant.agentName`,
                     64,
                   ),
@@ -589,6 +601,14 @@ function requiredRequestBodyLimit(value: unknown, path: string): number {
     throw new Error(
       `${path} must not exceed ${MAX_AGENTIC_APP_REQUEST_BODY_BYTES} bytes`,
     );
+  }
+  return result;
+}
+
+function requiredAssistantContextLimit(value: unknown, path: string): number {
+  const result = requiredNumber(value, path);
+  if (!Number.isSafeInteger(result) || result < 1 || result > 65536) {
+    throw new Error(`${path} must be an integer between 1 and 65536`);
   }
   return result;
 }

--- a/ui/src/lib/agentic-apps/config.ts
+++ b/ui/src/lib/agentic-apps/config.ts
@@ -240,9 +240,29 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
   const catalogRaw = raw.catalog === undefined
     ? undefined
     : asRecord(raw.catalog, `${path}.catalog`);
+  const assistantRaw = raw.assistant === undefined
+    ? undefined
+    : asRecord(raw.assistant, `${path}.assistant`);
   const healthRaw = raw.health === undefined
     ? undefined
     : asRecord(raw.health, `${path}.health`);
+
+  if (assistantRaw) {
+    assertKnownKeys(
+      assistantRaw,
+      [
+        "enabled",
+        "agentId",
+        "schemaVersions",
+        "maxContextBytes",
+        "capability",
+        "suggestions",
+        "label",
+        "agentName",
+      ],
+      `${path}.assistant`,
+    );
+  }
 
   return {
     id,
@@ -306,6 +326,81 @@ function parseManifest(value: unknown, path: string): AgenticAppManifest {
           }
         : {}),
     },
+    ...(assistantRaw
+      ? {
+          assistant: {
+            ...(assistantRaw.enabled !== undefined
+              ? {
+                  enabled: optionalBoolean(
+                    assistantRaw.enabled,
+                    true,
+                    `${path}.assistant.enabled`,
+                  ),
+                }
+              : {}),
+            ...(assistantRaw.agentId !== undefined
+              ? {
+                  agentId: requiredString(
+                    assistantRaw.agentId,
+                    `${path}.assistant.agentId`,
+                  ),
+                }
+              : {}),
+            ...(assistantRaw.schemaVersions !== undefined
+              ? {
+                  schemaVersions: requiredStringArray(
+                    assistantRaw.schemaVersions,
+                    `${path}.assistant.schemaVersions`,
+                    true,
+                  ),
+                }
+              : {}),
+            ...(assistantRaw.maxContextBytes !== undefined
+              ? {
+                  maxContextBytes: requiredNumber(
+                    assistantRaw.maxContextBytes,
+                    `${path}.assistant.maxContextBytes`,
+                  ),
+                }
+              : {}),
+            ...(assistantRaw.capability !== undefined
+              ? {
+                  capability: requiredString(
+                    assistantRaw.capability,
+                    `${path}.assistant.capability`,
+                  ),
+                }
+              : {}),
+            ...(assistantRaw.suggestions !== undefined
+              ? {
+                  suggestions: optionalBoolean(
+                    assistantRaw.suggestions,
+                    true,
+                    `${path}.assistant.suggestions`,
+                  ),
+                }
+              : {}),
+            ...(assistantRaw.label !== undefined
+              ? {
+                  label: requiredBoundedString(
+                    assistantRaw.label,
+                    `${path}.assistant.label`,
+                    32,
+                  ),
+                }
+              : {}),
+            ...(assistantRaw.agentName !== undefined
+              ? {
+                  agentName: requiredBoundedString(
+                    assistantRaw.agentName,
+                    `${path}.assistant.agentName`,
+                    64,
+                  ),
+                }
+              : {}),
+          },
+        }
+      : {}),
     ...(healthRaw
       ? {
           health: {
@@ -449,6 +544,14 @@ function assertKnownKeys(
 function requiredString(value: unknown, path: string): string {
   const result = typeof value === "string" ? value.trim() : "";
   if (!result) throw new Error(`${path} must be a non-empty string`);
+  return result;
+}
+
+function requiredBoundedString(value: unknown, path: string, maxLength: number): string {
+  const result = requiredString(value, path);
+  if (result.length > maxLength) {
+    throw new Error(`${path} must be at most ${maxLength} characters`);
+  }
   return result;
 }
 

--- a/ui/src/lib/agentic-apps/public-app.ts
+++ b/ui/src/lib/agentic-apps/public-app.ts
@@ -14,5 +14,18 @@ export function buildPublicAgenticApp(
     blockedReasons: canLaunch ? [] : ["unauthorized"],
     categories: app.manifest.catalog?.categories ?? [],
     capabilities: app.manifest.catalog?.capabilities ?? [],
+    assistantEnabled: app.manifest.assistant?.enabled !== false,
+    ...(app.manifest.assistant?.agentId
+      ? { assistantAgentId: app.manifest.assistant.agentId }
+      : {}),
+    ...(app.manifest.assistant?.label
+      ? { assistantLabel: app.manifest.assistant.label }
+      : {}),
+    ...(app.manifest.assistant?.agentName
+      ? { assistantAgentName: app.manifest.assistant.agentName }
+      : {}),
+    ...(app.manifest.assistant?.maxContextBytes
+      ? { assistantMaxContextBytes: app.manifest.assistant.maxContextBytes }
+      : {}),
   };
 }

--- a/ui/src/lib/chat-agent-selection.ts
+++ b/ui/src/lib/chat-agent-selection.ts
@@ -11,7 +11,14 @@ interface ApiEnvelope<T> {
 export interface ResolvedChatAgent {
   id: string;
   name: string;
-  source: "user-default" | "platform-default" | "first-available";
+  source: "configured" | "user-default" | "platform-default" | "first-available";
+}
+
+export interface ResolveUsableChatAgentOptions {
+  /** Select this exact agent from the authorization-filtered available list. */
+  requestedAgentId?: string;
+  /** Do not trust a default when the available-agent lookup fails. */
+  requireAvailableAgent?: boolean;
 }
 
 async function fetchJson<T>(url: string): Promise<T> {
@@ -56,7 +63,9 @@ async function fetchAvailableAgents(): Promise<DynamicAgentConfig[]> {
   return payload.data.filter((agent) => agent.enabled);
 }
 
-export async function resolveUsableChatAgent(): Promise<ResolvedChatAgent> {
+export async function resolveUsableChatAgent(
+  options: ResolveUsableChatAgentOptions = {},
+): Promise<ResolvedChatAgent> {
   const [defaultsResult, agentsResult] = await Promise.allSettled([
     fetchChatDefaultAgentIds(),
     fetchAvailableAgents(),
@@ -70,6 +79,21 @@ export async function resolveUsableChatAgent(): Promise<ResolvedChatAgent> {
   const defaultAgentId = defaults.platformDefaultAgentId;
   const availableAgents =
     agentsResult.status === "fulfilled" ? agentsResult.value : [];
+
+  const requestedAgentId = normalizedAgentId(options.requestedAgentId);
+  if (requestedAgentId) {
+    const configuredAgent = availableAgents.find((agent) => agent._id === requestedAgentId);
+    if (configuredAgent) {
+      return {
+        id: configuredAgent._id,
+        name: configuredAgent.name,
+        source: "configured",
+      };
+    }
+    throw new Error(
+      `Configured agent "${requestedAgentId}" is unavailable or not authorized for this user.`,
+    );
+  }
 
   // Highest priority: the user's own Web default, but only if they still have
   // access to it (it's in the available list). A stale/revoked choice falls
@@ -95,7 +119,7 @@ export async function resolveUsableChatAgent(): Promise<ResolvedChatAgent> {
       };
     }
 
-    if (agentsResult.status === "rejected") {
+    if (agentsResult.status === "rejected" && !options.requireAvailableAgent) {
       return {
         id: defaultAgentId,
         name: "Default agent",

--- a/ui/src/store/__tests__/chat-store.test.ts
+++ b/ui/src/store/__tests__/chat-store.test.ts
@@ -1282,6 +1282,29 @@ describe('chat-store', () => {
       );
     });
 
+    it('persists an app-scoped title and metadata on server and local state', async () => {
+      const metadata = {
+        conversation_surface: 'agentic-app',
+        agentic_app_id: 'weather',
+        agentic_app_agent_id: 'agent-weather',
+      };
+
+      const id = await useChatStore.getState().createConversation('agent-weather', {
+        title: 'Weather Lab Assistant',
+        metadata,
+      });
+
+      expect(mockApiClient.createConversation).toHaveBeenCalledWith({
+        title: 'Weather Lab Assistant',
+        client_type: 'webui',
+        agent_id: 'agent-weather',
+        metadata,
+      });
+      expect(useChatStore.getState().conversations.find((item) => item.id === id)).toEqual(
+        expect.objectContaining({ title: 'Weather Lab Assistant', metadata }),
+      );
+    });
+
     it('does not call server in localStorage mode', async () => {
       (global as unknown).__mockStorageMode = 'localStorage';
 

--- a/ui/src/store/chat-store.ts
+++ b/ui/src/store/chat-store.ts
@@ -90,7 +90,7 @@ interface ChatState {
 
   // Actions
   createConversation: (agentId: string) => Promise<string>;
-  setActiveConversation: (id: string) => void;
+  setActiveConversation: (id: string | null) => void;
   addMessage: (conversationId: string, message: Omit<ChatMessage, "id" | "timestamp">, turnId?: string, messageId?: string) => string;
   updateMessage: (conversationId: string, messageId: string, updates: Partial<ChatMessage>) => void;
   appendToMessage: (conversationId: string, messageId: string, content: string) => void;
@@ -250,12 +250,12 @@ const storeImplementation: StateCreator<ChatState> = (set, get) => ({
         return id;
       },
 
-      setActiveConversation: (id: string) => {
+      setActiveConversation: (id: string | null) => {
         const prev = get();
         const newUnviewed = new Set(prev.unviewedConversations);
-        newUnviewed.delete(id);
+        if (id) newUnviewed.delete(id);
         const newInputRequired = new Set(prev.inputRequiredConversations);
-        newInputRequired.delete(id);
+        if (id) newInputRequired.delete(id);
         set({
           activeConversationId: id,
           unviewedConversations: newUnviewed,

--- a/ui/src/store/chat-store.ts
+++ b/ui/src/store/chat-store.ts
@@ -89,7 +89,10 @@ interface ChatState {
   inputRequiredConversations: Set<string>;
 
   // Actions
-  createConversation: (agentId: string) => Promise<string>;
+  createConversation: (
+    agentId: string,
+    options?: { title?: string; metadata?: Record<string, unknown> },
+  ) => Promise<string>;
   setActiveConversation: (id: string | null) => void;
   addMessage: (conversationId: string, message: Omit<ChatMessage, "id" | "timestamp">, turnId?: string, messageId?: string) => string;
   updateMessage: (conversationId: string, messageId: string, updates: Partial<ChatMessage>) => void;
@@ -208,9 +211,13 @@ const storeImplementation: StateCreator<ChatState> = (set, get) => ({
       unviewedConversations: new Set<string>(),
       inputRequiredConversations: new Set<string>(),
 
-      createConversation: async (agentId: string) => {
+      createConversation: async (
+        agentId: string,
+        options?: { title?: string; metadata?: Record<string, unknown> },
+      ) => {
         const storageMode = getStorageMode();
         const normalizedAgentId = agentId.trim();
+        const title = options?.title?.trim() || "New Conversation";
         if (!normalizedAgentId) {
           throw new Error("agentId is required to create a chat conversation");
         }
@@ -220,9 +227,10 @@ const storeImplementation: StateCreator<ChatState> = (set, get) => ({
         if (storageMode === 'mongodb') {
           // MongoDB mode: server owns ID generation
           const result = await apiClient.createConversation({
-            title: 'New Conversation',
+            title,
             client_type: 'webui',
             agent_id: normalizedAgentId,
+            ...(options?.metadata ? { metadata: options.metadata } : {}),
           });
           id = result.conversation._id;
         } else {
@@ -232,12 +240,13 @@ const storeImplementation: StateCreator<ChatState> = (set, get) => ({
 
         const newConversation: Conversation = {
           id,
-          title: "New Conversation",
+          title,
           createdAt: new Date(),
           updatedAt: new Date(),
           messages: [],
           streamEvents: [],
           participants: buildParticipants(normalizedAgentId),
+          ...(options?.metadata ? { metadata: options.metadata } : {}),
         };
 
         // Update local state

--- a/ui/src/types/agentic-app.ts
+++ b/ui/src/types/agentic-app.ts
@@ -13,6 +13,18 @@ export interface AgenticAppPolicyAction {
   path?: string;
 }
 
+export interface AgenticAppAssistantConfig {
+  enabled?: boolean;
+  /** Exact dynamic agent used by this app's contextual chat surface. */
+  agentId?: string;
+  schemaVersions?: string[];
+  maxContextBytes?: number;
+  capability?: string;
+  suggestions?: boolean;
+  label?: string;
+  agentName?: string;
+}
+
 export interface AgenticAppManifest {
   id: string;
   displayName: string;
@@ -36,6 +48,7 @@ export interface AgenticAppManifest {
     tokenScopes: string[];
     policyActions: AgenticAppPolicyAction[];
   };
+  assistant?: AgenticAppAssistantConfig;
   health?: {
     endpoint: string;
     timeoutMs?: number;
@@ -75,4 +88,27 @@ export interface PublicAgenticApp {
   blockedReasons: string[];
   categories: string[];
   capabilities: string[];
+  assistantEnabled: boolean;
+  assistantAgentId?: string;
+  assistantLabel?: string;
+  assistantAgentName?: string;
+  assistantMaxContextBytes?: number;
+}
+
+export interface AgenticAppAssistantContextRecord {
+  contextId: string;
+  appId: string;
+  sessionId: string;
+  schemaVersion: string;
+  route: string;
+  payloadSizeBytes: number;
+  validationStatus: "accepted" | "ignored" | "rejected";
+  createdAt: string;
+  expiresAt: string;
+  title?: string;
+  summary?: string;
+  selection?: string;
+  resourceRefs?: Array<Record<string, string>>;
+  suggestedPrompts?: string[];
+  reasonCode?: string;
 }


### PR DESCRIPTION
# Description

Restore the floating glass assistant launcher on every enabled Agentic App page. Apps may bind the overlay to a dedicated authorized dynamic agent, customize its label, or explicitly disable it; apps without assistant configuration use the user/platform default available agent.

The shell accepts bounded same-origin context only from its own iframe and attaches the validated metadata to chat turns. This is the clean upstream port of cisco-eti/ai-platform-engineering-mirror#641, based directly on current upstream main.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Validation

- [x] Agentic App and API regression tests: 29 tests passed
- [x] Related chat/default-agent tests: 24 tests passed
- [x] Full UI ESLint passed
- [x] TypeScript no-emit check passed
- [x] Webpack production compilation passed
- [ ] Next.js route validation is clean (blocked by existing invalid non-route exports in unchanged API routes)

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented in code and manifest types
- [x] New selection controls follow the selection-control decision table, or the custom interaction is justified (not applicable)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All relevant tests pass