### PR TITLE
fix(rbac): harden private resource ownership transitions

### DIFF
--- a/ui/src/app/api/__tests__/agent-skill-content.test.ts
+++ b/ui/src/app/api/__tests__/agent-skill-content.test.ts
@@ -44,16 +44,24 @@ jest.mock("@/lib/mongodb", () => ({
   isMongoDBConfigured: true,
 }));
 
+jest.mock("@/lib/rbac/skill-team-grants", () => ({
+  reconcileSkillTeamShares: jest.fn().mockResolvedValue({
+    teamSlugs: [],
+    writesPlanned: 0,
+    writesApplied: 0,
+    deletesPlanned: 0,
+    deletesApplied: 0,
+    enabled: false,
+  }),
+  readSkillSharedTeamSlugsFromOpenFga: jest.fn().mockResolvedValue([]),
+}));
+
 function createMockCollection() {
-  const findReturnValue = {
-    project: jest.fn().mockReturnValue({
-      toArray: jest.fn().mockResolvedValue([]),
-    }),
-    sort: jest.fn().mockReturnValue({
-      toArray: jest.fn().mockResolvedValue([]),
-    }),
-    toArray: jest.fn().mockResolvedValue([]),
-  };
+  const findReturnValue: Record<string, jest.Mock> = {};
+  findReturnValue.project = jest.fn().mockReturnValue(findReturnValue);
+  findReturnValue.sort = jest.fn().mockReturnValue(findReturnValue);
+  findReturnValue.limit = jest.fn().mockReturnValue(findReturnValue);
+  findReturnValue.toArray = jest.fn().mockResolvedValue([]);
 
   return {
     find: jest.fn().mockReturnValue(findReturnValue),
@@ -61,6 +69,7 @@ function createMockCollection() {
     insertOne: jest.fn().mockResolvedValue({ insertedId: "test-id" }),
     updateOne: jest.fn().mockResolvedValue({ matchedCount: 1, modifiedCount: 1, acknowledged: true }),
     deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+    deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
     countDocuments: jest.fn().mockResolvedValue(0),
   };
 }
@@ -73,6 +82,7 @@ function userSession(email = "user@example.com") {
   return {
     user: { email, name: "Test User" },
     role: "user",
+    sub: "user-sub",
   };
 }
 
@@ -373,7 +383,7 @@ def hello():
     expect(insertedConfig.skill_content).toBe(SAMPLE_SKILL_CONTENT);
     expect(insertedConfig.is_quick_start).toBe(true);
     expect(insertedConfig.visibility).toBe("team");
-    expect(insertedConfig.shared_with_teams).toBeUndefined();
+    expect(insertedConfig.shared_with_teams).toEqual(["team-sre", "team-devops"]);
   });
 });
 

--- a/ui/src/app/api/__tests__/agent-skill-visibility.test.ts
+++ b/ui/src/app/api/__tests__/agent-skill-visibility.test.ts
@@ -83,22 +83,25 @@ jest.mock("@/lib/agent-skill-visibility", () => ({
 }));
 
 function createMockCollection() {
-  const findReturnValue = {
-    project: jest.fn().mockReturnValue({
-      toArray: jest.fn().mockResolvedValue([]),
-    }),
-    sort: jest.fn().mockReturnValue({
-      toArray: jest.fn().mockResolvedValue([]),
-    }),
-    toArray: jest.fn().mockResolvedValue([]),
-  };
+  const findReturnValue: Record<string, jest.Mock> = {};
+  findReturnValue.project = jest.fn().mockReturnValue(findReturnValue);
+  findReturnValue.sort = jest.fn().mockReturnValue(findReturnValue);
+  findReturnValue.limit = jest.fn().mockReturnValue(findReturnValue);
+  findReturnValue.toArray = jest.fn().mockResolvedValue([]);
 
   return {
     find: jest.fn().mockReturnValue(findReturnValue),
     findOne: jest.fn().mockResolvedValue(null),
+    findOneAndUpdate: jest.fn().mockImplementation(
+      async (_filter: unknown, update: { $set?: Record<string, unknown> }) => ({
+        id: "config-1",
+        ...(update.$set ?? {}),
+      }),
+    ),
     insertOne: jest.fn().mockResolvedValue({ insertedId: "test-id" }),
     updateOne: jest.fn().mockResolvedValue({ matchedCount: 1, modifiedCount: 1, acknowledged: true }),
     deleteOne: jest.fn().mockResolvedValue({ deletedCount: 1 }),
+    deleteMany: jest.fn().mockResolvedValue({ deletedCount: 0 }),
     countDocuments: jest.fn().mockResolvedValue(0),
   };
 }
@@ -151,7 +154,7 @@ describe("POST /api/skills/configs - visibility", () => {
     const collection = await mockGetCollection("agent_skills");
     const insertedConfig = collection.insertOne.mock.calls[0][0];
     expect(insertedConfig.visibility).toBe("private");
-    expect(insertedConfig.shared_with_teams).toBeUndefined();
+    expect(insertedConfig.shared_with_teams).toEqual([]);
   });
 
   it("should create with 'global' visibility", async () => {
@@ -172,7 +175,7 @@ describe("POST /api/skills/configs - visibility", () => {
     const collection = await mockGetCollection("agent_skills");
     const insertedConfig = collection.insertOne.mock.calls[0][0];
     expect(insertedConfig.visibility).toBe("global");
-    expect(insertedConfig.shared_with_teams).toBeUndefined();
+    expect(insertedConfig.shared_with_teams).toEqual([]);
   });
 
   it("should create with 'team' visibility and shared_with_teams", async () => {
@@ -194,7 +197,7 @@ describe("POST /api/skills/configs - visibility", () => {
     const collection = await mockGetCollection("agent_skills");
     const insertedConfig = collection.insertOne.mock.calls[0][0];
     expect(insertedConfig.visibility).toBe("team");
-    expect(insertedConfig.shared_with_teams).toBeUndefined();
+    expect(insertedConfig.shared_with_teams).toEqual(["team-1", "team-2"]);
   });
 
   it("should reject 'team' visibility without shared_with_teams", async () => {
@@ -269,7 +272,7 @@ describe("POST /api/skills/configs - visibility", () => {
     const collection = await mockGetCollection("agent_skills");
     const insertedConfig = collection.insertOne.mock.calls[0][0];
     expect(insertedConfig.visibility).toBe("global");
-    expect(insertedConfig.shared_with_teams).toBeUndefined();
+    expect(insertedConfig.shared_with_teams).toEqual([]);
   });
 });
 
@@ -407,8 +410,7 @@ describe("PUT /api/skills/configs - visibility updates", () => {
     const response = await PUT(request);
     expect(response.status).toBe(200);
 
-    const updateCall = configsCollection.updateOne.mock.calls[0][1];
-    expect(updateCall.$set.shared_with_teams).toBeUndefined();
-    expect(updateCall.$unset).toEqual({ shared_with_teams: "" });
+    const updateCall = configsCollection.findOneAndUpdate.mock.calls[0][1];
+    expect(updateCall.$set.shared_with_teams).toEqual([]);
   });
 });

--- a/ui/src/app/api/__tests__/mcp-servers-rbac.test.ts
+++ b/ui/src/app/api/__tests__/mcp-servers-rbac.test.ts
@@ -317,10 +317,10 @@ describe("MCP server per-resource RBAC", () => {
         personalOwnerAccess: false,
         nextSharedTeamSlugs: [],
       },
-      {
+      expect.objectContaining({
         caller: { type: "service_account", id: "bot-client-id" },
         source: "mcp_server_create",
-      },
+      }),
     );
     expect(insertOne).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -498,10 +498,10 @@ describe("MCP server per-resource RBAC", () => {
         personalOwnerAccess: true,
         nextSharedTeamSlugs: [],
       },
-      {
+      expect.objectContaining({
         caller: { type: "user", id: "alice-sub" },
         source: "mcp_server_create",
-      },
+      }),
     );
     expect(insertOne).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -607,10 +607,10 @@ describe("MCP server per-resource RBAC", () => {
         personalOwnerAccess: false,
         nextSharedTeamSlugs: [],
       },
-      {
+      expect.objectContaining({
         caller: { type: "user", id: "alice-sub" },
         source: "mcp_server_create",
-      },
+      }),
     );
     expect(insertOne).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -645,6 +645,54 @@ describe("MCP server per-resource RBAC", () => {
       expect.objectContaining({ sub: "alice-sub", role: "user" }),
       { type: "mcp_server", id: "mcp-visible", action: "manage" },
     );
+  });
+
+  it("converts a team MCP server to private when owner_team_slug is explicitly null", async () => {
+    const server = {
+      _id: "mcp-visible",
+      name: "Visible",
+      transport: "http",
+      endpoint: "https://mcp.example.test/mcp",
+      config_driven: false,
+      visibility: "team" as const,
+      owner_team_slug: "primary",
+      creator_subject: "alice-sub",
+      shared_with_teams: [],
+    };
+    const findOneAndUpdate = jest.fn().mockResolvedValue({
+      ...server,
+      visibility: "private",
+      owner_subject: "alice-sub",
+    });
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue(server),
+      findOneAndUpdate,
+    });
+    const { PUT } = await import("../mcp-servers/route");
+
+    const response = await PUT(request("/api/mcp-servers?id=mcp-visible", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ visibility: "private", owner_team_slug: null }),
+    }));
+
+    expect(response.status).toBe(200);
+    const pendingUpdate = findOneAndUpdate.mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+      $unset: Record<string, unknown>;
+    };
+    expect(pendingUpdate.$set).not.toHaveProperty("owner_team_slug");
+    expect(pendingUpdate.$unset).toMatchObject({ owner_team_slug: "" });
+    expect(pendingUpdate.$set).toMatchObject({
+      authz_revision: 1,
+      authz_sync_state: "pending",
+    });
+    expect(findOneAndUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockReconcileMcpServerRelationships.mock.invocationCallOrder[0],
+    );
+    expect(findOneAndUpdate.mock.calls[1][1]).toMatchObject({
+      $set: { authz_last_synced_revision: 1, authz_sync_state: "ready" },
+    });
   });
 
   it("keeps a global MCP server global on an unrelated update", async () => {

--- a/ui/src/app/api/__tests__/task-workflow-rbac.test.ts
+++ b/ui/src/app/api/__tests__/task-workflow-rbac.test.ts
@@ -29,18 +29,25 @@ jest.mock("@/lib/api-middleware", () => {
   return {
     ApiError,
     getUserTeamIds: (...args: unknown[]) => mockGetUserTeamIds(...args),
-    requireRbacPermission: (...args: unknown[]) => mockRequireRbacPermission(...args),
-    successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
-    withAuth: async (_request: NextRequest, handler: (...args: unknown[]) => Promise<Response>) =>
-      handler(_request, user, session),
+    requireRbacPermission: (...args: unknown[]) =>
+      mockRequireRbacPermission(...args),
+    successResponse: (data: unknown, status = 200) =>
+      Response.json({ success: true, data }, { status }),
+    withAuth: async (
+      _request: NextRequest,
+      handler: (...args: unknown[]) => Promise<Response>,
+    ) => handler(_request, user, session),
     withErrorHandler:
-      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      <T>(handler: (request: NextRequest) => Promise<T>) =>
       async (request: NextRequest) => {
         try {
           return await handler(request);
         } catch (error) {
           return Response.json(
-            { success: false, error: error instanceof Error ? error.message : "error" },
+            {
+              success: false,
+              error: error instanceof Error ? error.message : "error",
+            },
             { status: (error as { statusCode?: number }).statusCode ?? 500 },
           );
         }
@@ -49,8 +56,10 @@ jest.mock("@/lib/api-middleware", () => {
 });
 
 jest.mock("@/lib/rbac/resource-authz", () => ({
-  filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
-  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  filterResourcesByPermission: (...args: unknown[]) =>
+    mockFilterResourcesByPermission(...args),
+  requireResourcePermission: (...args: unknown[]) =>
+    mockRequireResourcePermission(...args),
   subjectFromSession: () => "alice-sub",
 }));
 
@@ -63,11 +72,15 @@ jest.mock("@/lib/server/workflow-cas-authz", () => ({
   workflowAccessAllowed: jest.fn().mockResolvedValue(false),
   requireWorkflowAccess: jest.fn(),
   requireWorkflowRunAccess: jest.fn(),
-  workflowSubjectFromSession: jest.fn(() => ({ type: "user", id: "alice-sub" })),
+  workflowSubjectFromSession: jest.fn(() => ({
+    type: "user",
+    id: "alice-sub",
+  })),
 }));
 
-const mockFilterAccessibleWorkflowConfigs = jest.requireMock("@/lib/server/workflow-cas-authz")
-  .filterAccessibleWorkflowConfigs as jest.Mock;
+const mockFilterAccessibleWorkflowConfigs = jest.requireMock(
+  "@/lib/server/workflow-cas-authz",
+).filterAccessibleWorkflowConfigs as jest.Mock;
 
 function request(path: string): NextRequest {
   return new NextRequest(new URL(path, "http://localhost:3000"));
@@ -79,17 +92,33 @@ describe("workflow config RBAC cutover", () => {
     mockGetUserTeamIds.mockResolvedValue(["legacy-team"]);
     mockRequireRbacPermission.mockRejectedValue(new Error("not admin"));
     mockRequireResourcePermission.mockResolvedValue(undefined);
-    mockFilterResourcesByPermission.mockImplementation(async (_session, items) => items);
-    mockFilterAccessibleWorkflowConfigs.mockImplementation(async (_session, items) => items);
+    mockFilterResourcesByPermission.mockImplementation(
+      async (_session, items) => items,
+    );
+    mockFilterAccessibleWorkflowConfigs.mockImplementation(
+      async (_session, items) => items,
+    );
   });
 
-  it("loads workflow configs through OpenFGA task discover instead of legacy team visibility", async () => {
+  it("hides another user's private workflow before OpenFGA discovery", async () => {
     const configs = [
-      { _id: "wf-openfga", name: "OpenFGA Workflow", visibility: "private", owner_id: "bob@example.com" },
-      { _id: "wf-global", name: "Global Workflow", visibility: "global", owner_id: "system" },
+      {
+        _id: "wf-openfga",
+        name: "OpenFGA Workflow",
+        visibility: "private",
+        owner_id: "bob@example.com",
+      },
+      {
+        _id: "wf-global",
+        name: "Global Workflow",
+        visibility: "global",
+        owner_id: "system",
+      },
     ];
-    mockFilterAccessibleWorkflowConfigs.mockResolvedValue([configs[0]]);
-    const sort = jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue(configs) });
+    mockFilterAccessibleWorkflowConfigs.mockResolvedValue([configs[1]]);
+    const sort = jest
+      .fn()
+      .mockReturnValue({ toArray: jest.fn().mockResolvedValue(configs) });
     const find = jest.fn().mockReturnValue({ sort });
     const teamsCollection = {
       find: jest.fn().mockReturnValue({
@@ -111,16 +140,13 @@ describe("workflow config RBAC cutover", () => {
     expect(find).toHaveBeenCalledWith({});
     expect(mockFilterAccessibleWorkflowConfigs).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
-      configs,
+      [configs[1]],
       expect.any(Function),
       "read",
     );
     expect(body).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({ _id: "wf-openfga" }),
-        expect.objectContaining({ _id: "wf-global" }),
-      ]),
+      expect.arrayContaining([expect.objectContaining({ _id: "wf-global" })]),
     );
-    expect(body).toHaveLength(2);
+    expect(body).toHaveLength(1);
   });
 });

--- a/ui/src/app/api/dynamic-agents/__tests__/route-org-admin-authz.test.ts
+++ b/ui/src/app/api/dynamic-agents/__tests__/route-org-admin-authz.test.ts
@@ -27,15 +27,26 @@ jest.mock("@/lib/api-middleware", () => {
 
   return {
     ApiError,
-    getAuthFromBearerOrSession: (...args: unknown[]) => mockGetAuthFromBearerOrSession(...args),
+    getAuthFromBearerOrSession: (...args: unknown[]) =>
+      mockGetAuthFromBearerOrSession(...args),
     getPaginationParams: () => ({ page: 1, pageSize: 20, skip: 0 }),
     getUserTeamIds: jest.fn().mockResolvedValue([]),
-    paginatedResponse: (items: unknown[], total: number, page: number, pageSize: number) =>
-      Response.json({ success: true, data: items, pagination: { total, page, pageSize } }),
+    paginatedResponse: (
+      items: unknown[],
+      total: number,
+      page: number,
+      pageSize: number,
+    ) =>
+      Response.json({
+        success: true,
+        data: items,
+        pagination: { total, page, pageSize },
+      }),
     requireRbacPermission: jest.fn().mockResolvedValue(undefined),
-    successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
+    successResponse: (data: unknown, status = 200) =>
+      Response.json({ success: true, data }, { status }),
     withErrorHandler:
-      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      <T>(handler: (request: NextRequest) => Promise<T>) =>
       async (request: NextRequest) => {
         try {
           return await handler(request);
@@ -58,7 +69,10 @@ jest.mock("@/lib/mongodb", () => ({
 }));
 
 jest.mock("@/lib/rbac/openfga", () => {
-  const actual = jest.requireActual<typeof import("@/lib/rbac/openfga")>("@/lib/rbac/openfga");
+  const actual =
+    jest.requireActual<typeof import("@/lib/rbac/openfga")>(
+      "@/lib/rbac/openfga",
+    );
   return {
     ...actual,
     checkOpenFgaTuple: (...args: unknown[]) => mockCheckOpenFgaTuple(...args),
@@ -66,7 +80,9 @@ jest.mock("@/lib/rbac/openfga", () => {
 });
 
 jest.mock("@/lib/rbac/resource-authz", () => {
-  const actual = jest.requireActual<typeof import("@/lib/rbac/resource-authz")>("@/lib/rbac/resource-authz");
+  const actual = jest.requireActual<typeof import("@/lib/rbac/resource-authz")>(
+    "@/lib/rbac/resource-authz",
+  );
   return {
     ...actual,
     requireAgentPermission: async (
@@ -81,7 +97,9 @@ jest.mock("@/lib/rbac/resource-authz", () => {
         object: `agent:${agentId}`,
       });
       if (!result.allowed) {
-        const error = new Error("You do not have permission to access this resource.") as Error & {
+        const error = new Error(
+          "You do not have permission to access this resource.",
+        ) as Error & {
           statusCode: number;
           code: string;
         };
@@ -94,9 +112,11 @@ jest.mock("@/lib/rbac/resource-authz", () => {
 });
 
 jest.mock("@/lib/rbac/openfga-agent-tools", () => ({
-  allowedToolsFromAgent: (agent: { allowed_tools?: Record<string, string[]> }) =>
-    agent.allowed_tools ?? {},
-  reconcileAgentRelationships: (...args: unknown[]) => mockReconcileAgentRelationships(...args),
+  allowedToolsFromAgent: (agent: {
+    allowed_tools?: Record<string, string[]>;
+  }) => agent.allowed_tools ?? {},
+  reconcileAgentRelationships: (...args: unknown[]) =>
+    mockReconcileAgentRelationships(...args),
 }));
 
 jest.mock("@/lib/rbac/shareable-resource", () => ({
@@ -111,10 +131,12 @@ jest.mock("@/lib/rbac/shareable-resource", () => ({
 jest.mock("@/lib/rbac/agent-mcp-dependency-scope", () => ({
   validatePersistedAgentMcpDependencies: (...args: unknown[]) =>
     mockValidatePersistedAgentMcpDependencies(...args),
+  validatePersistedAgentResourceDependencies: jest.fn(),
 }));
 
 jest.mock("@/lib/rbac/platform-default", () => ({
-  isPlatformDefaultAgent: (...args: unknown[]) => mockIsPlatformDefaultAgent(...args),
+  isPlatformDefaultAgent: (...args: unknown[]) =>
+    mockIsPlatformDefaultAgent(...args),
 }));
 
 function request(path: string, init?: RequestInit): NextRequest {
@@ -125,16 +147,17 @@ const orgAdminSession = { sub: "admin-sub", role: "admin" };
 const memberSession = { sub: "alice-sub", role: "user" };
 
 function mockOpenFgaAgentWrite(allowAgentWrite: boolean) {
-  mockCheckOpenFgaTuple.mockImplementation(async (tuple: {
-    user: string;
-    relation: string;
-    object: string;
-  }) => {
-    if (tuple.object === "agent:hello-world" && tuple.relation === "can_write") {
-      return { allowed: allowAgentWrite };
-    }
-    return { allowed: false };
-  });
+  mockCheckOpenFgaTuple.mockImplementation(
+    async (tuple: { user: string; relation: string; object: string }) => {
+      if (
+        tuple.object === "agent:hello-world" &&
+        tuple.relation === "can_write"
+      ) {
+        return { allowed: allowAgentWrite };
+      }
+      return { allowed: false };
+    },
+  );
 }
 
 describe("dynamic-agents PUT with real requireAgentPermission", () => {
@@ -147,7 +170,9 @@ describe("dynamic-agents PUT with real requireAgentPermission", () => {
   });
 
   it("allows org admins to update a team agent through its per-agent manager grant", async () => {
-    mockGetAuthFromBearerOrSession.mockResolvedValue({ session: orgAdminSession });
+    mockGetAuthFromBearerOrSession.mockResolvedValue({
+      session: orgAdminSession,
+    });
     mockOpenFgaAgentWrite(true);
 
     const findOneAndUpdate = jest.fn().mockResolvedValue({
@@ -186,7 +211,9 @@ describe("dynamic-agents PUT with real requireAgentPermission", () => {
   });
 
   it("denies non-org-admins without agent write access", async () => {
-    mockGetAuthFromBearerOrSession.mockResolvedValue({ session: memberSession });
+    mockGetAuthFromBearerOrSession.mockResolvedValue({
+      session: memberSession,
+    });
     mockOpenFgaAgentWrite(false);
 
     mockGetCollection.mockResolvedValue({

--- a/ui/src/app/api/dynamic-agents/__tests__/route-org-admin-authz.test.ts
+++ b/ui/src/app/api/dynamic-agents/__tests__/route-org-admin-authz.test.ts
@@ -12,6 +12,7 @@ const mockGetCollection = jest.fn();
 const mockReconcileAgentRelationships = jest.fn();
 const mockIsPlatformDefaultAgent = jest.fn();
 const mockCheckOpenFgaTuple = jest.fn();
+const mockValidatePersistedAgentMcpDependencies = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => {
   class ApiError extends Error {
@@ -107,6 +108,11 @@ jest.mock("@/lib/rbac/shareable-resource", () => ({
   })),
 }));
 
+jest.mock("@/lib/rbac/agent-mcp-dependency-scope", () => ({
+  validatePersistedAgentMcpDependencies: (...args: unknown[]) =>
+    mockValidatePersistedAgentMcpDependencies(...args),
+}));
+
 jest.mock("@/lib/rbac/platform-default", () => ({
   isPlatformDefaultAgent: (...args: unknown[]) => mockIsPlatformDefaultAgent(...args),
 }));
@@ -137,6 +143,7 @@ describe("dynamic-agents PUT with real requireAgentPermission", () => {
     process.env.CAIPE_ORG_KEY = "caipe";
     mockReconcileAgentRelationships.mockResolvedValue(undefined);
     mockIsPlatformDefaultAgent.mockResolvedValue(false);
+    mockValidatePersistedAgentMcpDependencies.mockResolvedValue(undefined);
   });
 
   it("allows org admins to update a team agent through its per-agent manager grant", async () => {

--- a/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
+++ b/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
@@ -26,6 +26,7 @@ const mockFilterAgentsByOwnershipScopeForSession = jest.fn();
 const mockResolveUnlinkedServiceAccountSub = jest.fn();
 const mockResolveUnlinkedServiceAccountGrantState = jest.fn();
 const mockValidatePersistedAgentMcpDependencies = jest.fn();
+const mockValidatePersistedAgentResourceDependencies = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => {
   class ApiError extends Error {
@@ -116,6 +117,8 @@ jest.mock("@/lib/rbac/agent-ownership-scope", () => ({
 jest.mock("@/lib/rbac/agent-mcp-dependency-scope", () => ({
   validatePersistedAgentMcpDependencies: (...args: unknown[]) =>
     mockValidatePersistedAgentMcpDependencies(...args),
+  validatePersistedAgentResourceDependencies: (...args: unknown[]) =>
+    mockValidatePersistedAgentResourceDependencies(...args),
 }));
 
 jest.mock("@/lib/rbac/unlinked-service-account", () => ({

--- a/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
+++ b/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
@@ -1003,6 +1003,64 @@ describe("dynamic agents RBAC routes", () => {
     );
   });
 
+  it("converts a team-owned agent to private without conflicting Mongo update paths", async () => {
+    const existingAgent = {
+      _id: "agent-personal-helper",
+      name: "Personal Helper",
+      owner_team_slug: "primary",
+      owner_team_id: "primary-id",
+      owner_subject: "alice-sub",
+      shared_with_teams: [],
+      allowed_tools: {},
+      visibility: "team",
+    };
+    const findOneAndUpdate = jest.fn().mockResolvedValue({
+      ...existingAgent,
+      owner_team_slug: undefined,
+      owner_team_id: undefined,
+      visibility: "private",
+    });
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue(existingAgent),
+      findOneAndUpdate,
+    });
+    const { PUT } = await import("../route");
+
+    const response = await PUT(
+      request("/api/dynamic-agents?id=agent-personal-helper", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ visibility: "private" }),
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      { _id: "agent-personal-helper" },
+      {
+        $set: expect.objectContaining({
+          visibility: "private",
+          shared_with_teams: [],
+        }),
+        $unset: { owner_team_slug: "", owner_team_id: "" },
+      },
+      { returnDocument: "after" },
+    );
+    const mongoUpdate = findOneAndUpdate.mock.calls[0][1] as {
+      $set: Record<string, unknown>;
+    };
+    expect(mongoUpdate.$set).not.toHaveProperty("owner_team_slug");
+    expect(mongoUpdate.$set).not.toHaveProperty("owner_team_id");
+    expect(mockReconcileAgentRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "agent-personal-helper",
+        ownerTeamSlug: null,
+        previousOwnerTeamSlug: "primary",
+        personalOwnerAccess: true,
+      }),
+    );
+  });
+
   it("rejects private agent creation while the rollout flag is disabled", async () => {
     process.env.PRIVATE_RESOURCES_ENABLED = "false";
     const insertOne = jest.fn();

--- a/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
+++ b/ui/src/app/api/dynamic-agents/__tests__/route-rbac.test.ts
@@ -25,6 +25,7 @@ const mockGetPlatformDefaultAgentId = jest.fn();
 const mockFilterAgentsByOwnershipScopeForSession = jest.fn();
 const mockResolveUnlinkedServiceAccountSub = jest.fn();
 const mockResolveUnlinkedServiceAccountGrantState = jest.fn();
+const mockValidatePersistedAgentMcpDependencies = jest.fn();
 
 jest.mock("@/lib/api-middleware", () => {
   class ApiError extends Error {
@@ -112,6 +113,11 @@ jest.mock("@/lib/rbac/agent-ownership-scope", () => ({
     mockFilterAgentsByOwnershipScopeForSession(...args),
 }));
 
+jest.mock("@/lib/rbac/agent-mcp-dependency-scope", () => ({
+  validatePersistedAgentMcpDependencies: (...args: unknown[]) =>
+    mockValidatePersistedAgentMcpDependencies(...args),
+}));
+
 jest.mock("@/lib/rbac/unlinked-service-account", () => ({
   resolveUnlinkedServiceAccountSub: (...args: unknown[]) => mockResolveUnlinkedServiceAccountSub(...args),
   resolveUnlinkedServiceAccountGrantState: (...args: unknown[]) =>
@@ -148,6 +154,7 @@ describe("dynamic agents RBAC routes", () => {
     mockRequireResourcePermission.mockResolvedValue(undefined);
     mockRequireAgentPermission.mockResolvedValue(undefined);
     mockCanTransferResourceOwnership.mockResolvedValue(true);
+    mockValidatePersistedAgentMcpDependencies.mockResolvedValue(undefined);
     mockReconcileAgentRelationships.mockResolvedValue(undefined);
     mockDeleteAllAgentToolTuples.mockResolvedValue(undefined);
     mockWriteOpenFgaTuples.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
@@ -739,7 +746,7 @@ describe("dynamic agents RBAC routes", () => {
     );
     // The persisted shared_with_teams should be canonical slugs only.
     expect(findOneAndUpdate).toHaveBeenCalledWith(
-      { _id: "agent-shared-agent" },
+      expect.objectContaining({ _id: "agent-shared-agent" }),
       expect.objectContaining({
         $set: expect.objectContaining({ shared_with_teams: ["sre"] }),
       }),
@@ -1003,6 +1010,37 @@ describe("dynamic agents RBAC routes", () => {
     );
   });
 
+  it("rejects an agent before persistence when an MCP dependency has a narrower audience", async () => {
+    const insertOne = jest.fn();
+    mockValidatePersistedAgentMcpDependencies.mockRejectedValueOnce(
+      Object.assign(new Error("MCP dependency scope mismatch"), {
+        statusCode: 400,
+        code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED",
+      }),
+    );
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue(null),
+      insertOne,
+    });
+    const { POST } = await import("../route");
+
+    const response = await POST(request("/api/dynamic-agents", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        name: "Shared Helper",
+        system_prompt: "Help the team",
+        model: { id: "example-model", provider: "example-provider" },
+        visibility: "private",
+        allowed_tools: { "mcp-private": true },
+      }),
+    }));
+
+    expect(response.status).toBe(400);
+    expect(insertOne).not.toHaveBeenCalled();
+    expect(mockReconcileAgentRelationships).not.toHaveBeenCalled();
+  });
+
   it("converts a team-owned agent to private without conflicting Mongo update paths", async () => {
     const existingAgent = {
       _id: "agent-personal-helper",
@@ -1036,13 +1074,13 @@ describe("dynamic agents RBAC routes", () => {
 
     expect(response.status).toBe(200);
     expect(findOneAndUpdate).toHaveBeenCalledWith(
-      { _id: "agent-personal-helper" },
+      expect.objectContaining({ _id: "agent-personal-helper" }),
       {
         $set: expect.objectContaining({
           visibility: "private",
           shared_with_teams: [],
         }),
-        $unset: { owner_team_slug: "", owner_team_id: "" },
+        $unset: expect.objectContaining({ owner_team_slug: "", owner_team_id: "" }),
       },
       { returnDocument: "after" },
     );
@@ -1051,6 +1089,15 @@ describe("dynamic agents RBAC routes", () => {
     };
     expect(mongoUpdate.$set).not.toHaveProperty("owner_team_slug");
     expect(mongoUpdate.$set).not.toHaveProperty("owner_team_id");
+    expect(findOneAndUpdate.mock.invocationCallOrder[0]).toBeLessThan(
+      mockReconcileAgentRelationships.mock.invocationCallOrder[0],
+    );
+    expect(findOneAndUpdate.mock.calls[0][1]).toMatchObject({
+      $set: { authz_revision: 1, authz_sync_state: "pending" },
+    });
+    expect(findOneAndUpdate.mock.calls[1][1]).toMatchObject({
+      $set: { authz_last_synced_revision: 1, authz_sync_state: "ready" },
+    });
     expect(mockReconcileAgentRelationships).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "agent-personal-helper",
@@ -1059,6 +1106,42 @@ describe("dynamic agents RBAC routes", () => {
         personalOwnerAccess: true,
       }),
     );
+  });
+
+  it("keeps a failed private transition in a retriable authorization error state", async () => {
+    const existingAgent = {
+      _id: "agent-personal-helper",
+      name: "Personal Helper",
+      owner_team_slug: "primary",
+      owner_subject: "alice-sub",
+      shared_with_teams: [],
+      allowed_tools: {},
+      visibility: "team",
+    };
+    const findOneAndUpdate = jest.fn().mockResolvedValue(existingAgent);
+    mockReconcileAgentRelationships.mockRejectedValueOnce(new Error("OpenFGA unavailable"));
+    mockGetCollection.mockResolvedValue({
+      findOne: jest.fn().mockResolvedValue(existingAgent),
+      findOneAndUpdate,
+    });
+    const { PUT } = await import("../route");
+
+    const response = await PUT(request("/api/dynamic-agents?id=agent-personal-helper", {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ visibility: "private" }),
+    }));
+
+    expect(response.status).toBe(500);
+    expect(findOneAndUpdate.mock.calls[0][1]).toMatchObject({
+      $set: { authz_sync_state: "pending" },
+    });
+    expect(findOneAndUpdate.mock.calls[1][1]).toMatchObject({
+      $set: {
+        authz_sync_state: "error",
+        authz_last_error_code: "OPENFGA_RECONCILIATION_FAILED",
+      },
+    });
   });
 
   it("rejects private agent creation while the rollout flag is disabled", async () => {

--- a/ui/src/app/api/dynamic-agents/route.ts
+++ b/ui/src/app/api/dynamic-agents/route.ts
@@ -16,6 +16,13 @@ withErrorHandler,
 import { getCollection } from "@/lib/mongodb";
 import { dynamicAgentForBrowser,dynamicAgentsForBrowser } from "@/lib/dynamic-agent-response";
 import { trustedInteractionFromRequest } from "@/lib/authz/trusted-interaction";
+import {
+  authzRevisionFilter,
+  AuthzSyncSupersededError,
+  hasActiveAuthzSync,
+  nextAuthzRevision,
+  runRevisionedAuthzSync,
+} from "@/lib/authz/resource-sync";
 import { isPrivateResourcesEnabled } from "@/lib/feature-flags/private-resources";
 import {
 allowedToolsFromAgent,
@@ -26,6 +33,7 @@ import {
 filterAgentsByOwnershipScopeForSession,
 isPrivateAgentOwner,
 } from "@/lib/rbac/agent-ownership-scope";
+import { validatePersistedAgentMcpDependencies } from "@/lib/rbac/agent-mcp-dependency-scope";
 import { caipeOrgKey } from "@/lib/rbac/organization";
 import { getPlatformDefaultAgentId,isPlatformDefaultAgent } from "@/lib/rbac/platform-default";
 import {
@@ -44,11 +52,10 @@ import type {
 DynamicAgentConfig,
 DynamicAgentConfigWithPermissions,
 LegacyVisibilityType,
-MCPServerConfig,
 SubAgentRef,
 VisibilityType,
 } from "@/types/dynamic-agent";
-import { Collection,ObjectId } from "mongodb";
+import { Collection,ObjectId,type UpdateFilter } from "mongodb";
 import { NextRequest } from "next/server";
 
 const PLATFORM_DEFAULT_VISIBILITY_ERROR =
@@ -68,6 +75,45 @@ const AGENT_SORT_FIELDS = new Set<AgentSortField>([
   "grade",
   "status",
 ]);
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  const normalizedLeft = [...new Set(left)].sort();
+  const normalizedRight = [...new Set(right)].sort();
+  return normalizedLeft.length === normalizedRight.length
+    && normalizedLeft.every((value, index) => value === normalizedRight[index]);
+}
+
+function sameAllowedTools(
+  left: Record<string, string[] | boolean>,
+  right: Record<string, string[] | boolean>,
+): boolean {
+  const normalize = (value: Record<string, string[] | boolean>) => Object.fromEntries(
+    Object.entries(value)
+      .sort(([leftKey], [rightKey]) => leftKey.localeCompare(rightKey))
+      .map(([key, tools]) => [key, Array.isArray(tools) ? [...tools].sort() : tools]),
+  );
+  return JSON.stringify(normalize(left)) === JSON.stringify(normalize(right));
+}
+
+function previousAgentAuthzState(agent: DynamicAgentConfig): DynamicAgentConfig {
+  const previous = agent.authz_previous_state;
+  return previous && typeof previous === "object" && !Array.isArray(previous)
+    ? { ...agent, ...previous, authz_previous_state: undefined }
+    : agent;
+}
+
+function agentAuthzSnapshot(agent: DynamicAgentConfig): Record<string, unknown> {
+  return {
+    visibility: agent.visibility,
+    allowed_tools: agent.allowed_tools ?? {},
+    owner_subject: agent.owner_subject,
+    owner_id: agent.owner_id,
+    creator_subject: agent.creator_subject,
+    owner_team_slug: agent.owner_team_slug,
+    owner_team_id: agent.owner_team_id,
+    shared_with_teams: agent.shared_with_teams ?? [],
+  };
+}
 
 interface TeamOwnershipDoc {
   _id?: unknown;
@@ -456,27 +502,6 @@ async function validateSubagentVisibility(
   return { valid: true };
 }
 
-async function validateMcpVisibility(
-  agentVisibility: VisibilityType,
-  allowedTools: Record<string, string[] | boolean>,
-  ownerSubject: string,
-): Promise<void> {
-  const serverIds = Object.keys(allowedTools);
-  if (serverIds.length === 0) return;
-  const servers = await getCollection<MCPServerConfig>("mcp_servers");
-  const docs = await servers.find({ _id: { $in: serverIds } }).toArray();
-  for (const server of docs) {
-    if (server.visibility !== "private") continue;
-    if (agentVisibility !== "private" || server.owner_subject !== ownerSubject) {
-      throw new ApiError(
-        `Private MCP server "${server.name}" can only be attached to a private agent owned by the same user.`,
-        400,
-        "PRIVATE_DEPENDENCY_SCOPE_MISMATCH",
-      );
-    }
-  }
-}
-
 // ═══════════════════════════════════════════════════════════════
 // GET — list agents
 // ═══════════════════════════════════════════════════════════════
@@ -745,6 +770,9 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       creator_subject: ownerSubject,
       is_system: false,
       config_driven: false,
+      authz_revision: 1,
+      authz_sync_state: "ready",
+      authz_last_synced_revision: 1,
       created_at: now.toISOString(),
       updated_at: now.toISOString(),
     };
@@ -754,7 +782,16 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     const unlinkedServiceAccountSub =
       visibility === "global" ? await resolveUnlinkedServiceAccountSub() : null;
 
-    await validateMcpVisibility(visibility, doc.allowed_tools, ownerSubject);
+    await validatePersistedAgentMcpDependencies({
+      session,
+      agent: {
+        visibility,
+        ownerSubject,
+        ownerTeamSlug,
+        sharedTeamSlugs,
+      },
+      allowedTools: doc.allowed_tools,
+    });
 
     await reconcileAgentRelationships({
       agentId,
@@ -775,6 +812,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       // Also grant the unlinked SA `can_use` so callers with no linked user
       // identity (Slack/Webex bots) are treated as "everyone" too.
       unlinkedServiceAccountSub,
+      verifyHigherConsistency: true,
     });
 
     try {
@@ -818,6 +856,14 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     }
     requirePrivateAgentOwner(agent, session);
     await requireAgentWritePermission(session, id);
+    if (hasActiveAuthzSync(agent)) {
+      throw new ApiError(
+        "This agent's authorization is already being reconciled. Retry shortly.",
+        409,
+        "AUTHZ_SYNC_PENDING",
+      );
+    }
+    const previousAuthzState = previousAgentAuthzState(agent);
 
     // Config-driven guard
     if (agent.config_driven) {
@@ -895,8 +941,8 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     // caller did not include `shared_with_teams` in the patch, keep the
     // existing value unchanged (do NOT clear it — that would silently
     // revoke team grants on every metadata-only update).
-    const previousSharedRaw = Array.isArray(agent.shared_with_teams)
-      ? (agent.shared_with_teams as string[])
+    const previousSharedRaw = Array.isArray(previousAuthzState.shared_with_teams)
+      ? (previousAuthzState.shared_with_teams as string[])
       : [];
     const { slugs: previousSharedTeamSlugs } =
       await resolveSharedTeamSlugs(previousSharedRaw);
@@ -931,6 +977,9 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     // its own org-admin/tool-caller tuples via `reconcileAgentRelationships`,
     // so we use the resolver for the decision only and apply persistence here.
     const previousOwnerTeamSlug = normalizeString(agent.owner_team_slug);
+    const previousReconciledOwnerTeamSlug = normalizeString(
+      previousAuthzState.owner_team_slug,
+    );
     const resolvedOwnership = finalVisibility === "private" ? {
       ownerTeamSlug: null,
       sharedTeamSlugs: [],
@@ -962,9 +1011,6 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       },
     );
     const nextOwnerTeamSlug = resolvedOwnership.ownerTeamSlug;
-    const transferPreviousOwner = resolvedOwnership.transferred
-      ? resolvedOwnership.previousOwnerTeamSlug ?? undefined
-      : undefined;
     if (resolvedOwnership.transferred) {
       if (nextOwnerTeamSlug) {
         const destinationTeam = await loadOwnerTeam({ slug: nextOwnerTeamSlug });
@@ -983,8 +1029,17 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
 
     const finalAllowedTools = (updateData.allowed_tools ??
       agent.allowed_tools ??
-      {}) as Record<string, string[]>;
-    await validateMcpVisibility(finalVisibility, finalAllowedTools, stableOwnerSubject);
+      {}) as Record<string, string[] | boolean>;
+    await validatePersistedAgentMcpDependencies({
+      session,
+      agent: {
+        visibility: finalVisibility,
+        ownerSubject: stableOwnerSubject,
+        ownerTeamSlug: nextOwnerTeamSlug,
+        sharedTeamSlugs,
+      },
+      allowedTools: finalAllowedTools,
+    });
     // Resolve the unlinked SA grant state whenever the wildcard grant is being
     // written OR revoked — the delete path needs the exact sub too, so we
     // can't skip resolution just because the agent is being demoted.
@@ -993,20 +1048,23 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     // override, so the unlinked SA keeps `can_use` on an agent it was
     // explicitly granted.
     const { sub: unlinkedServiceAccountSub, explicitAgentIds } =
-      finalVisibility === "global" || currentVisibility === "global"
+      finalVisibility === "global" || previousAuthzState.visibility === "global"
         ? await resolveUnlinkedServiceAccountGrantState()
         : { sub: null, explicitAgentIds: new Set<string>() };
-    await reconcileAgentRelationships({
+    const previousVisibilityForReconcile = previousAuthzState.visibility;
+    const reconcile = (verifyHigherConsistency: boolean) => reconcileAgentRelationships({
       agentId: id,
-      previousAllowedTools: allowedToolsFromAgent(agent),
+      previousAllowedTools: allowedToolsFromAgent(previousAuthzState),
       nextAllowedTools: finalAllowedTools,
       ownerSubject: agent.owner_subject ?? agent.owner_id,
       creatorSubject: stableCreatorSubject,
       personalOwnerAccess: finalVisibility === "private",
-      previousPersonalOwnerAccess: currentVisibility === "private",
+      previousPersonalOwnerAccess: previousVisibilityForReconcile === "private",
       organizationId: caipeOrgKey(),
       ownerTeamSlug: nextOwnerTeamSlug,
-      previousOwnerTeamSlug: transferPreviousOwner,
+      previousOwnerTeamSlug: previousReconciledOwnerTeamSlug !== nextOwnerTeamSlug
+        ? previousReconciledOwnerTeamSlug
+        : undefined,
       nextSharedTeamSlugs: sharedTeamSlugs,
       previousSharedTeamSlugs,
       // Keep the wildcard `user:* user agent:<id>` grant in sync with
@@ -1015,21 +1073,100 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       // so non-owner-team members keep `can_use` (the SRE-agent leak).
       // Only an exact 'global' match counts as a previous wildcard grant.
       globalUserAccess: finalVisibility === "global",
-      previousGlobalUserAccess: currentVisibility === "global",
+      previousGlobalUserAccess: previousVisibilityForReconcile === "global",
       // Keep the unlinked SA's grant in sync with the same promote/demote
       // transition so callers with no linked user identity gain/lose
       // access exactly when "everyone" does.
       unlinkedServiceAccountSub,
       unlinkedGrantIsExplicit: explicitAgentIds.has(id),
+      verifyHigherConsistency,
     });
 
-    const updated = await collection.findOneAndUpdate(
-      { _id: id },
-      finalVisibility === "private"
-        ? { $set: { ...updateData, shared_with_teams: [] }, $unset: { owner_team_slug: "", owner_team_id: "" } }
-        : { $set: updateData },
-      { returnDocument: "after" },
-    );
+    const mongoSet = finalVisibility === "private"
+      ? { ...updateData, shared_with_teams: [] }
+      : updateData;
+    const mongoUnset: Record<string, ""> | undefined = finalVisibility === "private"
+      ? { owner_team_slug: "", owner_team_id: "" }
+      : undefined;
+    const mongoUpdate: UpdateFilter<DynamicAgentConfig> = mongoUnset
+      ? { $set: mongoSet, $unset: mongoUnset }
+      : { $set: mongoSet };
+    const authzMutationRequired = agent.authz_sync_state === "pending"
+      || agent.authz_sync_state === "error"
+      || finalVisibility !== currentVisibility
+      || previousOwnerTeamSlug !== nextOwnerTeamSlug
+      || !sameStringSet(previousSharedTeamSlugs, sharedTeamSlugs)
+      || !sameAllowedTools(allowedToolsFromAgent(agent), finalAllowedTools);
+
+    let updated: DynamicAgentConfig | null;
+    if (!authzMutationRequired) {
+      await reconcile(false);
+      updated = await collection.findOneAndUpdate(
+        { _id: id },
+        mongoUpdate,
+        { returnDocument: "after" },
+      );
+    } else {
+      const revision = nextAuthzRevision(agent);
+      const pending = await collection.findOneAndUpdate(
+        { _id: id, ...authzRevisionFilter(agent) },
+        {
+          $set: {
+            ...mongoSet,
+            authz_revision: revision,
+            authz_sync_state: "pending",
+            authz_sync_started_at: new Date().toISOString(),
+            authz_previous_state: agent.authz_previous_state ?? agentAuthzSnapshot(agent),
+          },
+          ...(mongoUnset
+            ? { $unset: { ...mongoUnset, authz_last_error_code: "" } }
+            : { $unset: { authz_last_error_code: "" } }),
+        },
+        { returnDocument: "after" },
+      );
+      if (!pending) {
+        throw new ApiError(
+          "This agent changed while authorization was being prepared. Retry the save.",
+          409,
+          "AUTHZ_SYNC_SUPERSEDED",
+        );
+      }
+
+      try {
+        updated = await runRevisionedAuthzSync({
+          reconcile: async () => { await reconcile(true); },
+          markError: async (errorCode) => {
+            await collection.findOneAndUpdate(
+              { _id: id, authz_revision: revision, authz_sync_state: "pending" },
+              {
+                $set: { authz_sync_state: "error", authz_last_error_code: errorCode },
+                $unset: { authz_sync_started_at: "" },
+              },
+            );
+          },
+          markReady: () => collection.findOneAndUpdate(
+            { _id: id, authz_revision: revision, authz_sync_state: "pending" },
+            {
+              $set: {
+                authz_sync_state: "ready",
+                authz_last_synced_revision: revision,
+              },
+              $unset: {
+                authz_last_error_code: "",
+                authz_previous_state: "",
+                authz_sync_started_at: "",
+              },
+            },
+            { returnDocument: "after" },
+          ),
+        });
+      } catch (error) {
+        if (error instanceof AuthzSyncSupersededError) {
+          throw new ApiError(error.message, 409, "AUTHZ_SYNC_SUPERSEDED");
+        }
+        throw error;
+      }
+    }
 
     if (!updated) {
       throw new ApiError("Failed to update agent", 500);

--- a/ui/src/app/api/dynamic-agents/route.ts
+++ b/ui/src/app/api/dynamic-agents/route.ts
@@ -33,7 +33,10 @@ import {
 filterAgentsByOwnershipScopeForSession,
 isPrivateAgentOwner,
 } from "@/lib/rbac/agent-ownership-scope";
-import { validatePersistedAgentMcpDependencies } from "@/lib/rbac/agent-mcp-dependency-scope";
+import {
+validatePersistedAgentMcpDependencies,
+validatePersistedAgentResourceDependencies,
+} from "@/lib/rbac/agent-mcp-dependency-scope";
 import { caipeOrgKey } from "@/lib/rbac/organization";
 import { getPlatformDefaultAgentId,isPlatformDefaultAgent } from "@/lib/rbac/platform-default";
 import {
@@ -787,10 +790,23 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       agent: {
         visibility,
         ownerSubject,
+        ownerEmail: user.email,
         ownerTeamSlug,
         sharedTeamSlugs,
       },
       allowedTools: doc.allowed_tools,
+    });
+    await validatePersistedAgentResourceDependencies({
+      session,
+      agent: {
+        visibility,
+        ownerSubject,
+        ownerEmail: user.email,
+        ownerTeamSlug,
+        sharedTeamSlugs,
+      },
+      skillIds: doc.skills ?? [],
+      workflowIds: doc.builtin_tools?.workflows ?? [],
     });
 
     await reconcileAgentRelationships({
@@ -1035,10 +1051,26 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       agent: {
         visibility: finalVisibility,
         ownerSubject: stableOwnerSubject,
+        ownerEmail: agent.owner_id,
         ownerTeamSlug: nextOwnerTeamSlug,
         sharedTeamSlugs,
       },
       allowedTools: finalAllowedTools,
+    });
+    const finalSkills = (updateData.skills ?? agent.skills ?? []) as string[];
+    const finalBuiltinTools = (updateData.builtin_tools ??
+      agent.builtin_tools) as DynamicAgentConfig["builtin_tools"] | undefined;
+    await validatePersistedAgentResourceDependencies({
+      session,
+      agent: {
+        visibility: finalVisibility,
+        ownerSubject: stableOwnerSubject,
+        ownerEmail: agent.owner_id,
+        ownerTeamSlug: nextOwnerTeamSlug,
+        sharedTeamSlugs,
+      },
+      skillIds: finalSkills,
+      workflowIds: finalBuiltinTools?.workflows ?? [],
     });
     // Resolve the unlinked SA grant state whenever the wildcard grant is being
     // written OR revoked — the delete path needs the exact sub too, so we

--- a/ui/src/app/api/dynamic-agents/route.ts
+++ b/ui/src/app/api/dynamic-agents/route.ts
@@ -973,6 +973,11 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
         }
         updateData.owner_team_slug = nextOwnerTeamSlug;
         updateData.owner_team_id = teamIdString(destinationTeam) ?? undefined;
+      } else {
+        // Private ownership is represented by the absence of team-owner fields.
+        // Keep these paths out of $set because the private update unsets them.
+        delete updateData.owner_team_slug;
+        delete updateData.owner_team_id;
       }
     }
 

--- a/ui/src/app/api/mcp-servers/route.ts
+++ b/ui/src/app/api/mcp-servers/route.ts
@@ -15,6 +15,13 @@ withErrorHandler,
 import { getCollection } from "@/lib/mongodb";
 import { CREDENTIAL_COLLECTIONS } from "@/lib/credentials/collections";
 import { trustedInteractionFromRequest } from "@/lib/authz/trusted-interaction";
+import {
+  authzRevisionFilter,
+  AuthzSyncSupersededError,
+  hasActiveAuthzSync,
+  nextAuthzRevision,
+  runRevisionedAuthzSync,
+} from "@/lib/authz/resource-sync";
 import { isPrivateResourcesEnabled } from "@/lib/feature-flags/private-resources";
 import { agentGatewayMcpEndpointUrl } from "@/lib/rbac/agentgateway-mcp-discovery";
 import {
@@ -40,6 +47,7 @@ MCPServerConfigWithPermissions,
 TransportType,
 } from "@/types/dynamic-agent";
 import { NextRequest, NextResponse } from "next/server";
+import type { UpdateFilter } from "mongodb";
 
 const COLLECTION_NAME = "mcp_servers";
 
@@ -52,6 +60,31 @@ const MCP_SERVER_SORT_FIELDS = new Set<McpServerSortField>([
   "endpoint",
   "status",
 ]);
+
+function sameStringSet(left: readonly string[], right: readonly string[]): boolean {
+  const normalizedLeft = [...new Set(left)].sort();
+  const normalizedRight = [...new Set(right)].sort();
+  return normalizedLeft.length === normalizedRight.length
+    && normalizedLeft.every((value, index) => value === normalizedRight[index]);
+}
+
+function previousMcpAuthzState(server: MCPServerConfig): MCPServerConfig {
+  const previous = server.authz_previous_state;
+  return previous && typeof previous === "object" && !Array.isArray(previous)
+    ? { ...server, ...previous, authz_previous_state: undefined }
+    : server;
+}
+
+function mcpAuthzSnapshot(server: MCPServerConfig): Record<string, unknown> {
+  return {
+    visibility: normalizedMcpServerVisibility(server),
+    owner_subject: server.owner_subject,
+    owner_subject_kind: server.owner_subject_kind,
+    creator_subject: server.creator_subject,
+    owner_team_slug: server.owner_team_slug,
+    shared_with_teams: server.shared_with_teams ?? [],
+  };
+}
 
 // ═══════════════════════════════════════════════════════════════
 // Helpers
@@ -610,6 +643,9 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       shared_with_teams: sharedTeamSlugs,
       // Server-controlled — never from request body
       config_driven: false,
+      authz_revision: 1,
+      authz_sync_state: "ready",
+      authz_last_synced_revision: 1,
       created_at: now.toISOString(),
       updated_at: now.toISOString(),
     };
@@ -628,10 +664,22 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       {
         caller: { type: ownerSubjectKind, id: ownerSubject },
         source: "mcp_server_create",
+        verifyHigherConsistency: true,
       },
     );
 
-    await collection.insertOne(doc);
+    try {
+      await collection.insertOne(doc);
+    } catch (error) {
+      await deleteAllMcpServerRelationshipTuples(serverId, {
+        caller: { type: ownerSubjectKind, id: ownerSubject },
+        source: "mcp_server_create_rollback",
+        verifyHigherConsistency: true,
+      }).catch((cleanupError) => {
+        console.warn("[mcp-servers] failed to clean up OpenFGA tuples after create failure", cleanupError);
+      });
+      throw error;
+    }
 
     return successResponse(doc, 201);
 });
@@ -669,6 +717,14 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       action: "manage" as const,
     };
     await requireResourcePermission(session, updateTarget);
+    if (hasActiveAuthzSync(server)) {
+      throw new ApiError(
+        "This MCP server's authorization is already being reconciled. Retry shortly.",
+        409,
+        "AUTHZ_SYNC_PENDING",
+      );
+    }
+    const previousAuthzState = previousMcpAuthzState(server);
 
     // Config-driven guard
     if (isLockedConfigDrivenServer(server)) {
@@ -726,6 +782,11 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     for (const slug of nextSharedTeamSlugs) await requireOwnerTeamMembership(session, slug);
     updateData.visibility = nextVisibility;
     updateData.shared_with_teams = nextSharedTeamSlugs;
+    if (nextVisibility !== "team") {
+      // Never target the same ownership path from both MongoDB operators.
+      // JSON clients may explicitly send null even though the UI omits it.
+      delete updateData.owner_team_slug;
+    }
     const nextTransport = (updateData.transport as TransportType | undefined) ?? server.transport;
     if (isNetworkTransport(nextTransport)) {
       const gatewayManaged = await normalizeNetworkServerForAgentGateway({
@@ -754,65 +815,140 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     updateData.updated_at = new Date().toISOString();
 
     const ownerSubject = requireStableSubject(session);
-    const storedOwnerSubject = server.owner_subject ?? ownerSubject;
+    const storedOwnerSubject = server.owner_subject
+      ?? previousAuthzState.owner_subject
+      ?? ownerSubject;
     const storedOwnerSubjectKind = server.owner_subject_kind
-      ?? (server.owner_subject === ownerSubject && session.isServiceAccount === true
+      ?? previousAuthzState.owner_subject_kind
+      ?? (storedOwnerSubject === ownerSubject && session.isServiceAccount === true
         ? "service_account"
         : "user");
-    const previousPersonalOwnerAccess = previousVisibility === "private"
-      || (server.visibility === undefined && Boolean(server.owner_subject));
+    const previousVisibilityForReconcile = normalizedMcpServerVisibility(previousAuthzState);
+    const previousPersonalOwnerAccess = previousVisibilityForReconcile === "private"
+      || (previousAuthzState.visibility === undefined && Boolean(previousAuthzState.owner_subject));
     await validateCredentialScopes({
       visibility: nextVisibility,
       ownerSubject: nextVisibility === "private" ? ownerSubject : storedOwnerSubject,
       credentialSources: (updateData.credential_sources ?? server.credential_sources) as MCPCredentialSource[] | undefined,
     });
-    await reconcileMcpServerRelationships(
+    const reconcile = (verifyHigherConsistency: boolean) => reconcileMcpServerRelationships(
       {
         serverId: id,
         ownerSubject: nextVisibility === "private"
           ? ownerSubject
-          : previousPersonalOwnerAccess ? storedOwnerSubject : null,
+          : previousPersonalOwnerAccess
+            ? previousAuthzState.owner_subject ?? storedOwnerSubject
+            : null,
         ownerSubjectKind: nextVisibility === "private" ? "user" : storedOwnerSubjectKind,
         ownerTeamSlug: nextOwnerTeamSlug,
-        previousOwnerTeamSlug: server.owner_team_slug,
+        previousOwnerTeamSlug: previousAuthzState.owner_team_slug,
         creatorSubject: server.creator_subject
           ?? (storedOwnerSubjectKind === "user" ? storedOwnerSubject : null),
         personalOwnerAccess: nextVisibility === "private",
         previousPersonalOwnerAccess,
         nextSharedTeamSlugs,
-        previousSharedTeamSlugs: server.shared_with_teams ?? [],
+        previousSharedTeamSlugs: previousAuthzState.shared_with_teams ?? [],
         globalOrganizationAccess: nextVisibility === "global",
-        previousGlobalOrganizationAccess: previousVisibility === "global",
+        previousGlobalOrganizationAccess: previousVisibilityForReconcile === "global",
       },
       {
         caller: { type: session.isServiceAccount === true ? "service_account" : "user", id: ownerSubject },
         source: "mcp_server_update",
+        verifyHigherConsistency,
       },
     );
 
-    const updated = await collection.findOneAndUpdate(
-      { _id: id },
-      nextVisibility === "private"
-        ? {
-            $set: {
-              ...updateData,
-              owner_subject: ownerSubject,
-              owner_subject_kind: "user",
-              shared_with_teams: [],
-            },
-            $unset: { owner_team_slug: "" },
-          }
-        : nextVisibility === "team"
-          ? {
-            $set: { ...updateData, owner_team_slug: nextOwnerTeamSlug },
-            $unset: { owner_subject: "", owner_subject_kind: "" },
-          }
-          : {
-            $set: { ...updateData, visibility: "global", shared_with_teams: [] },
-            $unset: { owner_subject: "", owner_subject_kind: "", owner_team_slug: "" },
+    const mongoSet = nextVisibility === "private"
+      ? {
+          ...updateData,
+          owner_subject: ownerSubject,
+          owner_subject_kind: "user" as const,
+          shared_with_teams: [],
+        }
+      : nextVisibility === "team"
+        ? { ...updateData, owner_team_slug: nextOwnerTeamSlug }
+        : { ...updateData, visibility: "global" as const, shared_with_teams: [] };
+    const mongoUnset: Record<string, ""> = nextVisibility === "private"
+      ? { owner_team_slug: "" }
+      : nextVisibility === "team"
+        ? { owner_subject: "", owner_subject_kind: "" }
+        : { owner_subject: "", owner_subject_kind: "", owner_team_slug: "" };
+    const mongoUpdate: UpdateFilter<MCPServerConfig> = {
+      $set: mongoSet,
+      $unset: mongoUnset,
+    };
+    const authzMutationRequired = server.authz_sync_state === "pending"
+      || server.authz_sync_state === "error"
+      || nextVisibility !== previousVisibility
+      || nextOwnerTeamSlug !== normalizeString(server.owner_team_slug)
+      || !sameStringSet(server.shared_with_teams ?? [], nextSharedTeamSlugs);
+
+    let updated: MCPServerConfig | null;
+    if (!authzMutationRequired) {
+      await reconcile(false);
+      updated = await collection.findOneAndUpdate(
+        { _id: id },
+        mongoUpdate,
+        { returnDocument: "after" },
+      );
+    } else {
+      const revision = nextAuthzRevision(server);
+      const pending = await collection.findOneAndUpdate(
+        { _id: id, ...authzRevisionFilter(server) },
+        {
+          $set: {
+            ...mongoSet,
+            authz_revision: revision,
+            authz_sync_state: "pending",
+            authz_sync_started_at: new Date().toISOString(),
+            authz_previous_state: server.authz_previous_state ?? mcpAuthzSnapshot(server),
           },
-      { returnDocument: "after" },
-    );
+          $unset: { ...mongoUnset, authz_last_error_code: "" },
+        },
+        { returnDocument: "after" },
+      );
+      if (!pending) {
+        throw new ApiError(
+          "This MCP server changed while authorization was being prepared. Retry the save.",
+          409,
+          "AUTHZ_SYNC_SUPERSEDED",
+        );
+      }
+      try {
+        updated = await runRevisionedAuthzSync({
+          reconcile: async () => { await reconcile(true); },
+          markError: async (errorCode) => {
+            await collection.findOneAndUpdate(
+              { _id: id, authz_revision: revision, authz_sync_state: "pending" },
+              {
+                $set: { authz_sync_state: "error", authz_last_error_code: errorCode },
+                $unset: { authz_sync_started_at: "" },
+              },
+            );
+          },
+          markReady: () => collection.findOneAndUpdate(
+            { _id: id, authz_revision: revision, authz_sync_state: "pending" },
+            {
+              $set: {
+                authz_sync_state: "ready",
+                authz_last_synced_revision: revision,
+              },
+              $unset: {
+                authz_last_error_code: "",
+                authz_previous_state: "",
+                authz_sync_started_at: "",
+              },
+            },
+            { returnDocument: "after" },
+          ),
+        });
+      } catch (error) {
+        if (error instanceof AuthzSyncSupersededError) {
+          throw new ApiError(error.message, 409, "AUTHZ_SYNC_SUPERSEDED");
+        }
+        throw error;
+      }
+    }
 
     if (!updated) {
       throw new ApiError("Failed to update MCP server", 500);

--- a/ui/src/app/api/skills/__tests__/runnable-gate.test.ts
+++ b/ui/src/app/api/skills/__tests__/runnable-gate.test.ts
@@ -135,11 +135,17 @@ describe("filterSkillsByOpenFga", () => {
     expect(filtered.map((s) => s.id)).toEqual(["builtin-1", "my-custom-skill"]);
   });
 
-  it("does not call OpenFGA and returns all skills for admins", async () => {
+  it("does not call OpenFGA and returns non-private skills for admins", async () => {
     const check = jest.fn(async () => ({ allowed: false }));
     const skills: CatalogSkill[] = [
-      { ...baseSkill, id: "admin-visible-a" },
-      { ...baseSkill, id: "admin-visible-b" },
+      { ...baseSkill, id: "admin-visible-a", visibility: "global" },
+      { ...baseSkill, id: "admin-visible-b", visibility: "team" },
+      {
+        ...baseSkill,
+        id: "other-private",
+        visibility: "private",
+        owner_subject: "other-sub",
+      },
     ];
 
     const filtered = await filterSkillsByOpenFga(skills, {
@@ -150,6 +156,48 @@ describe("filterSkillsByOpenFga", () => {
     });
 
     expect(filtered.map((skill) => skill.id)).toEqual(["admin-visible-a", "admin-visible-b"]);
+    expect(check).not.toHaveBeenCalled();
+  });
+
+  it("returns a private skill only to its stable owner", async () => {
+    const privateSkill: CatalogSkill = {
+      ...baseSkill,
+      id: "private-owned",
+      visibility: "private",
+      owner_subject: "owner-sub",
+    };
+    const owner = await filterSkillsByOpenFga([privateSkill], {
+      subject: "user:owner-sub",
+      mode: "use",
+      check: jest.fn(),
+    });
+    const otherAdmin = await filterSkillsByOpenFga([privateSkill], {
+      subject: "user:admin-sub",
+      mode: "read",
+      isAdmin: true,
+      check: jest.fn(),
+    });
+
+    expect(owner).toEqual([privateSkill]);
+    expect(otherAdmin).toEqual([]);
+  });
+
+  it("fails closed for skills with unreconciled authorization state", async () => {
+    const check = jest.fn(async () => ({ allowed: true }));
+    const filtered = await filterSkillsByOpenFga(
+      [
+        {
+          ...baseSkill,
+          visibility: "global",
+          authz_revision: 3,
+          authz_sync_state: "ready",
+          authz_last_synced_revision: 2,
+        },
+      ],
+      { subject: "user:owner-sub", mode: "read", isAdmin: true, check },
+    );
+
+    expect(filtered).toEqual([]);
     expect(check).not.toHaveBeenCalled();
   });
 

--- a/ui/src/app/api/skills/configs/__tests__/route-rbac.test.ts
+++ b/ui/src/app/api/skills/configs/__tests__/route-rbac.test.ts
@@ -10,7 +10,9 @@ const mockFilterResourcesByPermission = jest.fn();
 const mockRequireResourcePermission = jest.fn();
 const mockGrantSkillsToTeams = jest.fn();
 const mockReconcileSkillTeamShares = jest.fn();
-const mockReadSkillSharedTeamSlugsFromOpenFga = jest.fn(async () => [] as string[]);
+const mockReadSkillSharedTeamSlugsFromOpenFga = jest.fn(
+  async () => [] as string[],
+);
 
 jest.mock("@/lib/mongodb", () => ({
   getCollection: (...args: unknown[]) => mockGetCollection(...args),
@@ -28,22 +30,32 @@ jest.mock("@/lib/api-middleware", () => {
   }
 
   const user = { email: "alice@example.com", role: "user" };
-  const session = { sub: "alice-sub", role: "user", realm_access: { roles: [] } };
+  const session = {
+    sub: "alice-sub",
+    role: "user",
+    realm_access: { roles: [] },
+  };
 
   return {
     ApiError,
     getUserTeamIds: (...args: unknown[]) => mockGetUserTeamIds(...args),
-    successResponse: (data: unknown, status = 200) => Response.json({ success: true, data }, { status }),
-    withAuth: async (_request: NextRequest, handler: (...args: unknown[]) => Promise<Response>) =>
-      handler(_request, user, session),
+    successResponse: (data: unknown, status = 200) =>
+      Response.json({ success: true, data }, { status }),
+    withAuth: async (
+      _request: NextRequest,
+      handler: (...args: unknown[]) => Promise<Response>,
+    ) => handler(_request, user, session),
     withErrorHandler:
-      <T,>(handler: (request: NextRequest) => Promise<T>) =>
+      <T>(handler: (request: NextRequest) => Promise<T>) =>
       async (request: NextRequest) => {
         try {
           return await handler(request);
         } catch (error) {
           return Response.json(
-            { success: false, error: error instanceof Error ? error.message : "error" },
+            {
+              success: false,
+              error: error instanceof Error ? error.message : "error",
+            },
             { status: (error as { statusCode?: number }).statusCode ?? 500 },
           );
         }
@@ -52,14 +64,18 @@ jest.mock("@/lib/api-middleware", () => {
 });
 
 jest.mock("@/lib/rbac/resource-authz", () => ({
-  filterResourcesByPermission: (...args: unknown[]) => mockFilterResourcesByPermission(...args),
-  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
-  requireSkillPermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  filterResourcesByPermission: (...args: unknown[]) =>
+    mockFilterResourcesByPermission(...args),
+  requireResourcePermission: (...args: unknown[]) =>
+    mockRequireResourcePermission(...args),
+  requireSkillPermission: (...args: unknown[]) =>
+    mockRequireResourcePermission(...args),
 }));
 
 jest.mock("@/lib/rbac/skill-team-grants", () => ({
   grantSkillsToTeams: (...args: unknown[]) => mockGrantSkillsToTeams(...args),
-  reconcileSkillTeamShares: (...args: unknown[]) => mockReconcileSkillTeamShares(...args),
+  reconcileSkillTeamShares: (...args: unknown[]) =>
+    mockReconcileSkillTeamShares(...args),
   readSkillSharedTeamSlugsFromOpenFga: (...args: unknown[]) =>
     mockReadSkillSharedTeamSlugsFromOpenFga(...args),
 }));
@@ -76,6 +92,10 @@ jest.mock("@/lib/agent-skill-visibility", () => ({
 
 jest.mock("@/lib/rbac/keycloak-resource-sync", () => ({
   syncSkillResource: jest.fn(),
+}));
+
+jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
+  deleteAllSkillRelationshipTuples: jest.fn(),
 }));
 
 jest.mock("@/lib/rbac/task-skill-realm-access", () => ({
@@ -105,19 +125,37 @@ describe("GET /api/skills/configs RBAC cutover", () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetUserTeamIds.mockResolvedValue(["legacy-team"]);
-    mockFilterResourcesByPermission.mockImplementation(async (_session, items) => items);
+    mockFilterResourcesByPermission.mockImplementation(
+      async (_session, items) => items,
+    );
     mockRequireResourcePermission.mockResolvedValue(undefined);
-    mockGrantSkillsToTeams.mockResolvedValue({ enabled: true, writesApplied: 1 });
-    mockReconcileSkillTeamShares.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
+    mockGrantSkillsToTeams.mockResolvedValue({
+      enabled: true,
+      writesApplied: 1,
+    });
+    mockReconcileSkillTeamShares.mockResolvedValue({
+      enabled: true,
+      writes: 1,
+      deletes: 0,
+    });
   });
 
-  it("lists skills by OpenFGA discover instead of prefiltering by legacy visibility fields", async () => {
+  it("hides another user's private skill before OpenFGA discovery", async () => {
     const skills = [
-      { id: "skill-a", name: "Allowed", visibility: "private", owner_id: "bob@example.com" },
+      {
+        id: "skill-a",
+        name: "Allowed",
+        visibility: "private",
+        owner_id: "bob@example.com",
+      },
       { id: "skill-b", name: "Denied", visibility: "global" },
     ];
-    mockFilterResourcesByPermission.mockResolvedValue([skills[0]]);
-    const sort = jest.fn().mockReturnValue({ toArray: jest.fn().mockResolvedValue(skills) });
+    mockFilterResourcesByPermission.mockImplementation(
+      async (_session, items) => items,
+    );
+    const sort = jest
+      .fn()
+      .mockReturnValue({ toArray: jest.fn().mockResolvedValue(skills) });
     const find = jest.fn().mockReturnValue({ sort });
     mockGetCollection.mockResolvedValue({ find });
     const { GET } = await import("../route");
@@ -130,13 +168,13 @@ describe("GET /api/skills/configs RBAC cutover", () => {
     expect(find).toHaveBeenCalledWith({});
     expect(mockFilterResourcesByPermission).toHaveBeenCalledWith(
       expect.objectContaining({ sub: "alice-sub" }),
-      skills,
+      [skills[1]],
       { type: "skill", action: "discover", id: expect.any(Function) },
     );
-    expect(body).toEqual([expect.objectContaining({ id: "skill-a" })]);
+    expect(body).toEqual([expect.objectContaining({ id: "skill-b" })]);
   });
 
-  it("loads a single skill by id and lets OpenFGA decide read access", async () => {
+  it("does not reveal another user's private skill by id", async () => {
     const skill = {
       id: "skill-openfga-only",
       name: "OpenFGA Only",
@@ -149,43 +187,56 @@ describe("GET /api/skills/configs RBAC cutover", () => {
     mockGetCollection.mockResolvedValue({ findOne });
     const { GET } = await import("../route");
 
-    const response = await GET(request("/api/skills/configs?id=skill-openfga-only"));
+    const response = await GET(
+      request("/api/skills/configs?id=skill-openfga-only"),
+    );
     const body = await response.json();
 
-    expect(response.status).toBe(200);
+    expect(response.status).toBe(404);
     expect(findOne).toHaveBeenCalledWith({ id: "skill-openfga-only" });
-    expect(mockRequireResourcePermission).toHaveBeenCalledWith(
-      expect.objectContaining({ sub: "alice-sub" }),
-      "skill-openfga-only",
-      "read",
-    );
-    expect(body).toMatchObject({ id: "skill-openfga-only" });
+    expect(mockRequireResourcePermission).not.toHaveBeenCalled();
+    expect(body).toMatchObject({ success: false });
   });
 
-  it("updates non-owner skills when OpenFGA grants write", async () => {
+  it("updates a shared skill when OpenFGA grants write", async () => {
     const skill = {
       id: "skill-openfga-write",
       name: "OpenFGA Write",
       description: "before",
-      visibility: "private",
+      visibility: "team",
+      shared_with_teams: ["platform"],
       owner_id: "bob@example.com",
       is_system: false,
-      tasks: [{ display_text: "Task", llm_prompt: "Do it", subagent: "skills" }],
+      tasks: [
+        { display_text: "Task", llm_prompt: "Do it", subagent: "skills" },
+      ],
     };
-    const findOne = jest
+    const ready = {
+      ...skill,
+      description: "after",
+      authz_revision: 1,
+      authz_sync_state: "ready",
+      authz_last_synced_revision: 1,
+    };
+    const findOne = jest.fn().mockResolvedValue(skill);
+    const findOneAndUpdate = jest
       .fn()
-      .mockResolvedValueOnce(skill) // PUT pre-heal visibility load
-      .mockResolvedValueOnce(skill) // updateAgentSkillInMongoDB before row
-      .mockResolvedValueOnce({ ...skill, description: "after" });
-    const updateOne = jest.fn().mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
-    mockGetCollection.mockResolvedValue({ findOne, updateOne });
+      .mockResolvedValueOnce({ ...ready, authz_sync_state: "pending" })
+      .mockResolvedValueOnce(ready);
+    mockGetCollection.mockResolvedValue({ findOne, findOneAndUpdate });
     const { PUT } = await import("../route");
 
     const response = await PUT(
-      new NextRequest(new URL("/api/skills/configs?id=skill-openfga-write", "http://localhost:3000"), {
-        method: "PUT",
-        body: JSON.stringify({ description: "after" }),
-      }),
+      new NextRequest(
+        new URL(
+          "/api/skills/configs?id=skill-openfga-write",
+          "http://localhost:3000",
+        ),
+        {
+          method: "PUT",
+          body: JSON.stringify({ description: "after" }),
+        },
+      ),
     );
 
     expect(response.status).toBe(200);
@@ -194,11 +245,12 @@ describe("GET /api/skills/configs RBAC cutover", () => {
       "skill-openfga-write",
       "write",
     );
-    expect(updateOne).toHaveBeenCalledWith(
-      { id: "skill-openfga-write" },
+    expect(findOneAndUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ id: "skill-openfga-write" }),
       expect.objectContaining({
         $set: expect.objectContaining({ description: "after" }),
       }),
+      { returnDocument: "after" },
     );
   });
 
@@ -213,7 +265,9 @@ describe("GET /api/skills/configs RBAC cutover", () => {
         body: JSON.stringify({
           name: "Team Owned Skill",
           category: "Custom",
-          tasks: [{ display_text: "Do it", llm_prompt: "Do it", subagent: "skills" }],
+          tasks: [
+            { display_text: "Do it", llm_prompt: "Do it", subagent: "skills" },
+          ],
           visibility: "team",
           shared_with_teams: ["platform"],
         }),
@@ -225,17 +279,23 @@ describe("GET /api/skills/configs RBAC cutover", () => {
     // Convergence (2026-06-04): create now reconciles team shares through the
     // shared shareable-resource reconciler (diff-based) instead of the
     // write-only grant helper. Fresh create has no previous shares to revoke.
-    expect(mockReconcileSkillTeamShares).toHaveBeenCalledWith({
-      skillId: savedSkill.id,
-      ownerSubject: "alice-sub",
-      previousTeamRefs: [],
-      nextTeamRefs: ["platform"],
-      nextVisibility: "team",
-    });
+    expect(mockReconcileSkillTeamShares).toHaveBeenCalledWith(
+      {
+        skillId: savedSkill.id,
+        ownerSubject: "alice-sub",
+        previousTeamRefs: [],
+        nextTeamRefs: ["platform"],
+        nextVisibility: "team",
+      },
+      expect.objectContaining({ verifyHigherConsistency: true }),
+    );
   });
 
   it("revokes un-shared teams on update (shared reconciler diff)", async () => {
-    mockReadSkillSharedTeamSlugsFromOpenFga.mockResolvedValue(["platform", "sre"]);
+    mockReadSkillSharedTeamSlugsFromOpenFga.mockResolvedValue([
+      "platform",
+      "sre",
+    ]);
     const skill = {
       id: "skill-reshared",
       name: "Reshared",
@@ -244,43 +304,59 @@ describe("GET /api/skills/configs RBAC cutover", () => {
       owner_id: "alice@example.com",
       is_system: false,
       shared_with_teams: ["platform", "sre"],
-      tasks: [{ display_text: "Task", llm_prompt: "Do it", subagent: "skills" }],
+      tasks: [
+        { display_text: "Task", llm_prompt: "Do it", subagent: "skills" },
+      ],
     };
-    const findOne = jest
+    const findOne = jest.fn().mockResolvedValue(skill);
+    const findOneAndUpdate = jest
       .fn()
-      .mockResolvedValueOnce(skill) // PUT pre-heal owner tuple
-      .mockResolvedValueOnce(skill) // updateAgentSkillInMongoDB before row
-      .mockResolvedValueOnce({ ...skill, shared_with_teams: ["platform"] });
-    const updateOne = jest.fn().mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
-    mockGetCollection.mockResolvedValue({ findOne, updateOne });
+      .mockResolvedValueOnce({
+        ...skill,
+        shared_with_teams: ["platform"],
+        authz_sync_state: "pending",
+      })
+      .mockResolvedValueOnce({
+        ...skill,
+        shared_with_teams: ["platform"],
+        owner_subject: "alice-sub",
+        authz_revision: 1,
+        authz_sync_state: "ready",
+        authz_last_synced_revision: 1,
+      });
+    mockGetCollection.mockResolvedValue({ findOne, findOneAndUpdate });
     const { PUT } = await import("../route");
 
     const response = await PUT(
-      new NextRequest(new URL("/api/skills/configs?id=skill-reshared", "http://localhost:3000"), {
-        method: "PUT",
-        body: JSON.stringify({ visibility: "team", shared_with_teams: ["platform"] }),
-      }),
+      new NextRequest(
+        new URL(
+          "/api/skills/configs?id=skill-reshared",
+          "http://localhost:3000",
+        ),
+        {
+          method: "PUT",
+          body: JSON.stringify({
+            visibility: "team",
+            shared_with_teams: ["platform"],
+          }),
+        },
+      ),
     );
 
     expect(response.status).toBe(200);
     // Dropping "sre" from the shared set must reach the reconciler with the
     // previous and next team sets so the stale grant is revoked, not orphaned.
-    expect(mockReconcileSkillTeamShares).toHaveBeenNthCalledWith(1, {
-      skillId: "skill-reshared",
-      ownerSubject: "alice-sub",
-      previousTeamRefs: ["platform", "sre"],
-      nextTeamRefs: ["platform", "sre"],
-      nextVisibility: "team",
-      previousVisibility: "team",
-    });
-    expect(mockReconcileSkillTeamShares).toHaveBeenNthCalledWith(2, {
-      skillId: "skill-reshared",
-      ownerSubject: "alice-sub",
-      previousTeamRefs: ["platform", "sre"],
-      nextTeamRefs: ["platform"],
-      nextVisibility: "team",
-      previousVisibility: "team",
-    });
+    expect(mockReconcileSkillTeamShares).toHaveBeenLastCalledWith(
+      {
+        skillId: "skill-reshared",
+        ownerSubject: "alice-sub",
+        previousTeamRefs: ["platform", "sre"],
+        nextTeamRefs: ["platform"],
+        nextVisibility: "team",
+        previousVisibility: "team",
+      },
+      expect.objectContaining({ verifyHigherConsistency: true }),
+    );
   });
 
   it("revokes all team shares when demoting to private visibility", async () => {
@@ -293,32 +369,54 @@ describe("GET /api/skills/configs RBAC cutover", () => {
       owner_id: "alice@example.com",
       is_system: false,
       shared_with_teams: ["platform"],
-      tasks: [{ display_text: "Task", llm_prompt: "Do it", subagent: "skills" }],
+      tasks: [
+        { display_text: "Task", llm_prompt: "Do it", subagent: "skills" },
+      ],
     };
-    const findOne = jest
+    const findOne = jest.fn().mockResolvedValue(skill);
+    const findOneAndUpdate = jest
       .fn()
-      .mockResolvedValueOnce(skill)
-      .mockResolvedValueOnce(skill)
-      .mockResolvedValueOnce({ ...skill, visibility: "private", shared_with_teams: undefined });
-    const updateOne = jest.fn().mockResolvedValue({ matchedCount: 1, modifiedCount: 1 });
-    mockGetCollection.mockResolvedValue({ findOne, updateOne });
+      .mockResolvedValueOnce({
+        ...skill,
+        visibility: "private",
+        authz_sync_state: "pending",
+      })
+      .mockResolvedValueOnce({
+        ...skill,
+        visibility: "private",
+        shared_with_teams: [],
+        owner_subject: "alice-sub",
+        authz_revision: 1,
+        authz_sync_state: "ready",
+        authz_last_synced_revision: 1,
+      });
+    mockGetCollection.mockResolvedValue({ findOne, findOneAndUpdate });
     const { PUT } = await import("../route");
 
     const response = await PUT(
-      new NextRequest(new URL("/api/skills/configs?id=skill-private", "http://localhost:3000"), {
-        method: "PUT",
-        body: JSON.stringify({ visibility: "private" }),
-      }),
+      new NextRequest(
+        new URL(
+          "/api/skills/configs?id=skill-private",
+          "http://localhost:3000",
+        ),
+        {
+          method: "PUT",
+          body: JSON.stringify({ visibility: "private" }),
+        },
+      ),
     );
 
     expect(response.status).toBe(200);
-    expect(mockReconcileSkillTeamShares).toHaveBeenLastCalledWith({
-      skillId: "skill-private",
-      ownerSubject: "alice-sub",
-      previousTeamRefs: ["platform"],
-      nextTeamRefs: [],
-      nextVisibility: "private",
-      previousVisibility: "team",
-    });
+    expect(mockReconcileSkillTeamShares).toHaveBeenLastCalledWith(
+      {
+        skillId: "skill-private",
+        ownerSubject: "alice-sub",
+        previousTeamRefs: ["platform"],
+        nextTeamRefs: [],
+        nextVisibility: "private",
+        previousVisibility: "team",
+      },
+      expect.objectContaining({ verifyHigherConsistency: true }),
+    );
   });
 });

--- a/ui/src/app/api/skills/configs/import-zip/route.ts
+++ b/ui/src/app/api/skills/configs/import-zip/route.ts
@@ -15,7 +15,10 @@ import {
 filterResourcesByPermission,
 requireSkillPermission,
 } from "@/lib/rbac/resource-authz";
-import { reconcileSkillTeamShares } from "@/lib/rbac/skill-team-grants";
+import {
+readSkillSharedTeamSlugsFromOpenFga,
+reconcileSkillTeamShares,
+} from "@/lib/rbac/skill-team-grants";
 import {
 generateSkillIdFromName,
 type ImportConflictAction,
@@ -231,7 +234,7 @@ export async function runZipImport(
     .filter((skill) => skill.outcome === "created" || skill.outcome === "overwritten")
     .map((skill) => skill.skillId)
     .filter(Boolean);
-  if (teamRefs.length > 0 && grantSkillIds.length > 0 && args.grantTeamAccess) {
+  if (grantSkillIds.length > 0 && args.grantTeamAccess) {
     await args.grantTeamAccess(teamRefs, grantSkillIds);
   }
 
@@ -616,6 +619,14 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     }
     const buffer = await file.arrayBuffer();
     const teamRefs = parseTeamRefsFromForm(form);
+    const ownerSubject =
+      typeof session?.sub === "string" ? session.sub.trim() : "";
+    if (!ownerSubject) {
+      throw new ApiError(
+        "A stable user subject is required to import a skill.",
+        401,
+      );
+    }
 
     let resolutions: ImportConflictDecision[] | undefined;
     const rawResolutions = form.get("resolutions");
@@ -643,11 +654,18 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     // CRUD route.
     const collection = await getCollection<AgentSkill>("agent_skills");
     const candidates = await collection.find({}).toArray();
-    const visible = await filterResourcesByPermission(session, candidates, {
+    const scopedCandidates = candidates.filter((skill) => {
+      if ((skill.visibility ?? "private") !== "private") return true;
+      return skill.owner_subject
+        ? skill.owner_subject === ownerSubject
+        : skill.owner_id.trim().toLowerCase() === user.email.toLowerCase();
+    });
+    const visible = await filterResourcesByPermission(session, scopedCandidates, {
       type: "skill",
       action: "discover",
       id: (skill) => skill.id,
     });
+    const previousById = new Map(candidates.map((skill) => [skill.id, skill]));
 
     const result = await runZipImport({
       buffer,
@@ -659,27 +677,53 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
         await requireSkillPermission(session, skill.id, "write");
       },
       grantTeamAccess: async (refs, skillIds) => {
-        const ownerSubject =
-          typeof session?.sub === "string" && session.sub.trim() ? session.sub.trim() : null;
         for (const skillId of skillIds) {
+          const previous = previousById.get(skillId);
+          const current = await collection.findOne({ id: skillId });
+          if (!current) continue;
+          const previousTeamRefs =
+            previous?.visibility === "team"
+              ? previous.shared_with_teams?.length
+                ? previous.shared_with_teams
+                : await readSkillSharedTeamSlugsFromOpenFga(skillId)
+              : [];
+          const nextTeamRefs =
+            current.visibility === "team"
+              ? current.shared_with_teams?.length
+                ? current.shared_with_teams
+                : refs
+              : [];
           await reconcileSkillTeamShares({
             skillId,
             ownerSubject,
-            previousTeamRefs: [],
-            nextTeamRefs: refs,
-            nextVisibility: refs.length > 0 ? "team" : "private",
+            previousTeamRefs,
+            nextTeamRefs,
+            nextVisibility: current.visibility ?? "private",
+            previousVisibility: previous?.visibility ?? "private",
           });
         }
       },
       persistSkill: async (skill, mode) => {
-        const mongoRow = { ...skill };
-        delete mongoRow.shared_with_teams;
+        const previous = previousById.get(skill.id);
+        const persistedTeamRefs =
+          skill.visibility === "team"
+            ? teamRefs.length > 0
+              ? teamRefs
+              : previous?.shared_with_teams ??
+                (await readSkillSharedTeamSlugsFromOpenFga(skill.id))
+            : [];
+        const mongoRow: AgentSkill = {
+          ...skill,
+          owner_subject:
+            skill.owner_subject ?? previous?.owner_subject ?? ownerSubject,
+          shared_with_teams: persistedTeamRefs,
+        };
         if (mode === "create") {
-          await collection.insertOne(mongoRow as AgentSkill);
+          await collection.insertOne(mongoRow);
         } else {
           await collection.updateOne(
             { id: skill.id },
-            { $set: mongoRow, $unset: { shared_with_teams: "" } },
+            { $set: mongoRow },
           );
         }
       },

--- a/ui/src/app/api/skills/configs/route.ts
+++ b/ui/src/app/api/skills/configs/route.ts
@@ -1,44 +1,52 @@
 import {
-getAgentSkillVisibleToUser,
-hydrateAgentSkillTeamShares,
-hydrateAgentSkillTeamSharesList,
+  getAgentSkillVisibleToUser,
+  hydrateAgentSkillTeamShares,
+  hydrateAgentSkillTeamSharesList,
 } from "@/lib/agent-skill-visibility";
 import {
-ApiError,
-successResponse,
-withAuth,
-withErrorHandler,
+  ApiError,
+  successResponse,
+  withAuth,
+  withErrorHandler,
 } from "@/lib/api-middleware";
 import {
-BUILTIN_LOCKED_MESSAGE,
-canMutateBuiltinSkill,
+  BUILTIN_LOCKED_MESSAGE,
+  canMutateBuiltinSkill,
 } from "@/lib/builtin-skill-policy";
-import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
-import { syncSkillResource } from "@/lib/rbac/keycloak-resource-sync";
+import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
 import {
-filterResourcesByPermission,
-requireSkillPermission,
+  AuthzSyncSupersededError,
+  authzRevisionFilter,
+  hasActiveAuthzSync,
+  nextAuthzRevision,
+  runRevisionedAuthzSync,
+} from "@/lib/authz/resource-sync";
+import { syncSkillResource } from "@/lib/rbac/keycloak-resource-sync";
+import { deleteAllSkillRelationshipTuples } from "@/lib/rbac/openfga-owned-resources-reconcile";
+import {
+  filterResourcesByPermission,
+  requireSkillPermission,
 } from "@/lib/rbac/resource-authz";
 import {
-readSkillSharedTeamSlugsFromOpenFga,
-reconcileSkillTeamShares,
+  readSkillSharedTeamSlugsFromOpenFga,
+  reconcileSkillTeamShares,
 } from "@/lib/rbac/skill-team-grants";
 import {
-deleteRevisionsForSkill,
-recordRevision,
-snapshotsDiffer,
-type SkillSnapshotInput,
+  deleteRevisionsForSkill,
+  recordRevision,
+  snapshotsDiffer,
+  type SkillSnapshotInput,
 } from "@/lib/skill-revisions";
 import { scanSkillContent as runSkillScan } from "@/lib/skill-scan";
 import { recordScanEvent } from "@/lib/skill-scan-history";
 import type {
-AgentSkill,
-CreateAgentSkillInput,
-ScanStatus,
-SkillVisibility,
-UpdateAgentSkillInput,
+  AgentSkill,
+  CreateAgentSkillInput,
+  ScanStatus,
+  SkillVisibility,
+  UpdateAgentSkillInput,
 } from "@/types/agent-skill";
-import { NextRequest,NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Persisted agent skill configs (CRUD)
@@ -55,13 +63,18 @@ const STORAGE_TYPE = isMongoDBConfigured ? "mongodb" : "none";
 
 const ANCILLARY_SIZE_LIMIT = 5 * 1024 * 1024; // 5 MB soft limit (FR-028)
 
-function validateAncillaryFiles(
-  files: Record<string, string> | undefined,
-): { valid: boolean; totalBytes: number; warning?: string } {
+function validateAncillaryFiles(files: Record<string, string> | undefined): {
+  valid: boolean;
+  totalBytes: number;
+  warning?: string;
+} {
   if (!files || Object.keys(files).length === 0) {
     return { valid: true, totalBytes: 0 };
   }
-  const totalBytes = Object.values(files).reduce((sum, v) => sum + new Blob([v]).size, 0);
+  const totalBytes = Object.values(files).reduce(
+    (sum, v) => sum + new Blob([v]).size,
+    0,
+  );
   if (totalBytes > ANCILLARY_SIZE_LIMIT) {
     return {
       valid: true,
@@ -106,15 +119,6 @@ function extractSnapshot(skill: AgentSkill): SkillSnapshotInput {
 
 const VALID_VISIBILITIES: SkillVisibility[] = ["private", "team", "global"];
 
-/** Team shares are OpenFGA-only; never persist legacy `shared_with_teams` on Mongo rows. */
-function stripSharedWithTeamsFromMongoFields<T extends { shared_with_teams?: unknown }>(
-  value: T,
-): Omit<T, "shared_with_teams"> {
-  const result = { ...value };
-  delete result.shared_with_teams;
-  return result;
-}
-
 function normalizeTeamRefList(values: string[] | undefined | null): string[] {
   if (!Array.isArray(values)) return [];
   const seen = new Set<string>();
@@ -128,6 +132,48 @@ function normalizeTeamRefList(values: string[] | undefined | null): string[] {
   return out;
 }
 
+function sameStringSet(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((value) => rightSet.has(value));
+}
+
+function skillAuthzSnapshot(skill: AgentSkill): Record<string, unknown> {
+  return {
+    visibility: skill.visibility ?? "private",
+    shared_with_teams: normalizeTeamRefList(skill.shared_with_teams),
+    owner_subject: skill.owner_subject,
+  };
+}
+
+function previousSkillAuthzState(skill: AgentSkill): AgentSkill {
+  const previous = skill.authz_previous_state;
+  return previous
+    ? ({ ...skill, ...previous, authz_previous_state: undefined } as AgentSkill)
+    : skill;
+}
+
+function stableSessionSubject(session: { sub?: unknown }): string {
+  const subject = typeof session.sub === "string" ? session.sub.trim() : "";
+  if (!subject) {
+    throw new ApiError("A stable user subject is required to own a skill", 401);
+  }
+  return subject;
+}
+
+function isPrivateSkillOwner(
+  skill: AgentSkill,
+  userEmail: string,
+  sessionSubject: string,
+): boolean {
+  if ((skill.visibility ?? "private") !== "private") return true;
+  if (skill.owner_subject) return skill.owner_subject === sessionSubject;
+  return skill.owner_id.trim().toLowerCase() === userEmail.trim().toLowerCase();
+}
+
 async function saveAgentSkillToMongoDB(config: AgentSkill): Promise<void> {
   const collection = await getCollection<AgentSkill>("agent_skills");
   await collection.insertOne(config);
@@ -137,8 +183,11 @@ async function updateAgentSkillInMongoDB(
   id: string,
   updates: Partial<AgentSkill>,
   user: { email: string; role?: string },
-): Promise<{ before: AgentSkill | null }> {
-  console.log(`[MongoDB] ========== updateAgentSkillInMongoDB START ==========`);
+  expectedAuthz?: AgentSkill,
+): Promise<{ before: AgentSkill; after: AgentSkill }> {
+  console.log(
+    `[MongoDB] ========== updateAgentSkillInMongoDB START ==========`,
+  );
   console.log(`[MongoDB] Config ID: ${id}`);
   console.log(`[MongoDB] User: ${user.email}, IsAdmin: ${isUserAdmin(user)}`);
 
@@ -168,28 +217,37 @@ async function updateAgentSkillInMongoDB(
   console.log(`[MongoDB] Permission checks passed`);
 
   const updatePayload = {
-    ...stripSharedWithTeamsFromMongoFields(updates),
+    ...updates,
     updated_at: new Date(),
   };
-  console.log(`[MongoDB] Update payload:`, JSON.stringify(updatePayload, null, 2));
-  console.log(`[MongoDB] Update payload tasks count:`, updatePayload.tasks?.length);
+  console.log(
+    `[MongoDB] Update payload:`,
+    JSON.stringify(updatePayload, null, 2),
+  );
+  console.log(
+    `[MongoDB] Update payload tasks count:`,
+    updatePayload.tasks?.length,
+  );
   if (updatePayload.tasks && updatePayload.tasks.length > 0) {
-    console.log(`[MongoDB] First task llm_prompt:`, updatePayload.tasks[0].llm_prompt);
+    console.log(
+      `[MongoDB] First task llm_prompt:`,
+      updatePayload.tasks[0].llm_prompt,
+    );
   }
 
   console.log(`[MongoDB] Executing updateOne...`);
-  const updateResult = await collection.updateOne(
-    { id },
-    { $set: updatePayload, $unset: { shared_with_teams: "" } },
+  const updated = await collection.findOneAndUpdate(
+    { id, ...(expectedAuthz ? authzRevisionFilter(expectedAuthz) : {}) },
+    { $set: updatePayload },
+    { returnDocument: "after" },
   );
-  console.log(`[MongoDB] UpdateOne result:`, {
-    matchedCount: updateResult.matchedCount,
-    modifiedCount: updateResult.modifiedCount,
-    acknowledged: updateResult.acknowledged,
-  });
-
-  console.log(`[MongoDB] Fetching updated config for verification...`);
-  const updated = await collection.findOne({ id });
+  if (!updated) {
+    throw new ApiError(
+      "This skill changed while authorization was being prepared. Retry the save.",
+      409,
+      "AUTHZ_SYNC_SUPERSEDED",
+    );
+  }
   console.log(`[MongoDB] Verified updated config:`, {
     id: updated?.id,
     name: updated?.name,
@@ -211,12 +269,10 @@ async function updateAgentSkillInMongoDB(
   // overlays the body onto `existing` to derive the post-update
   // snapshot. Keeping the read here means existing tests that mock
   // exactly two `findOne` calls keep working.
-  return { before: existing };
+  return { before: existing, after: updated };
 }
 
-async function deleteAgentSkillFromMongoDB(
-  id: string,
-): Promise<void> {
+async function deleteAgentSkillFromMongoDB(id: string): Promise<void> {
   const collection = await getCollection<AgentSkill>("agent_skills");
 
   const existing = await collection.findOne({ id });
@@ -262,22 +318,42 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   return await withAuth(request, async (req, user, session) => {
     const body: CreateAgentSkillInput = await request.json();
 
-    if (!body.name || !body.category || !body.tasks || body.tasks.length === 0) {
-      throw new ApiError("Missing required fields: name, category, and at least one task are required", 400);
+    if (
+      !body.name ||
+      !body.category ||
+      !body.tasks ||
+      body.tasks.length === 0
+    ) {
+      throw new ApiError(
+        "Missing required fields: name, category, and at least one task are required",
+        400,
+      );
     }
 
     for (const task of body.tasks) {
       if (!task.display_text || !task.llm_prompt || !task.subagent) {
-        throw new ApiError("Each task must have display_text, llm_prompt, and subagent", 400);
+        throw new ApiError(
+          "Each task must have display_text, llm_prompt, and subagent",
+          400,
+        );
       }
     }
 
     const visibility: SkillVisibility = body.visibility || "private";
     if (!VALID_VISIBILITIES.includes(visibility)) {
-      throw new ApiError(`Invalid visibility: ${visibility}. Must be one of: ${VALID_VISIBILITIES.join(", ")}`, 400);
+      throw new ApiError(
+        `Invalid visibility: ${visibility}. Must be one of: ${VALID_VISIBILITIES.join(", ")}`,
+        400,
+      );
     }
-    if (visibility === "team" && (!body.shared_with_teams || body.shared_with_teams.length === 0)) {
-      throw new ApiError("At least one team must be selected when visibility is 'team'", 400);
+    if (
+      visibility === "team" &&
+      (!body.shared_with_teams || body.shared_with_teams.length === 0)
+    ) {
+      throw new ApiError(
+        "At least one team must be selected when visibility is 'team'",
+        400,
+      );
     }
 
     const nameSlug = (body.name as string)
@@ -287,6 +363,9 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       .replace(/^-|-$/g, "");
     const id = `skill-${nameSlug}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date();
+    const ownerSubject = stableSessionSubject(session);
+    const sharedWithTeams =
+      visibility === "team" ? normalizeTeamRefList(body.shared_with_teams) : [];
 
     const ancillaryCheck = validateAncillaryFiles(body.ancillary_files);
 
@@ -297,11 +376,16 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       category: body.category,
       tasks: body.tasks,
       owner_id: user.email,
+      owner_subject: ownerSubject,
       is_system: false,
       created_at: now,
       updated_at: now,
       metadata: body.metadata,
       visibility,
+      shared_with_teams: sharedWithTeams,
+      authz_revision: 1,
+      authz_sync_state: "ready",
+      authz_last_synced_revision: 1,
       skill_content: body.skill_content,
       is_quick_start: body.is_quick_start,
       difficulty: body.difficulty,
@@ -312,7 +396,11 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     };
 
     const tCreate = Date.now();
-    const scanResult = await runSkillScan(body.name, body.skill_content || "", id);
+    const scanResult = await runSkillScan(
+      body.name,
+      body.skill_content || "",
+      id,
+    );
     config.scan_status = scanResult.scan_status;
     if (scanResult.scan_summary !== undefined) {
       config.scan_summary = scanResult.scan_summary;
@@ -328,11 +416,41 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       actor: user.email,
       scan_status: scanResult.scan_status,
       scan_summary: scanResult.scan_summary,
-      scanner_unavailable: !body.skill_content?.trim() || scanResult.scan_status === "unscanned",
+      scanner_unavailable:
+        !body.skill_content?.trim() || scanResult.scan_status === "unscanned",
       duration_ms: Date.now() - tCreate,
     });
 
-    await saveAgentSkillToMongoDB(stripSharedWithTeamsFromMongoFields(config) as AgentSkill);
+    await reconcileSkillTeamShares(
+      {
+        skillId: id,
+        ownerSubject,
+        previousTeamRefs: [],
+        nextTeamRefs: sharedWithTeams,
+        nextVisibility: visibility,
+      },
+      {
+        caller: { type: "user", id: ownerSubject },
+        source: "skill_create",
+        verifyHigherConsistency: true,
+      },
+    );
+
+    try {
+      await saveAgentSkillToMongoDB(config);
+    } catch (error) {
+      await deleteAllSkillRelationshipTuples(id, {
+        caller: { type: "user", id: ownerSubject },
+        source: "skill_create_rollback",
+        verifyHigherConsistency: true,
+      }).catch((cleanupError) => {
+        console.warn(
+          "[AgentSkill] Failed to clean up authorization after create failure",
+          cleanupError,
+        );
+      });
+      throw error;
+    }
     // Capture revision #1 right after the row is persisted so the
     // restore path always has a baseline to fall back to. We pass
     // through the same content fields the caller saved, plus the
@@ -349,35 +467,15 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     );
 
     await syncSkillResource("create", id, body.name, visibility);
-    // Reconcile owner + optional team-share grants. Without the owner tuple,
-    // the author can create/save via routes that skip per-skill FGA (POST) but
-    // later PUT/scan checks (`can_write`) fail with "You do not have permission
-    // to access this resource." Config (Mongo) is the source of truth, so an
-    // OpenFGA hiccup must not fail the create.
-    const ownerSubject =
-      typeof session?.sub === "string" && session.sub.trim() ? session.sub.trim() : null;
-    try {
-      await reconcileSkillTeamShares({
-        skillId: id,
-        ownerSubject,
-        previousTeamRefs: [],
-        nextTeamRefs: visibility === "team" ? body.shared_with_teams : [],
-        nextVisibility: visibility,
-      });
-    } catch (error) {
-      console.warn(
-        "[AgentSkill] Failed to reconcile skill FGA grants on create:",
-        error instanceof Error ? error.message : String(error),
-      );
-    }
-
     return successResponse(
       {
         id,
         message: "Agent config created successfully",
         scan_status: scanResult.scan_status,
         scan_summary: scanResult.scan_summary,
-        ...(ancillaryCheck.warning ? { ancillary_warning: ancillaryCheck.warning } : {}),
+        ...(ancillaryCheck.warning
+          ? { ancillary_warning: ancillaryCheck.warning }
+          : {}),
       },
       201,
     );
@@ -394,11 +492,17 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const id = searchParams.get("id");
 
   return await withAuth(request, async (req, user, session) => {
+    const sessionSubject = stableSessionSubject(session);
     if (id) {
-      console.log(`[API GET] Fetching single config: ${id} for user: ${user.email}`);
+      console.log(
+        `[API GET] Fetching single config: ${id} for user: ${user.email}`,
+      );
       const config = await getAgentSkillByIdFromMongoDB(id);
       if (!config) {
         console.log(`[API GET] Config not found: ${id}`);
+        throw new ApiError("Agent config not found", 404);
+      }
+      if (!isPrivateSkillOwner(config, user.email, sessionSubject)) {
         throw new ApiError("Agent config not found", 404);
       }
       await requireSkillPermission(session, id, "read");
@@ -409,18 +513,28 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
         updated_at: config.updated_at,
       });
       if (config.tasks && config.tasks.length > 0) {
-        console.log(`[API GET] First task llm_prompt:`, config.tasks[0].llm_prompt);
+        console.log(
+          `[API GET] First task llm_prompt:`,
+          config.tasks[0].llm_prompt,
+        );
       }
       const hydrated = await hydrateAgentSkillTeamShares(config);
       return NextResponse.json(hydrated) as NextResponse;
     } else {
       console.log(`[API GET] Fetching all configs for user: ${user.email}`);
       const configs = await getAgentSkillsFromMongoDB();
-      const visibleConfigs = await filterResourcesByPermission(session, configs, {
-        type: "skill",
-        action: "discover",
-        id: (config) => config.id,
-      });
+      const scopedConfigs = configs.filter((config) =>
+        isPrivateSkillOwner(config, user.email, sessionSubject),
+      );
+      const visibleConfigs = await filterResourcesByPermission(
+        session,
+        scopedConfigs,
+        {
+          type: "skill",
+          action: "discover",
+          id: (config) => config.id,
+        },
+      );
       const hydrated = await hydrateAgentSkillTeamSharesList(visibleConfigs);
       console.log(`[API GET] Returning ${hydrated.length} configs`);
       return NextResponse.json(hydrated) as NextResponse;
@@ -445,7 +559,9 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
   }
 
   return await withAuth(request, async (req, user, session) => {
-    console.log(`[API PUT] User: ${user.email}, Role: ${user.role}, IsAdmin: ${isUserAdmin(user)}`);
+    console.log(
+      `[API PUT] User: ${user.email}, Role: ${user.role}, IsAdmin: ${isUserAdmin(user)}`,
+    );
 
     const body: UpdateAgentSkillInput = await request.json();
     console.log(`[API PUT] Request body:`, JSON.stringify(body, null, 2));
@@ -454,37 +570,67 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       throw new ApiError("At least one field must be provided for update", 400);
     }
 
+    const sessionSubject = stableSessionSubject(session);
     const preUpdate = await getAgentSkillVisibleToUser(id);
-    if (preUpdate && preUpdate.owner_id === user.email) {
-      const healOwnerSubject =
-        typeof session?.sub === "string" && session.sub.trim() ? session.sub.trim() : null;
-      const healTeamRefs = await readSkillSharedTeamSlugsFromOpenFga(id);
-      if (healOwnerSubject) {
-        try {
-          await reconcileSkillTeamShares({
-            skillId: id,
-            ownerSubject: healOwnerSubject,
-            previousTeamRefs: healTeamRefs,
-            nextTeamRefs: healTeamRefs,
-            nextVisibility: preUpdate.visibility ?? "private",
-            previousVisibility: preUpdate.visibility ?? "private",
-          });
-        } catch (error) {
-          console.warn(
-            "[AgentSkill] Failed to reconcile owner FGA tuple before update:",
-            error instanceof Error ? error.message : String(error),
-          );
-        }
-      }
+    if (!preUpdate) {
+      throw new ApiError("Agent config not found", 404);
+    }
+    if (!isPrivateSkillOwner(preUpdate, user.email, sessionSubject)) {
+      throw new ApiError("Agent config not found", 404);
+    }
+    if (hasActiveAuthzSync(preUpdate)) {
+      throw new ApiError(
+        "This skill's authorization is already being reconciled. Retry shortly.",
+        409,
+        "AUTHZ_SYNC_PENDING",
+      );
+    }
+    const previousAuthzState = previousSkillAuthzState(preUpdate);
+    const ownerSubject =
+      preUpdate.owner_subject ??
+      (preUpdate.owner_id.trim().toLowerCase() ===
+      user.email.trim().toLowerCase()
+        ? sessionSubject
+        : null);
+
+    // Legacy rows may predate owner_subject. Repair the owner tuple before the
+    // write check, then persist the stable subject as part of this save.
+    if (!preUpdate.owner_subject && ownerSubject) {
+      const healTeamRefs = preUpdate.shared_with_teams?.length
+        ? normalizeTeamRefList(preUpdate.shared_with_teams)
+        : await readSkillSharedTeamSlugsFromOpenFga(id);
+      await reconcileSkillTeamShares(
+        {
+          skillId: id,
+          ownerSubject,
+          previousTeamRefs: healTeamRefs,
+          nextTeamRefs: healTeamRefs,
+          nextVisibility: preUpdate.visibility ?? "private",
+          previousVisibility: preUpdate.visibility ?? "private",
+        },
+        {
+          caller: { type: "user", id: sessionSubject },
+          source: "skill_owner_backfill",
+        },
+      );
     }
     await requireSkillPermission(session, id, "write");
 
     if (body.visibility !== undefined) {
       if (!VALID_VISIBILITIES.includes(body.visibility)) {
-        throw new ApiError(`Invalid visibility: ${body.visibility}. Must be one of: ${VALID_VISIBILITIES.join(", ")}`, 400);
+        throw new ApiError(
+          `Invalid visibility: ${body.visibility}. Must be one of: ${VALID_VISIBILITIES.join(", ")}`,
+          400,
+        );
       }
-      if (body.visibility === "team" && (!body.shared_with_teams || body.shared_with_teams.length === 0)) {
-        throw new ApiError("At least one team must be selected when visibility is 'team'", 400);
+      if (
+        body.visibility === "team" &&
+        (!body.shared_with_teams || body.shared_with_teams.length === 0)
+      ) {
+        throw new ApiError(
+          "At least one team must be selected when visibility is 'team'",
+          400,
+        );
       }
     }
 
@@ -495,7 +641,10 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       }
       for (const task of body.tasks) {
         if (!task.display_text || !task.llm_prompt || !task.subagent) {
-          throw new ApiError("Each task must have display_text, llm_prompt, and subagent", 400);
+          throw new ApiError(
+            "Each task must have display_text, llm_prompt, and subagent",
+            400,
+          );
         }
       }
       console.log(`[API PUT] Tasks validation passed`);
@@ -511,10 +660,15 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
     let scanSummaryFromSave: string | undefined;
     if (body.skill_content !== undefined) {
       const tPut = Date.now();
-      const scanResult = await runSkillScan(body.name || id, body.skill_content || "", id);
+      const scanResult = await runSkillScan(
+        body.name || id,
+        body.skill_content || "",
+        id,
+      );
       (body as Record<string, unknown>).scan_status = scanResult.scan_status;
       if (scanResult.scan_summary !== undefined) {
-        (body as Record<string, unknown>).scan_summary = scanResult.scan_summary;
+        (body as Record<string, unknown>).scan_summary =
+          scanResult.scan_summary;
         scanSummaryFromSave = scanResult.scan_summary;
       }
       if (body.skill_content?.trim()) {
@@ -529,86 +683,143 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
         actor: user.email,
         scan_status: scanResult.scan_status,
         scan_summary: scanResult.scan_summary,
-        scanner_unavailable: !body.skill_content?.trim() || scanResult.scan_status === "unscanned",
+        scanner_unavailable:
+          !body.skill_content?.trim() || scanResult.scan_status === "unscanned",
         duration_ms: Date.now() - tPut,
       });
     }
 
-    console.log(`[API PUT] Calling updateAgentSkillInMongoDB...`);
-    // updateAgentSkillInMongoDB already reads the pre-update row for
-    // its permission check; have it hand the row back so we can build
-    // a `prev` snapshot for the no-op diff guard without burning a
-    // duplicate `findOne`.
-    const { before: beforeUpdate } = await updateAgentSkillInMongoDB(
-      id,
-      body,
-      user,
-    );
-    if (beforeUpdate) {
-      const merged: AgentSkill = { ...beforeUpdate, ...(body as Partial<AgentSkill>) };
-      const prev = extractSnapshot(beforeUpdate);
-      const next = extractSnapshot(merged);
-      if (snapshotsDiffer(prev, next)) {
-        await recordRevision({
-          skillId: id,
-          snapshot: next,
-          trigger: "update",
-          actor: user.email,
-        });
-      }
-    }
-
-    // Reconcile the skill's team-share grants on edit. Previously the update
-    // path wrote NOTHING to OpenFGA, so changing `shared_with_teams` (or
-    // demoting away from `team` visibility) updated Mongo but left the old
-    // `team:<slug>#member user skill:<id>` grants in place — un-shared teams
-    // kept access. Diffing previous → next through the shared reconciler now
-    // revokes dropped teams and grants newly added ones. Config is the source
-    // of truth, so an OpenFGA failure is logged but does not fail the update.
-    if (beforeUpdate) {
-      const previousVisibility = beforeUpdate.visibility ?? "private";
-      const nextVisibility =
-        body.visibility !== undefined ? body.visibility : previousVisibility;
-      const previousTeamRefs = await readSkillSharedTeamSlugsFromOpenFga(id);
-      let nextTeamRefs: string[];
-      if (nextVisibility !== "team") {
-        nextTeamRefs = [];
-      } else if (Object.prototype.hasOwnProperty.call(body, "shared_with_teams")) {
-        nextTeamRefs = normalizeTeamRefList(body.shared_with_teams);
-      } else {
-        nextTeamRefs = previousTeamRefs;
-      }
-      const ownerSubject =
-        beforeUpdate.owner_id === user.email &&
-        typeof session?.sub === "string" &&
-        session.sub.trim()
-          ? session.sub.trim()
-          : null;
-      try {
-        await reconcileSkillTeamShares({
+    const previousVisibility = previousAuthzState.visibility ?? "private";
+    const nextVisibility = body.visibility ?? preUpdate.visibility ?? "private";
+    const previousTeamRefs = Array.isArray(previousAuthzState.shared_with_teams)
+      ? normalizeTeamRefList(previousAuthzState.shared_with_teams)
+      : await readSkillSharedTeamSlugsFromOpenFga(id);
+    const nextTeamRefs =
+      nextVisibility === "team"
+        ? Object.prototype.hasOwnProperty.call(body, "shared_with_teams")
+          ? normalizeTeamRefList(body.shared_with_teams)
+          : Array.isArray(preUpdate.shared_with_teams)
+            ? normalizeTeamRefList(preUpdate.shared_with_teams)
+            : previousTeamRefs
+        : [];
+    const reconcile = (verifyHigherConsistency: boolean) =>
+      reconcileSkillTeamShares(
+        {
           skillId: id,
           ownerSubject,
           previousTeamRefs,
           nextTeamRefs,
           nextVisibility,
           previousVisibility,
+        },
+        {
+          caller: { type: "user", id: sessionSubject },
+          source: "skill_update",
+          verifyHigherConsistency,
+        },
+      );
+    const authzMutationRequired =
+      preUpdate.authz_sync_state !== "ready" ||
+      preUpdate.authz_revision !== preUpdate.authz_last_synced_revision ||
+      !preUpdate.owner_subject ||
+      nextVisibility !== previousVisibility ||
+      !sameStringSet(previousTeamRefs, nextTeamRefs);
+    const baseUpdates: Partial<AgentSkill> = {
+      ...(body as Partial<AgentSkill>),
+      visibility: nextVisibility,
+      shared_with_teams: nextTeamRefs,
+      ...(ownerSubject ? { owner_subject: ownerSubject } : {}),
+    };
+
+    console.log(`[API PUT] Calling updateAgentSkillInMongoDB...`);
+    let beforeUpdate: AgentSkill;
+    let updated: AgentSkill;
+    if (!authzMutationRequired) {
+      await reconcile(false);
+      ({ before: beforeUpdate, after: updated } =
+        await updateAgentSkillInMongoDB(id, baseUpdates, user));
+    } else {
+      const revision = nextAuthzRevision(preUpdate);
+      const pendingUpdates: Partial<AgentSkill> = {
+        ...baseUpdates,
+        authz_revision: revision,
+        authz_sync_state: "pending",
+        authz_sync_started_at: new Date().toISOString(),
+        authz_previous_state:
+          preUpdate.authz_previous_state ?? skillAuthzSnapshot(preUpdate),
+      };
+      ({ before: beforeUpdate } = await updateAgentSkillInMongoDB(
+        id,
+        pendingUpdates,
+        user,
+        preUpdate,
+      ));
+      try {
+        updated = await runRevisionedAuthzSync({
+          reconcile: async () => {
+            await reconcile(true);
+          },
+          markError: async (errorCode) => {
+            await (
+              await getCollection<AgentSkill>("agent_skills")
+            ).findOneAndUpdate(
+              { id, authz_revision: revision, authz_sync_state: "pending" },
+              {
+                $set: {
+                  authz_sync_state: "error",
+                  authz_last_error_code: errorCode,
+                },
+                $unset: { authz_sync_started_at: "" },
+              },
+            );
+          },
+          markReady: async () =>
+            (await getCollection<AgentSkill>("agent_skills")).findOneAndUpdate(
+              { id, authz_revision: revision, authz_sync_state: "pending" },
+              {
+                $set: {
+                  authz_sync_state: "ready",
+                  authz_last_synced_revision: revision,
+                },
+                $unset: {
+                  authz_last_error_code: "",
+                  authz_previous_state: "",
+                  authz_sync_started_at: "",
+                },
+              },
+              { returnDocument: "after" },
+            ),
         });
       } catch (error) {
-        console.warn(
-          "[AgentSkill] Failed to reconcile skill FGA grants on update:",
-          error instanceof Error ? error.message : String(error),
-        );
+        if (error instanceof AuthzSyncSupersededError) {
+          throw new ApiError(error.message, 409, "AUTHZ_SYNC_SUPERSEDED");
+        }
+        throw error;
       }
+    }
+
+    const prev = extractSnapshot(beforeUpdate);
+    const next = extractSnapshot(updated);
+    if (snapshotsDiffer(prev, next)) {
+      await recordRevision({
+        skillId: id,
+        snapshot: next,
+        trigger: "update",
+        actor: user.email,
+      });
     }
     console.log(`[AgentSkill] Updated agent config "${id}" by ${user.email}`);
     console.log(`[API PUT] ============ UPDATE REQUEST END ============`);
 
-    const scanStatus = (body as Record<string, unknown>).scan_status as ScanStatus | undefined;
+    const scanStatus = (body as Record<string, unknown>).scan_status as
+      ScanStatus | undefined;
     return successResponse({
       id,
       message: "Agent config updated successfully",
       ...(scanStatus ? { scan_status: scanStatus } : {}),
-      ...(scanSummaryFromSave !== undefined ? { scan_summary: scanSummaryFromSave } : {}),
+      ...(scanSummaryFromSave !== undefined
+        ? { scan_summary: scanSummaryFromSave }
+        : {}),
       ...(ancillaryWarning ? { ancillary_warning: ancillaryWarning } : {}),
     });
   });
@@ -628,7 +839,20 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
   }
 
   return await withAuth(request, async (req, user, session) => {
+    const sessionSubject = stableSessionSubject(session);
+    const existing = await getAgentSkillByIdFromMongoDB(id);
+    if (
+      !existing ||
+      !isPrivateSkillOwner(existing, user.email, sessionSubject)
+    ) {
+      throw new ApiError("Agent config not found", 404);
+    }
     await requireSkillPermission(session, id, "delete");
+    await deleteAllSkillRelationshipTuples(id, {
+      caller: { type: "user", id: sessionSubject },
+      source: "skill_delete",
+      verifyHigherConsistency: true,
+    });
     await deleteAgentSkillFromMongoDB(id);
     // Drop history rows for this skill so we don't leak orphaned
     // revision documents that nobody can render. Best-effort: a

--- a/ui/src/app/api/skills/route.ts
+++ b/ui/src/app/api/skills/route.ts
@@ -2,6 +2,7 @@ import {
 getAuthFromBearerOrSession,
 withErrorHandler,
 } from "@/lib/api-middleware";
+import { authzSyncPreCheck } from "@/lib/authz/resource-sync";
 import type { SkillHubDoc } from "@/lib/hub-crawl";
 import { checkOpenFgaTuple,type OpenFgaCheckResult,type OpenFgaTupleKey } from "@/lib/rbac/openfga";
 import { organizationObjectId } from "@/lib/rbac/organization";
@@ -40,6 +41,14 @@ export interface CatalogSkill {
   description: string;
   source: "default" | "agent_skills" | "hub";
   source_id: string | null;
+  owner_id?: string | null;
+  owner_subject?: string;
+  visibility?: "private" | "team" | "global";
+  authz_revision?: number;
+  authz_sync_state?: "pending" | "ready" | "error";
+  authz_last_synced_revision?: number;
+  authz_last_error_code?: string;
+  authz_sync_started_at?: string;
   content: string | null;
   metadata: Record<string, unknown>;
   /**
@@ -269,6 +278,7 @@ type SkillOpenFgaMode = "read" | "use";
 
 interface FilterSkillsByOpenFgaOptions {
   subject?: string | null;
+  ownerEmail?: string | null;
   mode: SkillOpenFgaMode;
   isAdmin?: boolean;
   check?: (tuple: OpenFgaTupleKey) => Promise<OpenFgaCheckResult>;
@@ -278,9 +288,6 @@ export async function filterSkillsByOpenFga(
   skills: CatalogSkill[],
   options: FilterSkillsByOpenFgaOptions,
 ): Promise<CatalogSkill[]> {
-  if (options.isAdmin) return skills;
-  if (!options.subject) return [];
-
   const relation = options.mode === "use" ? "can_use" : "can_read";
   const check = options.check ?? checkOpenFgaTuple;
   let baselineUseAllowed: boolean | null = null;
@@ -301,6 +308,26 @@ export async function filterSkillsByOpenFga(
 
   const decisions = await Promise.all(
     skills.map(async (skill) => {
+      if (skill.source === "agent_skills") {
+        if (authzSyncPreCheck(skill)) return null;
+        const visibility =
+          skill.visibility ??
+          (skill.metadata.visibility as CatalogSkill["visibility"] | undefined);
+        if (visibility === "private") {
+          const subject = options.subject?.replace(/^user:/, "");
+          const ownsBySubject = Boolean(
+            subject && skill.owner_subject && subject === skill.owner_subject,
+          );
+          const ownsLegacyRow = Boolean(
+            options.ownerEmail &&
+              skill.owner_id &&
+              options.ownerEmail.toLowerCase() === skill.owner_id.toLowerCase(),
+          );
+          return ownsBySubject || ownsLegacyRow ? skill : null;
+        }
+      }
+      if (options.isAdmin) return skill;
+      if (!options.subject) return null;
       if (options.mode === "read" && skill.source === "default") return skill;
       if (options.mode === "use" && skill.source === "default" && await hasBaselineUseAccess()) {
         return skill;
@@ -443,6 +470,7 @@ async function aggregateLocally(
               skill_template: 1,
               tasks: 1,
               owner_id: 1,
+              owner_subject: 1,
               visibility: 1,
               is_system: 1,
               category: 1,
@@ -457,6 +485,11 @@ async function aggregateLocally(
               // can render the audit trail without an extra round
               // trip. Absent on docs without an override.
               scan_override: 1,
+              authz_revision: 1,
+              authz_sync_state: 1,
+              authz_last_synced_revision: 1,
+              authz_last_error_code: 1,
+              authz_sync_started_at: 1,
             },
           },
         )
@@ -472,6 +505,32 @@ async function aggregateLocally(
           description: String(doc.description).slice(0, 1024),
           source: "agent_skills",
           source_id: doc.owner_id ?? null,
+          owner_id: doc.owner_id ? String(doc.owner_id) : null,
+          ...(typeof doc.owner_subject === "string"
+            ? { owner_subject: doc.owner_subject }
+            : {}),
+          ...(doc.visibility === "private" ||
+          doc.visibility === "team" ||
+          doc.visibility === "global"
+            ? { visibility: doc.visibility }
+            : {}),
+          ...(typeof doc.authz_revision === "number"
+            ? { authz_revision: doc.authz_revision }
+            : {}),
+          ...(doc.authz_sync_state === "pending" ||
+          doc.authz_sync_state === "ready" ||
+          doc.authz_sync_state === "error"
+            ? { authz_sync_state: doc.authz_sync_state }
+            : {}),
+          ...(typeof doc.authz_last_synced_revision === "number"
+            ? { authz_last_synced_revision: doc.authz_last_synced_revision }
+            : {}),
+          ...(typeof doc.authz_last_error_code === "string"
+            ? { authz_last_error_code: doc.authz_last_error_code }
+            : {}),
+          ...(typeof doc.authz_sync_started_at === "string"
+            ? { authz_sync_started_at: doc.authz_sync_started_at }
+            : {}),
           content: includeContent ? content : null,
           metadata: {
             ...doc.metadata,
@@ -681,6 +740,7 @@ export const GET = withErrorHandler(async (req: NextRequest) => {
   const params = parseQueryParams(req);
   const skillAuth = {
     subject: typeof session?.sub === "string" ? `user:${session.sub}` : null,
+    ownerEmail: user.email,
     mode: params.includeContent ? ("use" as const) : ("read" as const),
     isAdmin: user.role === "admin" || session?.role === "admin",
   };

--- a/ui/src/app/api/workflow-configs/route.ts
+++ b/ui/src/app/api/workflow-configs/route.ts
@@ -1,32 +1,40 @@
 import {
-ApiError,
-successResponse,
-withAuth,
-withErrorHandler,
+  ApiError,
+  successResponse,
+  withAuth,
+  withErrorHandler,
 } from "@/lib/api-middleware";
-import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
+import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
 import {
-filterAccessibleWorkflowConfigs,
-workflowAccessAllowed,
+  AuthzSyncSupersededError,
+  authzRevisionFilter,
+  hasActiveAuthzSync,
+  nextAuthzRevision,
+  runRevisionedAuthzSync,
+} from "@/lib/authz/resource-sync";
+import { deleteAllWorkflowRelationshipTuples } from "@/lib/rbac/openfga-owned-resources-reconcile";
+import { validateWorkflowAgentDependencies } from "@/lib/rbac/workflow-agent-dependency-scope";
+import {
+  filterAccessibleWorkflowConfigs,
 } from "@/lib/server/workflow-cas-authz";
 import {
-buildTeamRefToSlugMap,
-filterWorkflowConfigsByRunAccess,
-mergeWorkflowConfigsById,
-normalizeSharedWithTeamSlugs,
-reconcileWorkflowConfigAccess,
-requireWorkflowConfigRunAccess,
-requireWorkflowConfigWriteAccess,
-resolveUserTeamSlugsForWorkflow,
+  buildTeamRefToSlugMap,
+  filterWorkflowConfigsByRunAccess,
+  mergeWorkflowConfigsById,
+  normalizeSharedWithTeamSlugs,
+  reconcileWorkflowConfigAccess,
+  requireWorkflowConfigRunAccess,
+  requireWorkflowConfigWriteAccess,
+  resolveUserTeamSlugsForWorkflow,
 } from "@/lib/rbac/workflow-config-rebac";
 import type {
-CreateWorkflowConfigInput,
-StepEntry,
-UpdateWorkflowConfigInput,
-WorkflowConfig,
-WorkflowConfigVisibility,
+  CreateWorkflowConfigInput,
+  StepEntry,
+  UpdateWorkflowConfigInput,
+  WorkflowConfig,
+  WorkflowConfigVisibility,
 } from "@/types/workflow-config";
-import { NextRequest,NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 /**
  * Workflow Config API Routes
@@ -37,7 +45,11 @@ import { NextRequest,NextResponse } from "next/server";
  */
 
 const STORAGE_TYPE = isMongoDBConfigured ? "mongodb" : "none";
-const VALID_VISIBILITIES: WorkflowConfigVisibility[] = ["private", "team", "global"];
+const VALID_VISIBILITIES: WorkflowConfigVisibility[] = [
+  "private",
+  "team",
+  "global",
+];
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -51,7 +63,7 @@ function validateSteps(steps: StepEntry[]): void {
     if (entry.type === "parallel") {
       throw new ApiError(
         "Parallel groups are not supported in v1. All steps must have type 'step'.",
-        400
+        400,
       );
     }
     if (entry.type !== "step") {
@@ -61,13 +73,16 @@ function validateSteps(steps: StepEntry[]): void {
     if (!entry.display_text || !entry.agent_id || !entry.prompt) {
       throw new ApiError(
         "Each step must have display_text, agent_id, and prompt",
-        400
+        400,
       );
     }
-    if (entry.on_error === "retry" && (!entry.retry || entry.retry.max_attempts < 1)) {
+    if (
+      entry.on_error === "retry" &&
+      (!entry.retry || entry.retry.max_attempts < 1)
+    ) {
       throw new ApiError(
         "Steps with on_error='retry' must have retry.max_attempts >= 1",
-        400
+        400,
       );
     }
   }
@@ -75,31 +90,91 @@ function validateSteps(steps: StepEntry[]): void {
 
 function validateVisibility(
   visibility: WorkflowConfigVisibility | undefined,
-  sharedWithTeams: string[] | undefined
+  sharedWithTeams: string[] | undefined,
 ): void {
   if (visibility !== undefined) {
     if (!VALID_VISIBILITIES.includes(visibility)) {
       throw new ApiError(
         `Invalid visibility: ${visibility}. Must be one of: ${VALID_VISIBILITIES.join(", ")}`,
-        400
+        400,
       );
     }
-    if (visibility === "team" && (!sharedWithTeams || sharedWithTeams.length === 0)) {
+    if (
+      visibility === "team" &&
+      (!sharedWithTeams || sharedWithTeams.length === 0)
+    ) {
       throw new ApiError(
         "At least one team must be selected when visibility is 'team'",
-        400
+        400,
       );
     }
   }
 }
 
+function stableSessionSubject(session: { sub?: unknown }): string {
+  const subject = typeof session.sub === "string" ? session.sub.trim() : "";
+  if (!subject) {
+    throw new ApiError(
+      "A stable user subject is required to own a workflow",
+      401,
+    );
+  }
+  return subject;
+}
+
+function normalizeTeamSet(values: string[] | null | undefined): string[] {
+  return [
+    ...new Set(
+      (values ?? []).map((value) => value.trim().toLowerCase()).filter(Boolean),
+    ),
+  ];
+}
+
+function sameStringSet(
+  left: readonly string[],
+  right: readonly string[],
+): boolean {
+  if (left.length !== right.length) return false;
+  const rightSet = new Set(right);
+  return left.every((value) => rightSet.has(value));
+}
+
+function workflowAuthzSnapshot(
+  config: WorkflowConfig,
+): Record<string, unknown> {
+  return {
+    visibility: config.visibility,
+    shared_with_teams: normalizeTeamSet(config.shared_with_teams),
+    owner_subject: config.owner_subject,
+  };
+}
+
+function previousWorkflowAuthzState(config: WorkflowConfig): WorkflowConfig {
+  return config.authz_previous_state
+    ? ({
+        ...config,
+        ...config.authz_previous_state,
+        authz_previous_state: undefined,
+      } as WorkflowConfig)
+    : config;
+}
+
+function isPrivateWorkflowOwner(
+  config: WorkflowConfig,
+  userEmail: string,
+  sessionSubject: string,
+): boolean {
+  if (config.visibility !== "private") return true;
+  if (config.owner_subject) return config.owner_subject === sessionSubject;
+  return (
+    config.owner_id.trim().toLowerCase() === userEmail.trim().toLowerCase()
+  );
+}
+
 async function getVisibleConfigs(): Promise<WorkflowConfig[]> {
   const collection = await getCollection<WorkflowConfig>("workflow_configs");
 
-  return collection
-    .find({})
-    .sort({ name: 1 })
-    .toArray();
+  return collection.find({}).sort({ name: 1 }).toArray();
 }
 
 async function getVisibleConfigById(
@@ -123,45 +198,32 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const id = searchParams.get("id");
 
   return await withAuth(request, async (_req, user, session) => {
-    // Admins can see all workflow configs
-    if (user.role === "admin") {
-      const collection = await getCollection<WorkflowConfig>("workflow_configs");
-      if (id) {
-        const config = await collection.findOne({ _id: id });
-        if (!config) throw new ApiError("Workflow config not found", 404);
-        return NextResponse.json(config) as NextResponse;
-      }
-      const configs = await collection.find({}).sort({ name: 1 }).toArray();
-      return NextResponse.json(configs) as NextResponse;
-    }
-
-    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+    const sessionSubject = stableSessionSubject(session);
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(
+      user.email,
+      session,
+    );
 
     if (id) {
       const config = await getVisibleConfigById(id);
       if (!config) {
         throw new ApiError("Workflow config not found", 404);
       }
-      // Additive CAS read (Phase 2) — mirrors the list's "visibility ∪ FGA read"
-      // semantics: if CAS grants task#read (org-admin bypass included) serve it;
-      // otherwise fall back to the legacy visibility check unchanged.
-      if (!(await workflowAccessAllowed(session, String(config._id), "read"))) {
-        await requireWorkflowConfigRunAccess(
-          session,
-          {
-            _id: String(config._id),
-            owner_id: config.owner_id,
-            visibility: config.visibility,
-            shared_with_teams: config.shared_with_teams,
-          },
-          user.email,
-          userTeamSlugs,
-        );
+      if (!isPrivateWorkflowOwner(config, user.email, sessionSubject)) {
+        throw new ApiError("Workflow config not found", 404);
       }
+      await requireWorkflowConfigRunAccess(
+        session,
+        config,
+        user.email,
+        userTeamSlugs,
+      );
       return NextResponse.json(config) as NextResponse;
     }
 
-    const configs = await getVisibleConfigs();
+    const configs = (await getVisibleConfigs()).filter((config) =>
+      isPrivateWorkflowOwner(config, user.email, sessionSubject),
+    );
     const teamRefToSlug = await buildTeamRefToSlugMap();
     const byVisibility = filterWorkflowConfigsByRunAccess(
       configs,
@@ -209,6 +271,7 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
 
     const id = `wf-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date();
+    const ownerSubject = stableSessionSubject(session);
 
     const config: WorkflowConfig = {
       _id: id,
@@ -216,18 +279,51 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
       description: body.description,
       steps: body.steps,
       owner_id: user.email,
+      owner_subject: ownerSubject,
       visibility,
-      shared_with_teams: sharedWithTeams,
+      shared_with_teams: sharedWithTeams ?? [],
+      authz_revision: 1,
+      authz_sync_state: "ready",
+      authz_last_synced_revision: 1,
       created_at: now,
       updated_at: now,
     };
 
+    await validateWorkflowAgentDependencies({
+      session,
+      workflow: { visibility, ownerSubject, ownerEmail: user.email },
+      steps: body.steps,
+    });
+
     const collection = await getCollection<WorkflowConfig>("workflow_configs");
-    await collection.insertOne(config);
+    await reconcileWorkflowConfigAccess(session, config, null, {
+      ownerSubject,
+      context: {
+        caller: { type: "user", id: ownerSubject },
+        source: "workflow_create",
+        verifyHigherConsistency: true,
+      },
+    });
+    try {
+      await collection.insertOne(config);
+    } catch (error) {
+      await deleteAllWorkflowRelationshipTuples(id, {
+        caller: { type: "user", id: ownerSubject },
+        source: "workflow_create_rollback",
+        verifyHigherConsistency: true,
+      }).catch((cleanupError) => {
+        console.warn(
+          "[workflow-configs] Failed to clean up authorization after create failure",
+          cleanupError,
+        );
+      });
+      throw error;
+    }
 
-    await reconcileWorkflowConfigAccess(session, config);
-
-    return successResponse({ id, message: "Workflow config created successfully" }, 201);
+    return successResponse(
+      { id, message: "Workflow config created successfully" },
+      201,
+    );
   });
 });
 
@@ -260,21 +356,41 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       throw new ApiError("Workflow config not found", 404);
     }
     if (existing.config_driven) {
-      throw new ApiError("Cannot modify a config-driven workflow. Edit app-config.yaml instead.", 403);
-    }
-
-    if (user.role !== "admin") {
-      await requireWorkflowConfigWriteAccess(
-        session,
-        {
-          _id: id,
-          owner_id: existing.owner_id,
-          visibility: existing.visibility,
-          shared_with_teams: existing.shared_with_teams,
-        },
-        user.email,
+      throw new ApiError(
+        "Cannot modify a config-driven workflow. Edit app-config.yaml instead.",
+        403,
       );
     }
+    const sessionSubject = stableSessionSubject(session);
+    if (!isPrivateWorkflowOwner(existing, user.email, sessionSubject)) {
+      throw new ApiError("Workflow config not found", 404);
+    }
+    if (hasActiveAuthzSync(existing)) {
+      throw new ApiError(
+        "This workflow's authorization is already being reconciled. Retry shortly.",
+        409,
+        "AUTHZ_SYNC_PENDING",
+      );
+    }
+    const previousAuthzState = previousWorkflowAuthzState(existing);
+    const ownerSubject =
+      existing.owner_subject ??
+      (existing.owner_id.trim().toLowerCase() ===
+      user.email.trim().toLowerCase()
+        ? sessionSubject
+        : null);
+
+    await requireWorkflowConfigWriteAccess(
+      session,
+      {
+        _id: id,
+        owner_id: existing.owner_id,
+        owner_subject: existing.owner_subject,
+        visibility: existing.visibility,
+        shared_with_teams: existing.shared_with_teams,
+      },
+      user.email,
+    );
 
     if (body.steps) {
       validateSteps(body.steps);
@@ -286,48 +402,159 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
       }
     }
     if (body.shared_with_teams?.length) {
-      body.shared_with_teams = await normalizeSharedWithTeamSlugs(body.shared_with_teams);
+      body.shared_with_teams = await normalizeSharedWithTeamSlugs(
+        body.shared_with_teams,
+      );
     }
 
     const mergedVisibility = body.visibility ?? existing.visibility;
     let mergedSharedWithTeams =
       mergedVisibility === "team"
-        ? body.shared_with_teams ?? existing.shared_with_teams
+        ? (body.shared_with_teams ?? existing.shared_with_teams)
         : mergedVisibility !== undefined
           ? undefined
           : existing.shared_with_teams;
 
     if (mergedVisibility === "team" && mergedSharedWithTeams?.length) {
       mergedSharedWithTeams =
-        (await normalizeSharedWithTeamSlugs(mergedSharedWithTeams)) ?? undefined;
+        (await normalizeSharedWithTeamSlugs(mergedSharedWithTeams)) ??
+        undefined;
     }
 
     const updateFields: Record<string, unknown> = {
       ...body,
+      visibility: mergedVisibility,
+      shared_with_teams: mergedSharedWithTeams ?? [],
+      ...(ownerSubject ? { owner_subject: ownerSubject } : {}),
       updated_at: new Date(),
     };
-    if (mergedVisibility === "team") {
-      updateFields.shared_with_teams = mergedSharedWithTeams;
-    } else if (
-      body.visibility !== undefined &&
-      (mergedVisibility === "private" || mergedVisibility === "global")
-    ) {
-      updateFields.shared_with_teams = undefined;
-    }
-
-    await collection.updateOne({ _id: id }, { $set: updateFields });
-
     const merged = {
       ...existing,
-      ...body,
+      ...updateFields,
       _id: id,
       visibility: mergedVisibility,
-      shared_with_teams: mergedSharedWithTeams,
-    };
+      shared_with_teams: mergedSharedWithTeams ?? [],
+    } as WorkflowConfig;
+    await validateWorkflowAgentDependencies({
+      session,
+      workflow: {
+        visibility: mergedVisibility,
+        ownerSubject: ownerSubject ?? sessionSubject,
+        ownerEmail: existing.owner_id,
+      },
+      steps: merged.steps,
+    });
+    const previousVisibility = previousAuthzState.visibility;
+    const previousTeams = normalizeTeamSet(
+      previousAuthzState.shared_with_teams,
+    );
+    const nextTeams = normalizeTeamSet(merged.shared_with_teams);
+    const reconcile = (verifyHigherConsistency: boolean) =>
+      reconcileWorkflowConfigAccess(session, merged, previousAuthzState, {
+        ownerSubject,
+        context: {
+          caller: { type: "user", id: sessionSubject },
+          source: "workflow_update",
+          verifyHigherConsistency,
+        },
+      });
+    const authzMutationRequired =
+      existing.authz_sync_state !== "ready" ||
+      existing.authz_revision !== existing.authz_last_synced_revision ||
+      !existing.owner_subject ||
+      mergedVisibility !== previousVisibility ||
+      !sameStringSet(previousTeams, nextTeams);
 
-    await reconcileWorkflowConfigAccess(session, merged, existing);
+    let updated: WorkflowConfig | null;
+    if (!authzMutationRequired) {
+      await reconcile(false);
+      updated = await collection.findOneAndUpdate(
+        { _id: id },
+        { $set: updateFields },
+        { returnDocument: "after" },
+      );
+    } else {
+      const revision = nextAuthzRevision(existing);
+      const pending = await collection.findOneAndUpdate(
+        { _id: id, ...authzRevisionFilter(existing) },
+        {
+          $set: {
+            ...updateFields,
+            authz_revision: revision,
+            authz_sync_state: "pending",
+            authz_sync_started_at: new Date().toISOString(),
+            authz_previous_state:
+              existing.authz_previous_state ?? workflowAuthzSnapshot(existing),
+          },
+          $unset: { authz_last_error_code: "" },
+        },
+        { returnDocument: "after" },
+      );
+      if (!pending) {
+        throw new ApiError(
+          "This workflow changed while authorization was being prepared. Retry the save.",
+          409,
+          "AUTHZ_SYNC_SUPERSEDED",
+        );
+      }
+      try {
+        updated = await runRevisionedAuthzSync({
+          reconcile: async () => {
+            await reconcile(true);
+          },
+          markError: async (errorCode) => {
+            await collection.findOneAndUpdate(
+              {
+                _id: id,
+                authz_revision: revision,
+                authz_sync_state: "pending",
+              },
+              {
+                $set: {
+                  authz_sync_state: "error",
+                  authz_last_error_code: errorCode,
+                },
+                $unset: { authz_sync_started_at: "" },
+              },
+            );
+          },
+          markReady: () =>
+            collection.findOneAndUpdate(
+              {
+                _id: id,
+                authz_revision: revision,
+                authz_sync_state: "pending",
+              },
+              {
+                $set: {
+                  authz_sync_state: "ready",
+                  authz_last_synced_revision: revision,
+                },
+                $unset: {
+                  authz_last_error_code: "",
+                  authz_previous_state: "",
+                  authz_sync_started_at: "",
+                },
+              },
+              { returnDocument: "after" },
+            ),
+        });
+      } catch (error) {
+        if (error instanceof AuthzSyncSupersededError) {
+          throw new ApiError(error.message, 409, "AUTHZ_SYNC_SUPERSEDED");
+        }
+        throw error;
+      }
+    }
+    if (!updated) throw new ApiError("Failed to update workflow config", 500);
 
-    return successResponse({ id, message: "Workflow config updated successfully" });
+    return successResponse({
+      id,
+      message: "Workflow config updated successfully",
+      authz_revision: updated.authz_revision,
+      authz_sync_state: updated.authz_sync_state,
+      authz_last_synced_revision: updated.authz_last_synced_revision,
+    });
   });
 });
 
@@ -354,23 +581,36 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
       throw new ApiError("Workflow config not found", 404);
     }
     if (existing.config_driven) {
-      throw new ApiError("Cannot delete a config-driven workflow. Remove it from app-config.yaml instead.", 403);
-    }
-
-    if (user.role !== "admin") {
-      await requireWorkflowConfigWriteAccess(
-        session,
-        {
-          _id: id,
-          owner_id: existing.owner_id,
-          visibility: existing.visibility,
-          shared_with_teams: existing.shared_with_teams,
-        },
-        user.email,
+      throw new ApiError(
+        "Cannot delete a config-driven workflow. Remove it from app-config.yaml instead.",
+        403,
       );
     }
+    const sessionSubject = stableSessionSubject(session);
+    if (!isPrivateWorkflowOwner(existing, user.email, sessionSubject)) {
+      throw new ApiError("Workflow config not found", 404);
+    }
+    await requireWorkflowConfigWriteAccess(
+      session,
+      {
+        _id: id,
+        owner_id: existing.owner_id,
+        owner_subject: existing.owner_subject,
+        visibility: existing.visibility,
+        shared_with_teams: existing.shared_with_teams,
+      },
+      user.email,
+    );
 
+    await deleteAllWorkflowRelationshipTuples(id, {
+      caller: { type: "user", id: sessionSubject },
+      source: "workflow_delete",
+      verifyHigherConsistency: true,
+    });
     await collection.deleteOne({ _id: id });
-    return successResponse({ id, message: "Workflow config deleted successfully" });
+    return successResponse({
+      id,
+      message: "Workflow config deleted successfully",
+    });
   });
 });

--- a/ui/src/app/api/workflow-runs/route.ts
+++ b/ui/src/app/api/workflow-runs/route.ts
@@ -9,63 +9,85 @@
  */
 
 import {
-ApiError,
-getAuthFromBearerOrSession,
-successResponse,
-withAuth,
-withErrorHandler,
+  ApiError,
+  getAuthFromBearerOrSession,
+  successResponse,
+  withAuth,
+  withErrorHandler,
 } from "@/lib/api-middleware";
-import { getCollection,isMongoDBConfigured } from "@/lib/mongodb";
+import { getCollection, isMongoDBConfigured } from "@/lib/mongodb";
 import {
-detectStaleRun,
-startWorkflowRun,
-type WorkflowRunDocument,
+  detectStaleRun,
+  startWorkflowRun,
+  type WorkflowRunDocument,
 } from "@/lib/server/workflow-engine";
-import { deleteEventsByRun,readEventsByRun } from "@/lib/server/event-store";
+import { deleteEventsByRun, readEventsByRun } from "@/lib/server/event-store";
 import {
-filterAccessibleWorkflowConfigs,
-requireWorkflowRunAccess,
-workflowSubjectFromSession,
-type WorkflowAuthzSession,
+  filterAccessibleWorkflowConfigs,
+  requireWorkflowRunAccess,
+  workflowSubjectFromSession,
+  type WorkflowAuthzSession,
 } from "@/lib/server/workflow-cas-authz";
 import {
-buildTeamRefToSlugMap,
-filterWorkflowConfigsByRunAccess,
-mergeWorkflowConfigsById,
-requireWorkflowConfigRunAccess,
-requireWorkflowConfigRunViewAccess,
-resolveUserTeamSlugsForWorkflow,
-type WorkflowConfigRebacSnapshot,
+  buildTeamRefToSlugMap,
+  filterWorkflowConfigsByRunAccess,
+  mergeWorkflowConfigsById,
+  requireWorkflowConfigRunAccess,
+  requireWorkflowConfigRunViewAccess,
+  resolveUserTeamSlugsForWorkflow,
+  type WorkflowConfigRebacSnapshot,
 } from "@/lib/rbac/workflow-config-rebac";
 import type { WorkflowConfig } from "@/types/workflow-config";
-import { NextRequest,NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 const STORAGE_TYPE = isMongoDBConfigured ? "mongodb" : "none";
 
 /** Days to retain workflow runs before auto-cleanup. 0 = disabled. */
-const RETENTION_DAYS = parseInt(process.env.WORKFLOW_RUN_RETENTION_DAYS ?? "7", 10);
+const RETENTION_DAYS = parseInt(
+  process.env.WORKFLOW_RUN_RETENTION_DAYS ?? "7",
+  10,
+);
 
 /** Throttle cleanup to run at most once per 30 minutes */
 let lastCleanupAt = 0;
 const CLEANUP_INTERVAL_MS = 30 * 60 * 1000;
 
-function ownerMatchesSession(run: WorkflowRunDocument, session: WorkflowAuthzSession): boolean {
+function ownerMatchesSession(
+  run: WorkflowRunDocument,
+  session: WorkflowAuthzSession,
+): boolean {
   const subject = workflowSubjectFromSession(session);
   if (!subject) return false;
-  return run.owner_subject?.type === subject.type && run.owner_subject.id === subject.id;
+  return (
+    run.owner_subject?.type === subject.type &&
+    run.owner_subject.id === subject.id
+  );
 }
 
-function filterRunsForOwner<T extends WorkflowRunDocument>(runs: T[], session: WorkflowAuthzSession): T[] {
-  return runs.filter((run) => !run.owner_subject || ownerMatchesSession(run, session));
+function filterRunsForOwner<T extends WorkflowRunDocument>(
+  runs: T[],
+  session: WorkflowAuthzSession,
+): T[] {
+  return runs.filter(
+    (run) => !run.owner_subject || ownerMatchesSession(run, session),
+  );
 }
 
-function workflowRunAccessConfig(config: WorkflowConfig): WorkflowConfigRebacSnapshot {
+function workflowRunAccessConfig(
+  config: WorkflowConfig,
+): WorkflowConfigRebacSnapshot {
   return {
     _id: String(config._id),
     owner_id: config.owner_id,
+    owner_subject: config.owner_subject,
     visibility: config.visibility,
     shared_with_teams: config.shared_with_teams,
     config_driven: config.config_driven,
+    authz_revision: config.authz_revision,
+    authz_sync_state: config.authz_sync_state,
+    authz_last_synced_revision: config.authz_last_synced_revision,
+    authz_last_error_code: config.authz_last_error_code,
+    authz_sync_started_at: config.authz_sync_started_at,
   };
 }
 
@@ -104,24 +126,34 @@ async function cleanupExpiredRuns(): Promise<void> {
       const runId = run._id as string;
       // Clean up files (best-effort)
       try {
-        const fsNamespace = JSON.stringify([run.workflow_config_id, runId, "filesystem"]);
+        const fsNamespace = JSON.stringify([
+          run.workflow_config_id,
+          runId,
+          "filesystem",
+        ]);
         await fetch(
           `${daUrl}/api/v1/files/namespace?fs_namespace=${encodeURIComponent(fsNamespace)}`,
           { method: "DELETE" },
         );
-      } catch { /* best-effort */ }
+      } catch {
+        /* best-effort */
+      }
 
       // Clean up events (best-effort)
       try {
         await deleteEventsByRun(runId);
-      } catch { /* best-effort */ }
+      } catch {
+        /* best-effort */
+      }
     }
 
     // Bulk delete the run documents
     const ids = expiredRuns.map((r) => r._id);
     await col.deleteMany({ _id: { $in: ids } });
 
-    console.log(`[workflow-cleanup] Deleted ${expiredRuns.length} expired workflow runs (retention: ${RETENTION_DAYS}d)`);
+    console.log(
+      `[workflow-cleanup] Deleted ${expiredRuns.length} expired workflow runs (retention: ${RETENTION_DAYS}d)`,
+    );
   } catch (err) {
     console.warn("[workflow-cleanup] Error during cleanup:", err);
   }
@@ -154,7 +186,10 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   // Start uses the same visibility ∪ authorization semantics as workflow config
   // reads, so global/team/owner-visible workflows remain runnable before every
   // legacy row has been projected into OpenFGA.
-  const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+  const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(
+    user.email,
+    session,
+  );
   await requireWorkflowConfigRunAccess(
     session,
     workflowRunAccessConfig(config),
@@ -168,18 +203,21 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
   // run-owner's token.
   const authHeaders: Record<string, string> = {};
   const incomingAuth = request.headers.get("Authorization");
-  const sessionAccessToken = typeof (session as { accessToken?: unknown }).accessToken === "string"
-    ? (session as { accessToken?: string }).accessToken
-    : undefined;
+  const sessionAccessToken =
+    typeof (session as { accessToken?: unknown }).accessToken === "string"
+      ? (session as { accessToken?: string }).accessToken
+      : undefined;
   if (incomingAuth) {
     authHeaders["Authorization"] = incomingAuth;
   } else if (sessionAccessToken) {
     authHeaders["Authorization"] = `Bearer ${sessionAccessToken}`;
   }
-  authHeaders["X-User-Context"] = Buffer.from(JSON.stringify({
-    email: user.email,
-    name: user.name,
-  })).toString("base64");
+  authHeaders["X-User-Context"] = Buffer.from(
+    JSON.stringify({
+      email: user.email,
+      name: user.name,
+    }),
+  ).toString("base64");
 
   // Enrich trigger_info with user context
   const enrichedTriggerInfo = {
@@ -196,7 +234,10 @@ export const POST = withErrorHandler(async (request: NextRequest) => {
     workflowSubjectFromSession(session),
   );
 
-  return NextResponse.json({ run_id: runId, status: "running" }, { status: 201 });
+  return NextResponse.json(
+    { run_id: runId, status: "running" },
+    { status: 201 },
+  );
 });
 
 // ═══════════════════════════════════════════════════════════════
@@ -262,7 +303,10 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
     if (!config) {
       return NextResponse.json([]) as NextResponse;
     }
-    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+    const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(
+      user.email,
+      session,
+    );
     try {
       await requireWorkflowConfigRunViewAccess(
         session,
@@ -288,9 +332,23 @@ export const GET = withErrorHandler(async (request: NextRequest) => {
   const configCol = await getCollection<WorkflowConfig>("workflow_configs");
   const configCandidates = (await configCol
     .find({})
-    .project({ _id: 1, owner_id: 1, visibility: 1, shared_with_teams: 1, config_driven: 1 })
+    .project({
+      _id: 1,
+      owner_id: 1,
+      visibility: 1,
+      shared_with_teams: 1,
+      config_driven: 1,
+      authz_revision: 1,
+      authz_sync_state: 1,
+      authz_last_synced_revision: 1,
+      authz_last_error_code: 1,
+      authz_sync_started_at: 1,
+    })
     .toArray()) as WorkflowConfigRebacSnapshot[];
-  const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(user.email, session);
+  const userTeamSlugs = await resolveUserTeamSlugsForWorkflow(
+    user.email,
+    session,
+  );
   const teamRefToSlug = await buildTeamRefToSlugMap();
   const byVisibility = filterWorkflowConfigsByRunAccess(
     configCandidates,
@@ -350,7 +408,10 @@ export const PUT = withErrorHandler(async (request: NextRequest) => {
 
     await col.updateOne({ _id: id }, { $set: body });
 
-    return successResponse({ id, message: "Workflow run updated successfully" });
+    return successResponse({
+      id,
+      message: "Workflow run updated successfully",
+    });
   });
 });
 
@@ -383,16 +444,22 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
     // Clean up GridFS files via backend
     try {
       const daUrl = process.env.DYNAMIC_AGENTS_URL || "http://localhost:8100";
-      const fsNamespace = JSON.stringify([run.workflow_config_id, id, "filesystem"]);
+      const fsNamespace = JSON.stringify([
+        run.workflow_config_id,
+        id,
+        "filesystem",
+      ]);
       await fetch(
         `${daUrl}/api/v1/files/namespace?fs_namespace=${encodeURIComponent(fsNamespace)}`,
         {
           method: "DELETE",
           headers: {
-            "X-User-Context": Buffer.from(JSON.stringify({
-              email: user.email,
-              name: user.name,
-            })).toString("base64"),
+            "X-User-Context": Buffer.from(
+              JSON.stringify({
+                email: user.email,
+                name: user.name,
+              }),
+            ).toString("base64"),
           },
         },
       );
@@ -410,6 +477,9 @@ export const DELETE = withErrorHandler(async (request: NextRequest) => {
     // Delete the run document
     await col.deleteOne({ _id: id });
 
-    return successResponse({ id, message: "Workflow run deleted successfully" });
+    return successResponse({
+      id,
+      message: "Workflow run deleted successfully",
+    });
   });
 });

--- a/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentEditor.tsx
@@ -12,6 +12,7 @@ buildLastReview,
 useAiReview,
 } from "@/components/ai-review";
 import { TeamOwnershipFields } from "@/components/rbac/TeamOwnershipFields";
+import { AuthorizationSyncStatus } from "@/components/shared/AuthorizationSyncStatus";
 import { UnsavedChangesDialog } from "@/components/shared/UnsavedChangesDialog";
 import { Button } from "@/components/ui/button";
 import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
@@ -1197,14 +1198,23 @@ export function DynamicAgentEditor({
                 : "Configure a new custom AI agent"}
             </CardDescription>
           </div>
-          <AgentAvatar
-            gradientTheme={gradientTheme}
-            customThemeConfig={gradientTheme === "custom" ? customThemeConfig : undefined}
-            rounded="rounded-lg"
-            size="ml-auto h-9 w-9"
-            iconSize="h-5 w-5"
-            className="transition-all"
-          />
+          <div className="ml-auto flex items-center gap-3">
+            <AuthorizationSyncStatus
+              document={agent}
+              busy={loading}
+              canRetry={!readOnly}
+            />
+            <AgentAvatar
+              gradientTheme={gradientTheme}
+              customThemeConfig={
+                gradientTheme === "custom" ? customThemeConfig : undefined
+              }
+              rounded="rounded-lg"
+              size="h-9 w-9"
+              iconSize="h-5 w-5"
+              className="transition-all"
+            />
+          </div>
         </div>
       </CardHeader>
       <CardContent>

--- a/ui/src/components/dynamic-agents/MCPServerEditor.tsx
+++ b/ui/src/components/dynamic-agents/MCPServerEditor.tsx
@@ -2,6 +2,7 @@
 
 // assisted-by Codex Codex-sonnet-4-6
 
+import { AuthorizationSyncStatus } from "@/components/shared/AuthorizationSyncStatus";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card,CardContent,CardDescription,CardHeader,CardTitle } from "@/components/ui/card";
@@ -663,6 +664,12 @@ export function MCPServerEditor({ server, readOnly, onSave, onCancel, initialVal
                 : "Configure a new MCP server connection"}
             </CardDescription>
           </div>
+          <AuthorizationSyncStatus
+            document={server}
+            busy={loading}
+            canRetry={!readOnly}
+            className="ml-auto"
+          />
         </div>
       </CardHeader>
       <CardContent>

--- a/ui/src/components/dynamic-agents/__tests__/DynamicAgentEditor.platform-default.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/DynamicAgentEditor.platform-default.test.tsx
@@ -159,4 +159,23 @@ describe("DynamicAgentEditor — platform default grant preview", () => {
     expect(option).not.toHaveTextContent("user:*");
     expect(option).not.toHaveTextContent("OpenFGA");
   });
+
+  it("shows authorization reconciliation beside the agent builder", async () => {
+    mockFetch(null);
+    render(
+      <DynamicAgentEditor
+        agent={{
+          ...editAgent,
+          authz_sync_state: "ready",
+          authz_revision: 2,
+          authz_last_synced_revision: 2,
+        }}
+        onCancel={jest.fn()}
+        onSave={jest.fn()}
+      />,
+    );
+    await flushAsync();
+
+    expect(screen.getByRole("status")).toHaveTextContent("Access synced");
+  });
 });

--- a/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServerEditor.credentials.test.tsx
@@ -118,6 +118,27 @@ describe("MCPServerEditor credential sources", () => {
     expect(screen.queryByText("Share with teams")).not.toBeInTheDocument();
   });
 
+  it("shows pending authorization reconciliation beside the MCP builder", () => {
+    render(
+      <MCPServerEditor
+        server={{
+          _id: "syncing-tools",
+          name: "Syncing Tools",
+          transport: "http",
+          endpoint: "https://mcp.example.test/mcp",
+          visibility: "private",
+          authz_sync_state: "pending",
+          authz_revision: 2,
+          authz_last_synced_revision: 1,
+        }}
+        onSave={jest.fn()}
+        onCancel={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Syncing access");
+  });
+
   it("creates header and environment secret refs from selectable secrets", async () => {
     const user = userEvent.setup();
     render(<MCPServerEditor server={null} onSave={jest.fn()} onCancel={jest.fn()} />);

--- a/ui/src/components/shared/AuthorizationSyncStatus.tsx
+++ b/ui/src/components/shared/AuthorizationSyncStatus.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { cn } from "@/lib/utils";
+import type { AuthzSyncMetadata } from "@/types/dynamic-agent";
+import { Loader2, ShieldAlert, ShieldCheck } from "lucide-react";
+
+type AuthorizationSyncPresentation = {
+  label: string;
+  description: string;
+  icon: typeof ShieldCheck;
+  className: string;
+  animate?: boolean;
+};
+
+function syncPresentation(
+  document: AuthzSyncMetadata | null | undefined,
+  busy: boolean,
+  canRetry: boolean,
+): AuthorizationSyncPresentation | null {
+  if (busy || document?.authz_sync_state === "pending") {
+    return {
+      label: "Syncing access",
+      description:
+        "Applying ownership and sharing access. Using this resource is briefly paused.",
+      icon: Loader2,
+      className:
+        "border-sky-500/25 bg-sky-500/10 text-sky-700 dark:text-sky-300",
+      animate: true,
+    };
+  }
+
+  const rawRevision = document?.authz_revision;
+  const revision =
+    Number.isSafeInteger(rawRevision) && (rawRevision ?? -1) >= 0
+      ? rawRevision ?? 0
+      : 0;
+  const revisionMismatch =
+    document?.authz_sync_state === "ready" &&
+    revision !== document.authz_last_synced_revision;
+  if (document?.authz_sync_state === "error" || revisionMismatch) {
+    return {
+      label: "Access sync needed",
+      description: canRetry
+        ? "Ownership and sharing access could not be synced. Save again to retry; use remains paused until it succeeds."
+        : "Ownership and sharing access could not be synced. Use remains paused until an administrator repairs it.",
+      icon: ShieldAlert,
+      className:
+        "border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300",
+    };
+  }
+
+  if (document?.authz_sync_state === "ready") {
+    return {
+      label: "Access synced",
+      description: "Ownership and sharing access are in sync.",
+      icon: ShieldCheck,
+      className: "border-border/60 bg-muted/40 text-muted-foreground",
+    };
+  }
+
+  return null;
+}
+
+export function AuthorizationSyncStatus({
+  document,
+  busy = false,
+  canRetry = true,
+  className,
+}: {
+  document?: AuthzSyncMetadata | null;
+  busy?: boolean;
+  canRetry?: boolean;
+  className?: string;
+}) {
+  const presentation = syncPresentation(document, busy, canRetry);
+  if (!presentation) return null;
+
+  const Icon = presentation.icon;
+  return (
+    <TooltipProvider delayDuration={250}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            role="status"
+            aria-label={presentation.label}
+            className={cn(
+              "inline-flex h-7 items-center gap-1.5 rounded-full border px-2.5 text-xs font-medium",
+              presentation.className,
+              className,
+            )}
+          >
+            <Icon
+              className={cn("h-3.5 w-3.5", presentation.animate && "animate-spin")}
+              aria-hidden="true"
+            />
+            <span className="hidden sm:inline">{presentation.label}</span>
+          </span>
+        </TooltipTrigger>
+        <TooltipContent className="max-w-64 text-xs">
+          {presentation.description}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/ui/src/components/shared/AuthorizationSyncStatus.tsx
+++ b/ui/src/components/shared/AuthorizationSyncStatus.tsx
@@ -7,7 +7,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
-import type { AuthzSyncMetadata } from "@/types/dynamic-agent";
+import type { AuthzSyncMetadata } from "@/types/authz-sync";
 import { Loader2, ShieldAlert, ShieldCheck } from "lucide-react";
 
 type AuthorizationSyncPresentation = {
@@ -38,7 +38,7 @@ function syncPresentation(
   const rawRevision = document?.authz_revision;
   const revision =
     Number.isSafeInteger(rawRevision) && (rawRevision ?? -1) >= 0
-      ? rawRevision ?? 0
+      ? (rawRevision ?? 0)
       : 0;
   const revisionMismatch =
     document?.authz_sync_state === "ready" &&
@@ -96,7 +96,10 @@ export function AuthorizationSyncStatus({
             )}
           >
             <Icon
-              className={cn("h-3.5 w-3.5", presentation.animate && "animate-spin")}
+              className={cn(
+                "h-3.5 w-3.5",
+                presentation.animate && "animate-spin",
+              )}
               aria-hidden="true"
             />
             <span className="hidden sm:inline">{presentation.label}</span>

--- a/ui/src/components/shared/__tests__/AuthorizationSyncStatus.test.tsx
+++ b/ui/src/components/shared/__tests__/AuthorizationSyncStatus.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+import { AuthorizationSyncStatus } from "../AuthorizationSyncStatus";
+
+describe("AuthorizationSyncStatus", () => {
+  it("stays hidden for resources without reconciliation metadata", () => {
+    const { container } = render(<AuthorizationSyncStatus document={{}} />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows a quiet healthy state with plain-language detail", async () => {
+    const user = userEvent.setup();
+    render(
+      <AuthorizationSyncStatus
+        document={{
+          authz_sync_state: "ready",
+          authz_revision: 3,
+          authz_last_synced_revision: 3,
+        }}
+      />,
+    );
+
+    const status = screen.getByRole("status");
+    expect(status).toHaveTextContent("Access synced");
+    await user.hover(status);
+    expect(await screen.findByText("Ownership and sharing access are in sync.")).toBeInTheDocument();
+  });
+
+  it("shows progress while a save is reconciling access", () => {
+    render(
+      <AuthorizationSyncStatus
+        document={{ authz_sync_state: "ready" }}
+        busy
+      />,
+    );
+
+    expect(screen.getByRole("status")).toHaveTextContent("Syncing access");
+  });
+
+  it.each([
+    { authz_sync_state: "error" as const },
+    { authz_sync_state: "ready" as const },
+    {
+      authz_sync_state: "ready" as const,
+      authz_revision: 4,
+      authz_last_synced_revision: 3,
+    },
+  ])("shows a retryable state when access is not in sync", (document) => {
+    render(<AuthorizationSyncStatus document={document} />);
+
+    expect(screen.getByRole("status")).toHaveTextContent("Access sync needed");
+  });
+});

--- a/ui/src/components/skills/workspace/SkillWorkspace.tsx
+++ b/ui/src/components/skills/workspace/SkillWorkspace.tsx
@@ -25,48 +25,46 @@
  */
 
 import {
-ArrowLeft,
-ArrowRight,
-Copy,
-Download,
-Eye,
-FileCode,
-History as HistoryIcon,
-Loader2,
-Save,
-Settings as SettingsIcon,
-ShieldCheck,
-Wrench,
+  ArrowLeft,
+  ArrowRight,
+  Copy,
+  Download,
+  Eye,
+  FileCode,
+  History as HistoryIcon,
+  Loader2,
+  Save,
+  Settings as SettingsIcon,
+  ShieldCheck,
+  Wrench,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import React,{ useCallback,useEffect,useMemo,useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
-Dialog,
-DialogContent,
-DialogDescription,
-DialogFooter,
-DialogHeader,
-DialogTitle,
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
 } from "@/components/ui/dialog";
-import {
-Tabs,
-TabsContent,
-TabsList,
-TabsTrigger,
-} from "@/components/ui/tabs";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useToast } from "@/components/ui/toast";
 import { getConfig } from "@/lib/config";
 import { pushWithNavigationProgress } from "@/lib/navigation-progress";
 import { cn } from "@/lib/utils";
 
-import { buildBlockingMessage,buildLastReview,useAiReview } from "@/components/ai-review";
-import { SkillScanStatusIndicator } from "@/components/skills/SkillScanStatusIndicator";
 import {
-useSkillForm,
-} from "@/components/skills/workspace/use-skill-form";
+  buildBlockingMessage,
+  buildLastReview,
+  useAiReview,
+} from "@/components/ai-review";
+import { AuthorizationSyncStatus } from "@/components/shared/AuthorizationSyncStatus";
+import { SkillScanStatusIndicator } from "@/components/skills/SkillScanStatusIndicator";
+import { useSkillForm } from "@/components/skills/workspace/use-skill-form";
 import { useUnsavedChangesStore } from "@/store/unsaved-changes-store";
 import type { AgentSkill } from "@/types/agent-skill";
 
@@ -89,11 +87,7 @@ import { VersionsTab } from "@/components/skills/workspace/tabs/VersionsTab";
  * the Files step) so old bookmarks don't 404 the editor.
  */
 export type SkillWorkspaceTabId =
-  | "overview"
-  | "files"
-  | "tools"
-  | "versions"
-  | "history";
+  "overview" | "files" | "tools" | "versions" | "history";
 
 export interface SkillWorkspaceProps {
   /** Existing saved skill (omit for new). */
@@ -221,17 +215,14 @@ export function SkillWorkspace({
         // the Scan tab polls for status on mount, so we don't need to
         // await it here.
         try {
-          void fetch(
-            `/api/skills/configs/${encodeURIComponent(id)}/scan`,
-            { method: "POST" },
-          );
+          void fetch(`/api/skills/configs/${encodeURIComponent(id)}/scan`, {
+            method: "POST",
+          });
         } catch {
           // Non-fatal — the Scan tab also exposes a manual "Scan now"
           // button. We deliberately swallow rather than block navigation.
         }
-        router.push(
-          `/skills/workspace/${encodeURIComponent(id)}?tab=scan`,
-        );
+        router.push(`/skills/workspace/${encodeURIComponent(id)}?tab=scan`);
       }
       // For updates we stay on the workspace so the user can keep editing.
     },
@@ -329,8 +320,8 @@ export function SkillWorkspace({
       form.guardedClose();
       return;
     }
-    pushWithNavigationProgress(router,backHref);
-  }, [form,router,backHref,trackDirty]);
+    pushWithNavigationProgress(router, backHref);
+  }, [form, router, backHref, trackDirty]);
 
   // Confirm + navigate. Prefer the pending external href (application-navigation click)
   // over `backHref` — when the user clicks "Chat" in the global header and
@@ -339,11 +330,9 @@ export function SkillWorkspace({
   const confirmDiscardAndNavigate = useCallback(() => {
     form.confirmDiscard();
     setUnsaved(false);
-    const externalHref = pendingNavigationHref
-      ? confirmNavigation()
-      : null;
+    const externalHref = pendingNavigationHref ? confirmNavigation() : null;
     const target = externalHref || backHref;
-    pushWithNavigationProgress(router,target);
+    pushWithNavigationProgress(router, target);
   }, [
     form,
     router,
@@ -503,8 +492,7 @@ export function SkillWorkspace({
       ? visibleSteps[currentIndex + 1]
       : null;
   const isFinalStep = nextStep === null;
-  const currentStepIsFullWidth =
-    visibleSteps[currentIndex]?.fullWidth ?? false;
+  const currentStepIsFullWidth = visibleSteps[currentIndex]?.fullWidth ?? false;
 
   // ---------------------------------------------------------------------
   // Save / Next gating — when AI Review is configured as `blocking` for
@@ -599,6 +587,11 @@ export function SkillWorkspace({
             {existingConfig && (
               <SkillScanStatusIndicator config={existingConfig} />
             )}
+            <AuthorizationSyncStatus
+              document={existingConfig}
+              busy={form.isSubmitting}
+              canRetry={!readOnly}
+            />
             {form.isDirty && !readOnly && (
               <Badge variant="secondary" className="text-[10px]">
                 Unsaved changes
@@ -726,9 +719,7 @@ export function SkillWorkspace({
                     <span
                       className={cn(
                         "hidden sm:inline-flex items-center gap-1 text-[11px] font-medium whitespace-nowrap",
-                        isActive
-                          ? "text-foreground"
-                          : "text-muted-foreground",
+                        isActive ? "text-foreground" : "text-muted-foreground",
                       )}
                     >
                       <Icon className="h-3 w-3 shrink-0" />
@@ -740,9 +731,7 @@ export function SkillWorkspace({
                       aria-hidden
                       className={cn(
                         "h-px flex-1 transition-colors",
-                        idx < currentIndex
-                          ? "bg-primary/40"
-                          : "bg-border/60",
+                        idx < currentIndex ? "bg-primary/40" : "bg-border/60",
                       )}
                     />
                   )}
@@ -882,8 +871,8 @@ export function SkillWorkspace({
           <DialogHeader>
             <DialogTitle>Discard unsaved changes?</DialogTitle>
             <DialogDescription>
-              You have unsaved edits to this skill. Leaving now will
-              discard them. This action cannot be undone.
+              You have unsaved edits to this skill. Leaving now will discard
+              them. This action cannot be undone.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>

--- a/ui/src/components/workflows/WorkflowCanvas.tsx
+++ b/ui/src/components/workflows/WorkflowCanvas.tsx
@@ -7,34 +7,34 @@ import { useUnsavedChangesStore } from "@/store/unsaved-changes-store";
 import { useWorkflowConfigStore } from "@/store/workflow-config-store";
 import { useWorkflowExecStore } from "@/store/workflow-exec-store";
 import type {
-CreateWorkflowConfigInput,
-UpdateWorkflowConfigInput,
-WorkflowConfig,
-WorkflowStep,
+  CreateWorkflowConfigInput,
+  UpdateWorkflowConfigInput,
+  WorkflowConfig,
+  WorkflowStep,
 } from "@/types/workflow-config";
 import { createBlankStep } from "@/types/workflow-config";
 import {
-Background,
-BackgroundVariant,
-Panel,
-ReactFlow,
-ReactFlowProvider,
-useReactFlow,
-type Edge,
-type Node,
-type NodeMouseHandler,
+  Background,
+  BackgroundVariant,
+  Panel,
+  ReactFlow,
+  ReactFlowProvider,
+  useReactFlow,
+  type Edge,
+  type Node,
+  type NodeMouseHandler,
 } from "@xyflow/react";
 import "@xyflow/react/dist/style.css";
 import { Lock } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { useRouter } from "next/navigation";
-import { useCallback,useEffect,useMemo,useRef,useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import YAML from "yaml";
 import {
-AddButtonNode,
-WorkflowStepNode,
-type AddButtonNodeData,
-type WorkflowStepNodeData,
+  AddButtonNode,
+  WorkflowStepNode,
+  type AddButtonNodeData,
+  type WorkflowStepNodeData,
 } from "./WorkflowStepNode";
 import { WorkflowStepSidebar } from "./WorkflowStepSidebar";
 import { WorkflowToolbar } from "./WorkflowToolbar";
@@ -90,17 +90,15 @@ function useDynamicAgents() {
         const res = await fetch("/api/dynamic-agents/available");
         if (!res.ok) throw new Error("Failed to fetch agents");
         const data = await res.json();
-        const list = (Array.isArray(data)
-          ? data
-          : Array.isArray(data.data)
-            ? data.data
-            : []) as Array<{
-              _id?: string;
-              id?: string;
-              name?: string;
-              description?: string;
-              ui?: AgentAvatarAgent["ui"];
-            }>;
+        const list = (
+          Array.isArray(data) ? data : Array.isArray(data.data) ? data.data : []
+        ) as Array<{
+          _id?: string;
+          id?: string;
+          name?: string;
+          description?: string;
+          ui?: AgentAvatarAgent["ui"];
+        }>;
         if (!cancelled) {
           setAgents(
             list.map((a) => ({
@@ -156,8 +154,12 @@ function buildNodes(steps: WorkflowStep[], agents: AgentInfo[]): Node[] {
 
     // "+" button after each step
     const isLastStep = i === steps.length - 1;
-    const btnSize = isLastStep ? ADD_BUTTON_APPEND_SIZE : ADD_BUTTON_INSERT_SIZE;
-    const btnYOffset = hasBadge ? ADD_BUTTON_Y_OFFSET_WITH_BADGE : ADD_BUTTON_Y_OFFSET;
+    const btnSize = isLastStep
+      ? ADD_BUTTON_APPEND_SIZE
+      : ADD_BUTTON_INSERT_SIZE;
+    const btnYOffset = hasBadge
+      ? ADD_BUTTON_Y_OFFSET_WITH_BADGE
+      : ADD_BUTTON_Y_OFFSET;
     nodes.push({
       id: `add-${i}`,
       type: "addButton",
@@ -241,19 +243,48 @@ function CanvasControls() {
     <Panel position="bottom-left">
       <div className="flex flex-col gap-0.5 bg-card border border-border rounded-lg p-1 shadow-lg">
         <button onClick={() => zoomIn()} className={btnClass} title="Zoom in">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+          >
             <line x1="12" y1="5" x2="12" y2="19" />
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
         </button>
         <button onClick={() => zoomOut()} className={btnClass} title="Zoom out">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round">
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2.5"
+            strokeLinecap="round"
+          >
             <line x1="5" y1="12" x2="19" y2="12" />
           </svg>
         </button>
         <div className="h-px bg-border my-0.5" />
-        <button onClick={() => fitView({ padding: 0.3 })} className={btnClass} title="Fit view">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <button
+          onClick={() => fitView({ padding: 0.3 })}
+          className={btnClass}
+          title="Fit view"
+        >
+          <svg
+            width="16"
+            height="16"
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          >
             <path d="M15 3h6v6M9 21H3v-6M21 3l-7 7M3 21l7-7" />
           </svg>
         </button>
@@ -293,8 +324,14 @@ function WorkflowCanvasInner({
   initialSteps,
   onBack,
 }: WorkflowCanvasProps) {
-  const { createConfig, updateConfig, deleteConfig, closeEditor, loadConfigs, openEditor } =
-    useWorkflowConfigStore();
+  const {
+    createConfig,
+    updateConfig,
+    deleteConfig,
+    closeEditor,
+    loadConfigs,
+    openEditor,
+  } = useWorkflowConfigStore();
   const { data: authSession } = useSession();
   const { executeWorkflow } = useWorkflowExecStore();
   const {
@@ -316,7 +353,9 @@ function WorkflowCanvasInner({
 
   const seedSteps = useMemo(() => {
     if (existingConfig) {
-      return existingConfig.steps.filter((s): s is WorkflowStep => s.type === "step");
+      return existingConfig.steps.filter(
+        (s): s is WorkflowStep => s.type === "step",
+      );
     }
     return initialSteps && initialSteps.length > 0 ? initialSteps : [];
   }, [existingConfig, initialSteps]);
@@ -344,12 +383,13 @@ function WorkflowCanvasInner({
 
   useEffect(() => {
     fetch("/api/dynamic-agents/teams")
-      .then((r) => r.ok ? r.json() : null)
+      .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (data?.success && Array.isArray(data.data)) {
           setAvailableTeams(
             data.data.filter(
-              (team: { slug?: string }) => typeof team.slug === "string" && team.slug.length > 0,
+              (team: { slug?: string }) =>
+                typeof team.slug === "string" && team.slug.length > 0,
             ),
           );
         }
@@ -359,11 +399,17 @@ function WorkflowCanvasInner({
 
   // Legacy workflows stored Mongo team _id in shared_with_teams; normalize to slug in UI.
   useEffect(() => {
-    if (!existingConfig?.shared_with_teams?.length || availableTeams.length === 0) return;
+    if (
+      !existingConfig?.shared_with_teams?.length ||
+      availableTeams.length === 0
+    )
+      return;
     setSharedWithTeams((current) => {
       const normalized = existingConfig.shared_with_teams!.map((ref) => {
         const refLower = ref.trim().toLowerCase();
-        const bySlug = availableTeams.find((t) => t.slug.toLowerCase() === refLower);
+        const bySlug = availableTeams.find(
+          (t) => t.slug.toLowerCase() === refLower,
+        );
         if (bySlug) return bySlug.slug;
         const byId = availableTeams.find((t) => t._id === ref);
         return byId?.slug ?? refLower;
@@ -430,10 +476,14 @@ function WorkflowCanvasInner({
     (_event, node) => {
       if (node.type === "addButton") {
         if (isReadOnly) {
-          toast("This workflow is config-driven and cannot be edited", "warning");
+          toast(
+            "This workflow is config-driven and cannot be edited",
+            "warning",
+          );
           return;
         }
-        const insertIndex = (node.data as unknown as AddButtonNodeData).insertIndex;
+        const insertIndex = (node.data as unknown as AddButtonNodeData)
+          .insertIndex;
         markDirty();
         const newStep = createBlankStep();
         setSteps((prev) => {
@@ -460,9 +510,10 @@ function WorkflowCanvasInner({
   // Selected step
   // -----------------------------------------------------------------------
 
-  const selectedStep = selectedStepIndex >= 0 && selectedStepIndex < steps.length
-    ? steps[selectedStepIndex]
-    : null;
+  const selectedStep =
+    selectedStepIndex >= 0 && selectedStepIndex < steps.length
+      ? steps[selectedStepIndex]
+      : null;
 
   // -----------------------------------------------------------------------
   // Step mutations (called from sidebar)
@@ -473,7 +524,9 @@ function WorkflowCanvasInner({
       if (selectedStepIndex < 0) return;
       markDirty();
       setSteps((prev) =>
-        prev.map((s, i) => (i === selectedStepIndex ? { ...s, ...updates } : s)),
+        prev.map((s, i) =>
+          i === selectedStepIndex ? { ...s, ...updates } : s,
+        ),
       );
     },
     [selectedStepIndex, markDirty],
@@ -484,7 +537,8 @@ function WorkflowCanvasInner({
       markDirty();
       setSteps((prev) => prev.filter((_, i) => i !== stepIndex));
       if (selectedStepIndex === stepIndex) setSelectedStepIndex(-1);
-      else if (selectedStepIndex > stepIndex) setSelectedStepIndex((i) => i - 1);
+      else if (selectedStepIndex > stepIndex)
+        setSelectedStepIndex((i) => i - 1);
     },
     [selectedStepIndex, markDirty],
   );
@@ -554,12 +608,18 @@ function WorkflowCanvasInner({
   }, [existingConfig, openEditor, guardAction]);
 
   const handleNameChange = useCallback(
-    (v: string) => { markDirty(); setName(v); },
+    (v: string) => {
+      markDirty();
+      setName(v);
+    },
     [markDirty],
   );
 
   const handleDescriptionChange = useCallback(
-    (v: string) => { markDirty(); setDescription(v); },
+    (v: string) => {
+      markDirty();
+      setDescription(v);
+    },
     [markDirty],
   );
 
@@ -567,23 +627,51 @@ function WorkflowCanvasInner({
   // Save
   // -----------------------------------------------------------------------
 
-  const persistWorkflow = useCallback(async (
-    overrides?: Pick<CreateWorkflowConfigInput, "visibility" | "shared_with_teams">,
-  ): Promise<string | null> => {
-    if (!name || steps.length === 0) {
-      toast("Workflow name and at least one step are required", "error");
-      return null;
-    }
+  const persistWorkflow = useCallback(
+    async (
+      overrides?: Pick<
+        CreateWorkflowConfigInput,
+        "visibility" | "shared_with_teams"
+      >,
+    ): Promise<string | null> => {
+      if (!name || steps.length === 0) {
+        toast("Workflow name and at least one step are required", "error");
+        return null;
+      }
 
-    const effectiveVisibility = overrides?.visibility ?? visibility;
-    const effectiveSharedWithTeams =
-      effectiveVisibility === "team"
-        ? overrides?.shared_with_teams ?? sharedWithTeams
-        : undefined;
+      const effectiveVisibility = overrides?.visibility ?? visibility;
+      const effectiveSharedWithTeams =
+        effectiveVisibility === "team"
+          ? (overrides?.shared_with_teams ?? sharedWithTeams)
+          : undefined;
 
-    if (existingConfig?.config_driven) {
+      if (existingConfig?.config_driven) {
+        const input: CreateWorkflowConfigInput = {
+          name: `${name.trim()} (editable)`,
+          description: description.trim() || undefined,
+          steps,
+          visibility: effectiveVisibility,
+          shared_with_teams: effectiveSharedWithTeams,
+        };
+        const newId = await createConfig(input);
+        openEditor("edit", newId);
+        return newId;
+      }
+
+      if (existingConfig) {
+        const updates: UpdateWorkflowConfigInput = {
+          name: name.trim(),
+          description: description.trim() || undefined,
+          steps,
+          visibility: effectiveVisibility,
+          shared_with_teams: effectiveSharedWithTeams,
+        };
+        await updateConfig(existingConfig._id, updates);
+        return existingConfig._id;
+      }
+
       const input: CreateWorkflowConfigInput = {
-        name: `${name.trim()} (editable)`,
+        name: name.trim(),
         description: description.trim() || undefined,
         steps,
         visibility: effectiveVisibility,
@@ -592,67 +680,48 @@ function WorkflowCanvasInner({
       const newId = await createConfig(input);
       openEditor("edit", newId);
       return newId;
-    }
-
-    if (existingConfig) {
-      const updates: UpdateWorkflowConfigInput = {
-        name: name.trim(),
-        description: description.trim() || undefined,
-        steps,
-        visibility: effectiveVisibility,
-        shared_with_teams: effectiveSharedWithTeams,
-      };
-      await updateConfig(existingConfig._id, updates);
-      return existingConfig._id;
-    }
-
-    const input: CreateWorkflowConfigInput = {
-      name: name.trim(),
-      description: description.trim() || undefined,
+    },
+    [
+      name,
+      description,
       steps,
-      visibility: effectiveVisibility,
-      shared_with_teams: effectiveSharedWithTeams,
-    };
-    const newId = await createConfig(input);
-    openEditor("edit", newId);
-    return newId;
-  }, [
-    name,
-    description,
-    steps,
-    visibility,
-    sharedWithTeams,
-    existingConfig,
-    createConfig,
-    updateConfig,
-    openEditor,
-    toast,
-  ]);
+      visibility,
+      sharedWithTeams,
+      existingConfig,
+      createConfig,
+      updateConfig,
+      openEditor,
+      toast,
+    ],
+  );
 
-  const doSave = useCallback(async (successMsg?: string) => {
-    setIsSaving(true);
-    try {
-      const savedId = await persistWorkflow();
-      if (!savedId) return;
-      isDirtyRef.current = false;
-      setUnsaved(false);
-      toast(
-        successMsg ??
-          (existingConfig?.config_driven
-            ? "Saved as a new editable workflow"
-            : "Workflow saved"),
-        "success",
-      );
-    } catch (error) {
-      console.error("Failed to save workflow config:", error);
-      toast(
-        error instanceof Error ? error.message : "Failed to save workflow",
-        "error",
-      );
-    } finally {
-      setIsSaving(false);
-    }
-  }, [persistWorkflow, existingConfig?.config_driven, setUnsaved, toast]);
+  const doSave = useCallback(
+    async (successMsg?: string) => {
+      setIsSaving(true);
+      try {
+        const savedId = await persistWorkflow();
+        if (!savedId) return;
+        isDirtyRef.current = false;
+        setUnsaved(false);
+        toast(
+          successMsg ??
+            (existingConfig?.config_driven
+              ? "Saved as a new editable workflow"
+              : "Workflow saved"),
+          "success",
+        );
+      } catch (error) {
+        console.error("Failed to save workflow config:", error);
+        toast(
+          error instanceof Error ? error.message : "Failed to save workflow",
+          "error",
+        );
+      } finally {
+        setIsSaving(false);
+      }
+    },
+    [persistWorkflow, existingConfig?.config_driven, setUnsaved, toast],
+  );
 
   const handleSave = useCallback(async () => {
     if (visibility !== "private") {
@@ -661,13 +730,19 @@ function WorkflowCanvasInner({
         const res = await fetch("/api/workflow-configs/check-agent-access", {
           method: "POST",
           headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ steps, visibility, shared_with_teams: sharedWithTeams }),
+          body: JSON.stringify({
+            steps,
+            visibility,
+            shared_with_teams: sharedWithTeams,
+          }),
         });
         if (res.ok) {
           const data = await res.json();
           gaps = data.gaps ?? [];
         }
-      } catch { /* non-fatal — proceed to save */ }
+      } catch {
+        /* non-fatal — proceed to save */
+      }
       if (gaps.length > 0) {
         setAgentAccessGaps(gaps);
         setShowAccessModal(true);
@@ -694,7 +769,10 @@ function WorkflowCanvasInner({
   const handleSaveAsPrivate = useCallback(async () => {
     setIsSaving(true);
     try {
-      const savedId = await persistWorkflow({ visibility: "private", shared_with_teams: [] });
+      const savedId = await persistWorkflow({
+        visibility: "private",
+        shared_with_teams: [],
+      });
       if (!savedId) return;
       setVisibility("private");
       setSharedWithTeams([]);
@@ -802,7 +880,9 @@ function WorkflowCanvasInner({
         : {}),
       steps,
     };
-    const blob = new Blob([YAML.stringify(config)], { type: "application/x-yaml" });
+    const blob = new Blob([YAML.stringify(config)], {
+      type: "application/x-yaml",
+    });
     const url = URL.createObjectURL(blob);
     const a = document.createElement("a");
     a.href = url;
@@ -817,15 +897,23 @@ function WorkflowCanvasInner({
       const obj = parsed as Record<string, unknown>;
       if (typeof obj.name === "string") setName(obj.name);
       if (typeof obj.description === "string") setDescription(obj.description);
-      if (obj.visibility === "private" || obj.visibility === "team" || obj.visibility === "global") {
+      if (
+        obj.visibility === "private" ||
+        obj.visibility === "team" ||
+        obj.visibility === "global"
+      ) {
         setVisibility(obj.visibility);
       }
       if (Array.isArray(obj.shared_with_teams)) {
-        const refs = (obj.shared_with_teams as string[]).map((ref) => ref.trim().toLowerCase());
+        const refs = (obj.shared_with_teams as string[]).map((ref) =>
+          ref.trim().toLowerCase(),
+        );
         setSharedWithTeams(
           refs
             .map((ref) => {
-              const bySlug = availableTeams.find((t) => t.slug.toLowerCase() === ref);
+              const bySlug = availableTeams.find(
+                (t) => t.slug.toLowerCase() === ref,
+              );
               if (bySlug) return bySlug.slug;
               const byId = availableTeams.find((t) => t._id === ref);
               return byId?.slug ?? ref;
@@ -843,7 +931,13 @@ function WorkflowCanvasInner({
 
   // Agent objects for the sidebar (with _id, name, description, ui)
   const sidebarAgents = useMemo(
-    () => agents.map((a) => ({ _id: a.value, name: a.label, description: a.description, ui: a.ui })),
+    () =>
+      agents.map((a) => ({
+        _id: a.value,
+        name: a.label,
+        description: a.description,
+        ui: a.ui,
+      })),
     [agents],
   );
 
@@ -874,7 +968,9 @@ function WorkflowCanvasInner({
     if (selectedStepIndex < 0) return nodes;
     const selectedId = `step-${selectedStepIndex}`;
     return nodes.map((n) =>
-      n.id === selectedId ? { ...n, selected: true } : { ...n, selected: false },
+      n.id === selectedId
+        ? { ...n, selected: true }
+        : { ...n, selected: false },
     );
   }, [nodes, selectedStepIndex]);
 
@@ -900,16 +996,25 @@ function WorkflowCanvasInner({
         readOnlyHint={readOnlyHint}
         onCloneToEdit={existingConfig ? handleCloneToEdit : undefined}
         visibility={visibility}
-        onVisibilityChange={(v) => { setVisibility(v); markDirty(); }}
+        onVisibilityChange={(v) => {
+          setVisibility(v);
+          markDirty();
+        }}
         sharedWithTeams={sharedWithTeams}
-        onSharedWithTeamsChange={(t) => { setSharedWithTeams(t); markDirty(); }}
+        onSharedWithTeamsChange={(t) => {
+          setSharedWithTeams(t);
+          markDirty();
+        }}
         teams={availableTeams}
+        authzDocument={existingConfig}
       />
 
       {isReadOnly && readOnlyHint && (
         <div className="px-4 py-2.5 bg-amber-500/10 border-b border-amber-500/20 flex items-start gap-2 shrink-0">
           <Lock className="h-4 w-4 text-amber-500 shrink-0 mt-0.5" />
-          <p className="text-xs text-amber-700 dark:text-amber-300 leading-relaxed">{readOnlyHint}</p>
+          <p className="text-xs text-amber-700 dark:text-amber-300 leading-relaxed">
+            {readOnlyHint}
+          </p>
         </div>
       )}
 
@@ -944,12 +1049,16 @@ function WorkflowCanvasInner({
           stepIndex={selectedStepIndex}
           onChange={handleStepChange}
           onDelete={handleDeleteStep}
-          onAddStep={isReadOnly ? undefined : () => {
-            markDirty();
-            const newStep = createBlankStep();
-            setSteps((prev) => [...prev, newStep]);
-            setSelectedStepIndex(0);
-          }}
+          onAddStep={
+            isReadOnly
+              ? undefined
+              : () => {
+                  markDirty();
+                  const newStep = createBlankStep();
+                  setSteps((prev) => [...prev, newStep]);
+                  setSelectedStepIndex(0);
+                }
+          }
           agents={sidebarAgents}
           agentsLoading={agentsLoading}
           readOnly={isReadOnly}
@@ -970,7 +1079,10 @@ function WorkflowCanvasInner({
           visibility={visibility}
           onGrantAndSave={handleGrantAndSave}
           onSaveAsPrivate={handleSaveAsPrivate}
-          onCancel={() => { setShowAccessModal(false); setAgentAccessGaps([]); }}
+          onCancel={() => {
+            setShowAccessModal(false);
+            setAgentAccessGaps([]);
+          }}
         />
       )}
 
@@ -978,9 +1090,12 @@ function WorkflowCanvasInner({
       {showDeleteDialog && (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
           <div className="bg-card border border-border rounded-lg p-6 shadow-xl max-w-sm mx-4">
-            <h3 className="text-sm font-bold text-foreground mb-2">Delete workflow</h3>
+            <h3 className="text-sm font-bold text-foreground mb-2">
+              Delete workflow
+            </h3>
             <p className="text-sm text-muted-foreground mb-4">
-              Are you sure you want to delete &ldquo;{name}&rdquo;? This cannot be undone.
+              Are you sure you want to delete &ldquo;{name}&rdquo;? This cannot
+              be undone.
             </p>
             <div className="flex justify-end gap-2">
               <button

--- a/ui/src/components/workflows/WorkflowToolbar.tsx
+++ b/ui/src/components/workflows/WorkflowToolbar.tsx
@@ -1,12 +1,28 @@
 "use client";
 
 import { Button } from "@/components/ui/button";
+import { AuthorizationSyncStatus } from "@/components/shared/AuthorizationSyncStatus";
 import { Input } from "@/components/ui/input";
-import { TeamMultiPicker, type TeamPickerOption } from "@/components/ui/team-picker";
+import {
+  TeamMultiPicker,
+  type TeamPickerOption,
+} from "@/components/ui/team-picker";
 import { cn } from "@/lib/utils";
 import type { WorkflowConfigVisibility } from "@/types/workflow-config";
-import { ArrowLeft,Copy,Download,Globe,Lock,Play,Save,Trash2,Upload,Users } from "lucide-react";
-import React,{ useEffect,useMemo,useRef,useState } from "react";
+import type { AuthzSyncMetadata } from "@/types/authz-sync";
+import {
+  ArrowLeft,
+  Copy,
+  Download,
+  Globe,
+  Lock,
+  Play,
+  Save,
+  Trash2,
+  Upload,
+  Users,
+} from "lucide-react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import YAML from "yaml";
 
@@ -42,14 +58,18 @@ interface WorkflowToolbarProps {
   sharedWithTeams: string[];
   onSharedWithTeamsChange: (teams: string[]) => void;
   teams: Team[];
+  authzDocument?: AuthzSyncMetadata | null;
 }
 
-const VISIBILITY_CONFIG: Record<WorkflowConfigVisibility, {
-  icon: React.ReactNode;
-  label: string;
-  description: string;
-  color: string;
-}> = {
+const VISIBILITY_CONFIG: Record<
+  WorkflowConfigVisibility,
+  {
+    icon: React.ReactNode;
+    label: string;
+    description: string;
+    color: string;
+  }
+> = {
   private: {
     icon: <Lock className="h-3.5 w-3.5" />,
     label: "Private",
@@ -86,7 +106,10 @@ function VisibilityPopover({
   disabled?: boolean;
 }) {
   const [open, setOpen] = useState(false);
-  const [dropdownCoords, setDropdownCoords] = useState<{ top: number; left: number } | null>(null);
+  const [dropdownCoords, setDropdownCoords] = useState<{
+    top: number;
+    left: number;
+  } | null>(null);
   const buttonRef = useRef<HTMLButtonElement>(null);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -111,7 +134,8 @@ function VisibilityPopover({
       if (
         buttonRef.current?.contains(target) ||
         dropdownRef.current?.contains(target)
-      ) return;
+      )
+        return;
       setOpen(false);
     };
     document.addEventListener("mousedown", handler);
@@ -132,66 +156,79 @@ function VisibilityPopover({
     [teams],
   );
 
-  const dropdown = open && dropdownCoords ? createPortal(
-    <div
-      ref={dropdownRef}
-      style={{ position: "fixed", top: dropdownCoords.top, left: dropdownCoords.left }}
-      className="z-[200] w-72 rounded-lg border border-border bg-card shadow-lg p-2"
-      onPointerDown={(e) => e.stopPropagation()}
-      onMouseDown={(e) => e.stopPropagation()}
-      onClick={(e) => e.stopPropagation()}
-    >
-      {(["global", "team", "private"] as WorkflowConfigVisibility[]).map((v) => {
-        const opt = VISIBILITY_CONFIG[v];
-        return (
-          <button
-            key={v}
-            type="button"
-            onClick={() => {
-              onVisibilityChange(v);
-              if (v !== "team") setOpen(false);
+  const dropdown =
+    open && dropdownCoords
+      ? createPortal(
+          <div
+            ref={dropdownRef}
+            style={{
+              position: "fixed",
+              top: dropdownCoords.top,
+              left: dropdownCoords.left,
             }}
-            className={cn(
-              "w-full flex items-start gap-2.5 p-2 rounded-md text-left transition-colors",
-              visibility === v
-                ? "bg-primary/5 border border-primary/30"
-                : "hover:bg-muted/50 border border-transparent",
-            )}
+            className="z-[200] w-72 rounded-lg border border-border bg-card shadow-lg p-2"
+            onPointerDown={(e) => e.stopPropagation()}
+            onMouseDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
           >
-            <span className={cn("mt-0.5", VISIBILITY_CONFIG[v].color)}>{opt.icon}</span>
-            <div>
-              <div className="text-xs font-medium">{opt.label}</div>
-              <div className="text-[10px] text-muted-foreground">{opt.description}</div>
-            </div>
-          </button>
-        );
-      })}
+            {(["global", "team", "private"] as WorkflowConfigVisibility[]).map(
+              (v) => {
+                const opt = VISIBILITY_CONFIG[v];
+                return (
+                  <button
+                    key={v}
+                    type="button"
+                    onClick={() => {
+                      onVisibilityChange(v);
+                      if (v !== "team") setOpen(false);
+                    }}
+                    className={cn(
+                      "w-full flex items-start gap-2.5 p-2 rounded-md text-left transition-colors",
+                      visibility === v
+                        ? "bg-primary/5 border border-primary/30"
+                        : "hover:bg-muted/50 border border-transparent",
+                    )}
+                  >
+                    <span className={cn("mt-0.5", VISIBILITY_CONFIG[v].color)}>
+                      {opt.icon}
+                    </span>
+                    <div>
+                      <div className="text-xs font-medium">{opt.label}</div>
+                      <div className="text-[10px] text-muted-foreground">
+                        {opt.description}
+                      </div>
+                    </div>
+                  </button>
+                );
+              },
+            )}
 
-      {visibility === "team" && (
-        <div className="mt-2 pt-2 border-t border-border px-0.5">
-          {teamOptions.length === 0 ? (
-            <p className="text-[10px] text-muted-foreground italic px-1">
-              No teams available.
-            </p>
-          ) : (
-            <TeamMultiPicker
-              options={teamOptions}
-              selected={sharedWithTeams}
-              onChange={onSharedWithTeamsChange}
-              disabled={disabled}
-              ariaLabel="Share workflow with teams"
-              placeholder="Share with teams…"
-              searchPlaceholder="Search teams…"
-              emptyLabel="No teams match"
-              triggerChipCap={1}
-              contentClassName="z-[210]"
-            />
-          )}
-        </div>
-      )}
-    </div>,
-    document.body,
-  ) : null;
+            {visibility === "team" && (
+              <div className="mt-2 pt-2 border-t border-border px-0.5">
+                {teamOptions.length === 0 ? (
+                  <p className="text-[10px] text-muted-foreground italic px-1">
+                    No teams available.
+                  </p>
+                ) : (
+                  <TeamMultiPicker
+                    options={teamOptions}
+                    selected={sharedWithTeams}
+                    onChange={onSharedWithTeamsChange}
+                    disabled={disabled}
+                    ariaLabel="Share workflow with teams"
+                    placeholder="Share with teams…"
+                    searchPlaceholder="Search teams…"
+                    emptyLabel="No teams match"
+                    triggerChipCap={1}
+                    contentClassName="z-[210]"
+                  />
+                )}
+              </div>
+            )}
+          </div>,
+          document.body,
+        )
+      : null;
 
   return (
     <div className="relative">
@@ -241,6 +278,7 @@ export function WorkflowToolbar({
   sharedWithTeams,
   onSharedWithTeamsChange,
   teams,
+  authzDocument,
 }: WorkflowToolbarProps) {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -271,7 +309,12 @@ export function WorkflowToolbar({
     <div className="px-4 py-3 border-b border-border bg-card/80 backdrop-blur-sm shrink-0">
       {/* Single row: Back | Name & Desc | Actions */}
       <div className="flex items-center gap-3">
-        <Button variant="ghost" size="sm" onClick={onBack} className="gap-1.5 h-8 px-2.5 shrink-0">
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onBack}
+          className="gap-1.5 h-8 px-2.5 shrink-0"
+        >
           <ArrowLeft className="h-4 w-4" />
           Exit
         </Button>
@@ -329,6 +372,11 @@ export function WorkflowToolbar({
           onSharedWithTeamsChange={onSharedWithTeamsChange}
           teams={teams}
           disabled={readOnly}
+        />
+        <AuthorizationSyncStatus
+          document={authzDocument}
+          busy={isSaving}
+          canRetry={!readOnly}
         />
 
         <div className="h-5 w-px bg-border shrink-0" />
@@ -409,7 +457,9 @@ export function WorkflowToolbar({
           <Button
             size="sm"
             onClick={onSave}
-            disabled={isSaving || !name || stepCount === 0 || (readOnly && !saveAsCopy)}
+            disabled={
+              isSaving || !name || stepCount === 0 || (readOnly && !saveAsCopy)
+            }
             title={readOnly && !saveAsCopy ? readOnlyHint : undefined}
             className="gap-1.5 h-8 text-xs px-4 gradient-primary text-white disabled:opacity-40"
           >

--- a/ui/src/lib/agent-skill-visibility.ts
+++ b/ui/src/lib/agent-skill-visibility.ts
@@ -7,8 +7,8 @@ import type { AgentSkill } from "@/types/agent-skill";
  * Load a single agent_skills row by id.
  *
  * Authorization is enforced by callers with concrete OpenFGA checks. Mongo
- * stores `visibility` and `owner_id` as metadata; team shares are OpenFGA-only
- * and exposed on API responses via {@link hydrateAgentSkillTeamShares}.
+ * stores the desired visibility/share state so failed reconciliation can be
+ * retried without treating stale OpenFGA tuples as the source of truth.
  */
 export async function getAgentSkillVisibleToUser(
   id: string,
@@ -25,6 +25,7 @@ export async function hydrateAgentSkillTeamShares(skill: AgentSkill): Promise<Ag
   if (skill.visibility !== "team") {
     return { ...skill, shared_with_teams: undefined };
   }
+  if (Array.isArray(skill.shared_with_teams)) return skill;
   const slugs = await readSkillSharedTeamSlugsFromOpenFga(skill.id);
   return {
     ...skill,

--- a/ui/src/lib/authz/__tests__/index.test.ts
+++ b/ui/src/lib/authz/__tests__/index.test.ts
@@ -21,7 +21,10 @@ jest.mock("../engines/openfga", () => {
 });
 // Audit is a no-op in tests (Mongo unconfigured).
 jest.mock("@/lib/mongodb", () => ({
-  getCollection: jest.fn(async () => ({ findOne: jest.fn(async () => null) })),
+  getCollection: jest.fn(async () => ({
+    findOne: jest.fn(async () => null),
+    find: jest.fn(() => ({ toArray: jest.fn(async () => []) })),
+  })),
   isMongoDBConfigured: false,
 }));
 

--- a/ui/src/lib/authz/__tests__/reconcile.test.ts
+++ b/ui/src/lib/authz/__tests__/reconcile.test.ts
@@ -8,10 +8,12 @@ const mockWriteOpenFgaTupleDiff = jest.fn();
 const mockIsOpenFgaReconciliationEnabled = jest.fn();
 const mockEmitReconcileAudit = jest.fn();
 const mockInvalidateDecisionCache = jest.fn();
+const mockVerifyOpenFgaTupleDiff = jest.fn();
 
 jest.mock("@/lib/rbac/openfga", () => ({
   writeOpenFgaTupleDiff: (...args: unknown[]) => mockWriteOpenFgaTupleDiff(...args),
   isOpenFgaReconciliationEnabled: () => mockIsOpenFgaReconciliationEnabled(),
+  verifyOpenFgaTupleDiff: (...args: unknown[]) => mockVerifyOpenFgaTupleDiff(...args),
 }));
 
 jest.mock("../audit", () => ({
@@ -37,6 +39,7 @@ beforeEach(() => {
   jest.clearAllMocks();
   mockIsOpenFgaReconciliationEnabled.mockReturnValue(true);
   mockWriteOpenFgaTupleDiff.mockResolvedValue({ enabled: true, writes: 1, deletes: 0 });
+  mockVerifyOpenFgaTupleDiff.mockResolvedValue(undefined);
 });
 
 describe("reconcileTupleDiff", () => {
@@ -53,6 +56,23 @@ describe("reconcileTupleDiff", () => {
       result,
       expect.objectContaining({ source: "mcp_server_create" }),
     );
+  });
+
+  it("verifies the intended tuple state at higher consistency when requested", async () => {
+    const diff = { writes: [sampleWrite], deletes: [] };
+
+    await reconcileTupleDiff(diff, { verifyHigherConsistency: true });
+
+    expect(mockVerifyOpenFgaTupleDiff).toHaveBeenCalledWith(diff);
+  });
+
+  it("fails closed when higher-consistency verification fails", async () => {
+    mockVerifyOpenFgaTupleDiff.mockRejectedValue(new Error("verification lag"));
+
+    await expect(reconcileTupleDiff(
+      { writes: [sampleWrite], deletes: [] },
+      { verifyHigherConsistency: true },
+    )).rejects.toThrow("verification lag");
   });
 
   it("does not invalidate cache when the filtered diff is a no-op", async () => {

--- a/ui/src/lib/authz/__tests__/resource-sync.test.ts
+++ b/ui/src/lib/authz/__tests__/resource-sync.test.ts
@@ -1,0 +1,76 @@
+import {
+  authzRevisionFilter,
+  authzSyncPreCheck,
+  currentAuthzRevision,
+  hasActiveAuthzSync,
+  nextAuthzRevision,
+  runRevisionedAuthzSync,
+} from "../resource-sync";
+
+describe("revisioned authorization sync", () => {
+  it("treats legacy documents as revision zero", () => {
+    expect(currentAuthzRevision({})).toBe(0);
+    expect(nextAuthzRevision({})).toBe(1);
+    expect(authzRevisionFilter({})).toEqual({ authz_revision: { $exists: false } });
+  });
+
+  it("fails data access closed for pending and error revisions", () => {
+    expect(authzSyncPreCheck({ authz_sync_state: "pending" })).toMatchObject({
+      decision: "DENY",
+      reason: "AUTHZ_SYNC_PENDING",
+      retriable: true,
+    });
+    expect(authzSyncPreCheck({ authz_sync_state: "error" })).toMatchObject({
+      decision: "DENY",
+      reason: "AUTHZ_SYNC_ERROR",
+      retriable: true,
+    });
+    expect(authzSyncPreCheck({
+      authz_sync_state: "ready",
+      authz_revision: 2,
+      authz_last_synced_revision: 1,
+    })).toMatchObject({
+      decision: "DENY",
+      reason: "AUTHZ_SYNC_ERROR",
+    });
+    expect(authzSyncPreCheck({
+      authz_sync_state: "ready",
+      authz_revision: 2,
+      authz_last_synced_revision: 2,
+    })).toBeNull();
+    expect(authzSyncPreCheck({})).toBeNull();
+  });
+
+  it("only treats a recent pending revision as an active concurrent update", () => {
+    const now = Date.parse("2026-09-08T08:00:00.000Z");
+    expect(hasActiveAuthzSync({
+      authz_sync_state: "pending",
+      authz_sync_started_at: "2026-09-08T07:59:30.000Z",
+    }, now)).toBe(true);
+    expect(hasActiveAuthzSync({
+      authz_sync_state: "pending",
+      authz_sync_started_at: "2026-09-08T07:50:00.000Z",
+    }, now)).toBe(false);
+  });
+
+  it("marks a reconciled revision ready", async () => {
+    const order: string[] = [];
+    const result = await runRevisionedAuthzSync({
+      reconcile: async () => { order.push("reconcile"); },
+      markReady: async () => { order.push("ready"); return { state: "ready" }; },
+      markError: async () => { order.push("error"); },
+    });
+    expect(result).toEqual({ state: "ready" });
+    expect(order).toEqual(["reconcile", "ready"]);
+  });
+
+  it("records a sanitized error state when reconciliation fails", async () => {
+    const markError = jest.fn(async () => undefined);
+    await expect(runRevisionedAuthzSync({
+      reconcile: async () => { throw new Error("secret endpoint details"); },
+      markReady: async () => ({ state: "ready" }),
+      markError,
+    })).rejects.toThrow("secret endpoint details");
+    expect(markError).toHaveBeenCalledWith("OPENFGA_RECONCILIATION_FAILED");
+  });
+});

--- a/ui/src/lib/authz/contract.ts
+++ b/ui/src/lib/authz/contract.ts
@@ -16,7 +16,9 @@ export type ReasonCode =
   | "NOT_AUTHENTICATED"// caller token missing or invalid
   | "AUTHZ_UNAVAILABLE"// PDP error, retriable
   | "INVALID_REQUEST"  // bad id or malformed input
-  | "PRIVATE_RESOURCE_CONTEXT_DENIED"; // private use outside web/personal or a verified DM
+  | "PRIVATE_RESOURCE_CONTEXT_DENIED" // private use outside web/personal or a verified DM
+  | "AUTHZ_SYNC_PENDING" // persisted ownership is awaiting OpenFGA reconciliation
+  | "AUTHZ_SYNC_ERROR"; // reconciliation failed and requires a retry/repair
 
 export interface Subject {
   type: SubjectType;

--- a/ui/src/lib/authz/domains/__tests__/private-resource-precheck.test.ts
+++ b/ui/src/lib/authz/domains/__tests__/private-resource-precheck.test.ts
@@ -34,7 +34,11 @@ describe("private resource persisted-state prechecks", () => {
       subject: { type: "user", id: "user-a" },
       action: "discover",
       trustedContext: {
-        interaction: { source: "web", conversationKind: "personal", verified: false },
+        interaction: {
+          source: "web",
+          conversationKind: "personal",
+          verified: false,
+        },
       },
       resourceType: "agent",
       ids: ["pending", "failed", "ready", "legacy"],
@@ -45,4 +49,33 @@ describe("private resource persisted-state prechecks", () => {
     expect(decisions.has("ready")).toBe(false);
     expect(decisions.has("legacy")).toBe(false);
   });
+
+  it.each([
+    [
+      "skill" as const,
+      "invoke" as const,
+      { id: "pending", authz_sync_state: "pending" },
+    ],
+    [
+      "task" as const,
+      "read" as const,
+      { _id: "pending", authz_sync_state: "pending" },
+    ],
+  ])(
+    "applies the sync gate to %s resources",
+    async (resourceType, action, row) => {
+      mockGetCollection.mockResolvedValue({
+        find: jest.fn(() => ({ toArray: jest.fn(async () => [row]) })),
+      });
+
+      const decisions = await privateResourceBatchPreChecks({
+        subject: { type: "user", id: "user-a" },
+        action,
+        resourceType,
+        ids: ["pending"],
+      });
+
+      expect(decisions.get("pending")?.reason).toBe("AUTHZ_SYNC_PENDING");
+    },
+  );
 });

--- a/ui/src/lib/authz/domains/__tests__/private-resource-precheck.test.ts
+++ b/ui/src/lib/authz/domains/__tests__/private-resource-precheck.test.ts
@@ -1,0 +1,48 @@
+const mockGetCollection = jest.fn();
+
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: (...args: unknown[]) => mockGetCollection(...args),
+}));
+
+jest.mock("@/lib/feature-flags/private-resources", () => ({
+  isPrivateResourcesEnabled: () => true,
+}));
+
+import { privateResourceBatchPreChecks } from "../private-resource";
+
+describe("private resource persisted-state prechecks", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("denies execution for pending and failed authorization revisions", async () => {
+    mockGetCollection.mockResolvedValue({
+      find: jest.fn(() => ({
+        toArray: jest.fn(async () => [
+          { _id: "pending", authz_sync_state: "pending" },
+          { _id: "failed", authz_sync_state: "error" },
+          {
+            _id: "ready",
+            authz_sync_state: "ready",
+            authz_revision: 2,
+            authz_last_synced_revision: 2,
+          },
+          { _id: "legacy" },
+        ]),
+      })),
+    });
+
+    const decisions = await privateResourceBatchPreChecks({
+      subject: { type: "user", id: "user-a" },
+      action: "discover",
+      trustedContext: {
+        interaction: { source: "web", conversationKind: "personal", verified: false },
+      },
+      resourceType: "agent",
+      ids: ["pending", "failed", "ready", "legacy"],
+    });
+
+    expect(decisions.get("pending")?.reason).toBe("AUTHZ_SYNC_PENDING");
+    expect(decisions.get("failed")?.reason).toBe("AUTHZ_SYNC_ERROR");
+    expect(decisions.has("ready")).toBe(false);
+    expect(decisions.has("legacy")).toBe(false);
+  });
+});

--- a/ui/src/lib/authz/domains/private-resource.ts
+++ b/ui/src/lib/authz/domains/private-resource.ts
@@ -2,7 +2,19 @@ import { CREDENTIAL_COLLECTIONS } from "@/lib/credentials/collections";
 import { getCollection } from "@/lib/mongodb";
 import { isPrivateResourcesEnabled } from "@/lib/feature-flags/private-resources";
 
-import type { AuthorizeRequest, AuthorizeResult } from "../contract";
+import type {
+  Action,
+  AuthorizeRequest,
+  AuthorizeResult,
+  ResourceType,
+  Subject,
+  TrustedAuthorizeContext,
+} from "../contract";
+import {
+  AUTHZ_SYNC_GATED_ACTIONS,
+  authzSyncPreCheck,
+  type AuthzSyncDocument,
+} from "../resource-sync";
 import {
   evaluatePrivateResourceContext,
   PRIVATE_DATA_ACTIONS,
@@ -11,7 +23,7 @@ import {
 
 export { evaluatePrivateResourceContext } from "./private-resource-policy";
 
-interface VisibilityDocument {
+interface VisibilityDocument extends AuthzSyncDocument {
   _id?: string;
   id?: string;
   visibility?: string;
@@ -19,7 +31,7 @@ interface VisibilityDocument {
   sharedWithTeams?: string[];
 }
 
-async function loadVisibility(req: AuthorizeRequest): Promise<ResourceVisibility> {
+async function loadResourceState(req: AuthorizeRequest): Promise<VisibilityDocument | null> {
   let document: VisibilityDocument | null = null;
   if (req.resource.type === "agent") {
     const collection = await getCollection<VisibilityDocument>("dynamic_agents");
@@ -33,7 +45,33 @@ async function loadVisibility(req: AuthorizeRequest): Promise<ResourceVisibility
   } else {
     return null;
   }
+  return document;
+}
 
+async function loadResourceStates(
+  resourceType: ResourceType,
+  ids: string[],
+): Promise<VisibilityDocument[]> {
+  if (ids.length === 0) return [];
+  if (resourceType === "agent") {
+    return getCollection<VisibilityDocument>("dynamic_agents")
+      .then((collection) => collection.find({ _id: { $in: ids } }).toArray());
+  }
+  if (resourceType === "mcp_server") {
+    return getCollection<VisibilityDocument>("mcp_servers")
+      .then((collection) => collection.find({ _id: { $in: ids } }).toArray());
+  }
+  if (resourceType === "secret_ref") {
+    return getCollection<VisibilityDocument>(CREDENTIAL_COLLECTIONS.secretRefs)
+      .then((collection) => collection.find({ id: { $in: ids } }).toArray());
+  }
+  return [];
+}
+
+function visibilityFromDocument(
+  req: AuthorizeRequest,
+  document: VisibilityDocument | null,
+): ResourceVisibility {
   if (!document) return null;
   if (document.visibility === "private" || document.visibility === "team" || document.visibility === "global") {
     return document.visibility;
@@ -47,6 +85,51 @@ async function loadVisibility(req: AuthorizeRequest): Promise<ResourceVisibility
 }
 
 export async function privateResourcePreCheck(req: AuthorizeRequest): Promise<AuthorizeResult | null> {
-  if (!isPrivateResourcesEnabled() || !PRIVATE_DATA_ACTIONS.has(req.action)) return null;
-  return evaluatePrivateResourceContext(req, await loadVisibility(req));
+  if (!AUTHZ_SYNC_GATED_ACTIONS.has(req.action) && !PRIVATE_DATA_ACTIONS.has(req.action)) return null;
+  const document = await loadResourceState(req);
+  if (!document) return null;
+  const syncDecision = AUTHZ_SYNC_GATED_ACTIONS.has(req.action)
+    ? authzSyncPreCheck(document)
+    : null;
+  if (syncDecision || !isPrivateResourcesEnabled()) return syncDecision;
+  return evaluatePrivateResourceContext(req, visibilityFromDocument(req, document));
+}
+
+export async function privateResourceBatchPreChecks(input: {
+  subject: Subject;
+  action: Action;
+  resourceType: ResourceType;
+  ids: string[];
+  trustedContext?: TrustedAuthorizeContext;
+}): Promise<Map<string, AuthorizeResult>> {
+  const decisions = new Map<string, AuthorizeResult>();
+  if (
+    !AUTHZ_SYNC_GATED_ACTIONS.has(input.action)
+    && !PRIVATE_DATA_ACTIONS.has(input.action)
+  ) return decisions;
+  const documents = await loadResourceStates(input.resourceType, input.ids);
+  for (const document of documents) {
+    const id = input.resourceType === "secret_ref" ? document.id : document._id;
+    if (!id) continue;
+    const syncDecision = AUTHZ_SYNC_GATED_ACTIONS.has(input.action)
+      ? authzSyncPreCheck(document)
+      : null;
+    if (syncDecision) {
+      decisions.set(id, syncDecision);
+      continue;
+    }
+    if (!isPrivateResourcesEnabled() || !PRIVATE_DATA_ACTIONS.has(input.action)) continue;
+    const request: AuthorizeRequest = {
+      subject: input.subject,
+      action: input.action,
+      resource: { type: input.resourceType, id },
+      trustedContext: input.trustedContext,
+    };
+    const contextDecision = evaluatePrivateResourceContext(
+      request,
+      visibilityFromDocument(request, document),
+    );
+    if (contextDecision) decisions.set(id, contextDecision);
+  }
+  return decisions;
 }

--- a/ui/src/lib/authz/domains/private-resource.ts
+++ b/ui/src/lib/authz/domains/private-resource.ts
@@ -29,19 +29,40 @@ interface VisibilityDocument extends AuthzSyncDocument {
   visibility?: string;
   owner?: { type?: string };
   sharedWithTeams?: string[];
+  owner_id?: string;
+  owner_subject?: string;
 }
 
-async function loadResourceState(req: AuthorizeRequest): Promise<VisibilityDocument | null> {
+function shouldSyncGate(resourceType: ResourceType, action: Action): boolean {
+  return (
+    AUTHZ_SYNC_GATED_ACTIONS.has(action) ||
+    ((resourceType === "skill" || resourceType === "task") && action === "read")
+  );
+}
+
+async function loadResourceState(
+  req: AuthorizeRequest,
+): Promise<VisibilityDocument | null> {
   let document: VisibilityDocument | null = null;
   if (req.resource.type === "agent") {
-    const collection = await getCollection<VisibilityDocument>("dynamic_agents");
+    const collection =
+      await getCollection<VisibilityDocument>("dynamic_agents");
     document = await collection.findOne({ _id: req.resource.id });
   } else if (req.resource.type === "mcp_server") {
     const collection = await getCollection<VisibilityDocument>("mcp_servers");
     document = await collection.findOne({ _id: req.resource.id });
   } else if (req.resource.type === "secret_ref") {
-    const collection = await getCollection<VisibilityDocument>(CREDENTIAL_COLLECTIONS.secretRefs);
+    const collection = await getCollection<VisibilityDocument>(
+      CREDENTIAL_COLLECTIONS.secretRefs,
+    );
     document = await collection.findOne({ id: req.resource.id });
+  } else if (req.resource.type === "skill") {
+    const collection = await getCollection<VisibilityDocument>("agent_skills");
+    document = await collection.findOne({ id: req.resource.id });
+  } else if (req.resource.type === "task") {
+    const collection =
+      await getCollection<VisibilityDocument>("workflow_configs");
+    document = await collection.findOne({ _id: req.resource.id });
   } else {
     return null;
   }
@@ -54,16 +75,29 @@ async function loadResourceStates(
 ): Promise<VisibilityDocument[]> {
   if (ids.length === 0) return [];
   if (resourceType === "agent") {
-    return getCollection<VisibilityDocument>("dynamic_agents")
-      .then((collection) => collection.find({ _id: { $in: ids } }).toArray());
+    return getCollection<VisibilityDocument>("dynamic_agents").then(
+      (collection) => collection.find({ _id: { $in: ids } }).toArray(),
+    );
   }
   if (resourceType === "mcp_server") {
-    return getCollection<VisibilityDocument>("mcp_servers")
-      .then((collection) => collection.find({ _id: { $in: ids } }).toArray());
+    return getCollection<VisibilityDocument>("mcp_servers").then((collection) =>
+      collection.find({ _id: { $in: ids } }).toArray(),
+    );
   }
   if (resourceType === "secret_ref") {
-    return getCollection<VisibilityDocument>(CREDENTIAL_COLLECTIONS.secretRefs)
-      .then((collection) => collection.find({ id: { $in: ids } }).toArray());
+    return getCollection<VisibilityDocument>(
+      CREDENTIAL_COLLECTIONS.secretRefs,
+    ).then((collection) => collection.find({ id: { $in: ids } }).toArray());
+  }
+  if (resourceType === "skill") {
+    return getCollection<VisibilityDocument>("agent_skills").then(
+      (collection) => collection.find({ id: { $in: ids } }).toArray(),
+    );
+  }
+  if (resourceType === "task") {
+    return getCollection<VisibilityDocument>("workflow_configs").then(
+      (collection) => collection.find({ _id: { $in: ids } }).toArray(),
+    );
   }
   return [];
 }
@@ -73,26 +107,40 @@ function visibilityFromDocument(
   document: VisibilityDocument | null,
 ): ResourceVisibility {
   if (!document) return null;
-  if (document.visibility === "private" || document.visibility === "team" || document.visibility === "global") {
+  if (
+    document.visibility === "private" ||
+    document.visibility === "team" ||
+    document.visibility === "global"
+  ) {
     return document.visibility;
   }
   if (req.resource.type === "secret_ref") {
-    return document.owner?.type === "user" && (document.sharedWithTeams?.length ?? 0) === 0
+    return document.owner?.type === "user" &&
+      (document.sharedWithTeams?.length ?? 0) === 0
       ? "private"
       : "team";
   }
   return null;
 }
 
-export async function privateResourcePreCheck(req: AuthorizeRequest): Promise<AuthorizeResult | null> {
-  if (!AUTHZ_SYNC_GATED_ACTIONS.has(req.action) && !PRIVATE_DATA_ACTIONS.has(req.action)) return null;
+export async function privateResourcePreCheck(
+  req: AuthorizeRequest,
+): Promise<AuthorizeResult | null> {
+  if (
+    !shouldSyncGate(req.resource.type, req.action) &&
+    !PRIVATE_DATA_ACTIONS.has(req.action)
+  )
+    return null;
   const document = await loadResourceState(req);
   if (!document) return null;
-  const syncDecision = AUTHZ_SYNC_GATED_ACTIONS.has(req.action)
+  const syncDecision = shouldSyncGate(req.resource.type, req.action)
     ? authzSyncPreCheck(document)
     : null;
   if (syncDecision || !isPrivateResourcesEnabled()) return syncDecision;
-  return evaluatePrivateResourceContext(req, visibilityFromDocument(req, document));
+  return evaluatePrivateResourceContext(
+    req,
+    visibilityFromDocument(req, document),
+  );
 }
 
 export async function privateResourceBatchPreChecks(input: {
@@ -104,21 +152,26 @@ export async function privateResourceBatchPreChecks(input: {
 }): Promise<Map<string, AuthorizeResult>> {
   const decisions = new Map<string, AuthorizeResult>();
   if (
-    !AUTHZ_SYNC_GATED_ACTIONS.has(input.action)
-    && !PRIVATE_DATA_ACTIONS.has(input.action)
-  ) return decisions;
+    !shouldSyncGate(input.resourceType, input.action) &&
+    !PRIVATE_DATA_ACTIONS.has(input.action)
+  )
+    return decisions;
   const documents = await loadResourceStates(input.resourceType, input.ids);
   for (const document of documents) {
-    const id = input.resourceType === "secret_ref" ? document.id : document._id;
+    const id =
+      input.resourceType === "secret_ref" || input.resourceType === "skill"
+        ? document.id
+        : document._id;
     if (!id) continue;
-    const syncDecision = AUTHZ_SYNC_GATED_ACTIONS.has(input.action)
+    const syncDecision = shouldSyncGate(input.resourceType, input.action)
       ? authzSyncPreCheck(document)
       : null;
     if (syncDecision) {
       decisions.set(id, syncDecision);
       continue;
     }
-    if (!isPrivateResourcesEnabled() || !PRIVATE_DATA_ACTIONS.has(input.action)) continue;
+    if (!isPrivateResourcesEnabled() || !PRIVATE_DATA_ACTIONS.has(input.action))
+      continue;
     const request: AuthorizeRequest = {
       subject: input.subject,
       action: input.action,

--- a/ui/src/lib/authz/index.ts
+++ b/ui/src/lib/authz/index.ts
@@ -59,21 +59,19 @@ export async function authorizeMany(
   ctx: DecisionContext = {},
   trustedContext?: AuthorizeRequest["trustedContext"],
 ): Promise<Map<string, AuthorizeResult>> {
-  if (trustedContext && (action === "use" || action === "invoke" || action === "call")) {
-    const entries = await Promise.all(ids.map(async (id) => [
-      id,
-      await authorize({
-        subject,
-        action,
-        resource: { type: resourceType, id },
-        trustedContext,
-      }, ctx),
-    ] as const));
-    return new Map(entries);
-  }
-  const results = await engine.batchCheck(subject, action, resourceType, ids);
+  const { privateResourceBatchPreChecks } = await import("./domains/private-resource");
+  const preChecks = await privateResourceBatchPreChecks({
+    subject,
+    action,
+    resourceType,
+    ids,
+    trustedContext,
+  });
+  const uncheckedIds = ids.filter((id) => !preChecks.has(id));
+  const results = await engine.batchCheck(subject, action, resourceType, uncheckedIds);
+  for (const [id, decision] of preChecks) results.set(id, decision);
   for (const [id, result] of results) {
-    emitDecisionAudit(subject, { type: resourceType, id }, action, result, ctx);
+    emitDecisionAudit(subject, { type: resourceType, id }, action, result, ctx, trustedContext);
   }
   return results;
 }

--- a/ui/src/lib/authz/reasons.ts
+++ b/ui/src/lib/authz/reasons.ts
@@ -13,6 +13,8 @@ const REASON_META: Record<ReasonCode, ReasonMeta> = {
   NO_CAPABILITY:    { retriable: false, httpStatusHint: 200, userActionHint: "contact_admin" },
   NOT_AUTHENTICATED:{ retriable: false, httpStatusHint: 401, userActionHint: "sign_in" },
   AUTHZ_UNAVAILABLE:{ retriable: true,  httpStatusHint: 503, userActionHint: "retry" },
+  AUTHZ_SYNC_PENDING:{ retriable: true, httpStatusHint: 409, userActionHint: "retry" },
+  AUTHZ_SYNC_ERROR:  { retriable: true, httpStatusHint: 503, userActionHint: "contact_admin" },
   INVALID_REQUEST:  { retriable: false, httpStatusHint: 400, userActionHint: "fix_request" },
   PRIVATE_RESOURCE_CONTEXT_DENIED: {
     retriable: false,

--- a/ui/src/lib/authz/reconcile.ts
+++ b/ui/src/lib/authz/reconcile.ts
@@ -6,6 +6,7 @@
 
 import {
   writeOpenFgaTupleDiff,
+  verifyOpenFgaTupleDiff,
   isOpenFgaReconciliationEnabled,
   type OpenFgaReconcileResult,
   type TeamResourceTupleDiff,
@@ -20,6 +21,8 @@ export interface TupleReconcileContext extends DecisionContext {
   caller?: Subject;
   /** Short label for the audit tab (e.g. mcp_server_create, team_resources). */
   source?: string;
+  /** Verify changed direct tuples using OpenFGA's higher-consistency read mode. */
+  verifyHigherConsistency?: boolean;
 }
 
 export class OpenFgaReconcileRequiredError extends Error {
@@ -75,6 +78,17 @@ export async function reconcileTupleDiff(
 
   if (result.enabled && (result.writes > 0 || result.deletes > 0)) {
     invalidateDecisionCache();
+  }
+  if (ctx.verifyHigherConsistency && result.enabled) {
+    try {
+      await verifyOpenFgaTupleDiff(diff);
+    } catch (error) {
+      emitReconcileAudit(diff, result, ctx, {
+        outcome: "error",
+        reasonCode: error instanceof Error ? error.name : "PDP_VERIFY_FAILED",
+      });
+      throw error;
+    }
   }
   emitReconcileAudit(diff, result, ctx);
   return result;

--- a/ui/src/lib/authz/resource-sync.ts
+++ b/ui/src/lib/authz/resource-sync.ts
@@ -1,0 +1,101 @@
+import type { AuthorizeResult, ReasonCode } from "./contract";
+
+export type AuthzSyncState = "pending" | "ready" | "error";
+
+export const AUTHZ_SYNC_GATED_ACTIONS = new Set([
+  "discover",
+  "use",
+  "invoke",
+  "call",
+]);
+
+export interface AuthzSyncDocument {
+  authz_revision?: number;
+  authz_sync_state?: AuthzSyncState;
+  authz_last_synced_revision?: number;
+  authz_last_error_code?: string;
+  authz_sync_started_at?: string;
+}
+
+export class AuthzSyncSupersededError extends Error {
+  constructor() {
+    super("Authorization state changed while it was being reconciled");
+    this.name = "AuthzSyncSupersededError";
+  }
+}
+
+export function currentAuthzRevision(document: AuthzSyncDocument): number {
+  return Number.isSafeInteger(document.authz_revision) && document.authz_revision! >= 0
+    ? document.authz_revision!
+    : 0;
+}
+
+export function nextAuthzRevision(document: AuthzSyncDocument): number {
+  return currentAuthzRevision(document) + 1;
+}
+
+export function authzRevisionFilter(document: AuthzSyncDocument): Record<string, unknown> {
+  return document.authz_revision === undefined
+    ? { authz_revision: { $exists: false } }
+    : { authz_revision: currentAuthzRevision(document) };
+}
+
+const ACTIVE_SYNC_WINDOW_MS = 90_000;
+
+export function hasActiveAuthzSync(
+  document: AuthzSyncDocument,
+  now = Date.now(),
+): boolean {
+  if (document.authz_sync_state !== "pending") return false;
+  const started = Date.parse(document.authz_sync_started_at ?? "");
+  return Number.isFinite(started) && now - started < ACTIVE_SYNC_WINDOW_MS;
+}
+
+export function authzSyncPreCheck(
+  document: AuthzSyncDocument,
+): AuthorizeResult | null {
+  const readyRevisionMismatch = document.authz_sync_state === "ready"
+    && currentAuthzRevision(document) !== document.authz_last_synced_revision;
+  if (
+    document.authz_sync_state !== "pending"
+    && document.authz_sync_state !== "error"
+    && !readyRevisionMismatch
+  ) {
+    return null;
+  }
+  const reason: ReasonCode = document.authz_sync_state === "pending"
+    ? "AUTHZ_SYNC_PENDING"
+    : "AUTHZ_SYNC_ERROR";
+  return {
+    decision: "DENY",
+    reason,
+    retriable: true,
+    via: "authz_sync_state",
+  };
+}
+
+export function sanitizedAuthzErrorCode(error: unknown): string {
+  const name = error instanceof Error ? error.name : "";
+  if (name === "OpenFgaReconcileRequiredError") return "OPENFGA_RECONCILIATION_REQUIRED";
+  if (name === "OpenFgaVerificationError") return "OPENFGA_VERIFICATION_FAILED";
+  return "OPENFGA_RECONCILIATION_FAILED";
+}
+
+export async function runRevisionedAuthzSync<T>(input: {
+  reconcile: () => Promise<void>;
+  markReady: () => Promise<T | null>;
+  markError: (errorCode: string) => Promise<void>;
+}): Promise<T> {
+  try {
+    await input.reconcile();
+  } catch (error) {
+    await input.markError(sanitizedAuthzErrorCode(error)).catch((markError) => {
+      console.error("[authz-sync] failed to persist reconciliation error state", markError);
+    });
+    throw error;
+  }
+
+  const ready = await input.markReady();
+  if (!ready) throw new AuthzSyncSupersededError();
+  return ready;
+}

--- a/ui/src/lib/credentials/__tests__/secret-service.test.ts
+++ b/ui/src/lib/credentials/__tests__/secret-service.test.ts
@@ -35,7 +35,12 @@ class MemorySecretRefsCollection {
   async findOne(query: Record<string, unknown>) {
     return (
       this.docs.find((doc) =>
-        Object.entries(query).every(([key, value]) => doc[key] === value),
+        Object.entries(query).every(([key, value]) => {
+          if (value && typeof value === "object" && "$exists" in value) {
+            return (key in doc) === Boolean(value.$exists);
+          }
+          return doc[key] === value;
+        }),
       ) ?? null
     );
   }
@@ -46,11 +51,13 @@ class MemorySecretRefsCollection {
       $set?: Record<string, unknown>;
       $addToSet?: { sharedWithTeams?: string };
       $pull?: { sharedWithTeams?: string };
+      $unset?: Record<string, unknown>;
     },
   ) {
     const doc = await this.findOne(query);
     if (!doc) return { matchedCount: 0, modifiedCount: 0 };
     Object.assign(doc, update.$set ?? {});
+    for (const key of Object.keys(update.$unset ?? {})) delete doc[key];
     if (update.$addToSet?.sharedWithTeams) {
       doc.sharedWithTeams = [...new Set([...(doc.sharedWithTeams ?? []), update.$addToSet.sharedWithTeams])];
     }
@@ -396,6 +403,32 @@ describe("SecretService", () => {
     expect(deleteShare).toHaveBeenCalledWith("secret-1", "platform-team");
     expect(deleteAllRelationships).toHaveBeenCalledWith("secret-1");
     expect(refs.docs).toEqual([]);
+  });
+
+  it("persists a failed share reconciliation as an error revision", async () => {
+    const { refs, reconcileShare, service } = createService();
+    await service.createSecret({
+      session: { sub: "alice-sub" },
+      owner: { type: "user", id: "alice-sub" },
+      name: "Example token",
+      type: "bearer_token",
+      plaintext: "example-token-value",
+    });
+    reconcileShare.mockRejectedValueOnce(new Error("OpenFGA unavailable"));
+
+    await expect(service.shareSecret({
+      session: { sub: "alice-sub" },
+      secretId: "secret-1",
+      teamId: "primary",
+    })).rejects.toThrow("OpenFGA unavailable");
+
+    expect(refs.docs[0]).toMatchObject({
+      authz_revision: 2,
+      authz_sync_state: "error",
+      authz_last_error_code: "OPENFGA_RECONCILIATION_FAILED",
+      sharedWithTeams: ["primary"],
+      visibility: "team",
+    });
   });
 
   it("supports admin listing and metadata edits without exposing plaintext", async () => {

--- a/ui/src/lib/credentials/secret-openfga.ts
+++ b/ui/src/lib/credentials/secret-openfga.ts
@@ -91,6 +91,7 @@ export async function reconcileSecretRefOwnerRelationships(input: {
   }, {
     caller: input.ownerSubject ? { type: "user", id: input.ownerSubject } : undefined,
     source: "secret_ref_owner_reconcile",
+    verifyHigherConsistency: true,
   });
 }
 
@@ -98,14 +99,14 @@ export async function reconcileSecretRefShare(secretId: string, teamId: string):
   await reconcileTupleDiff({
     writes: buildSecretRefShareTuples(secretId, teamId),
     deletes: [],
-  }, { source: "secret_ref_share" });
+  }, { source: "secret_ref_share", verifyHigherConsistency: true });
 }
 
 export async function deleteSecretRefShare(secretId: string, teamId: string): Promise<void> {
   await reconcileTupleDiff({
     writes: [],
     deletes: buildSecretRefShareTuples(secretId, teamId),
-  }, { source: "secret_ref_share_revoke" });
+  }, { source: "secret_ref_share_revoke", verifyHigherConsistency: true });
 }
 
 export async function deleteAllSecretRefRelationships(secretId: string): Promise<void> {

--- a/ui/src/lib/credentials/secret-service.ts
+++ b/ui/src/lib/credentials/secret-service.ts
@@ -1,6 +1,14 @@
 // assisted-by Codex Codex-sonnet-4-6
 
 import { ApiError } from "@/lib/api-error";
+import {
+  authzRevisionFilter,
+  AuthzSyncSupersededError,
+  hasActiveAuthzSync,
+  nextAuthzRevision,
+  runRevisionedAuthzSync,
+  type AuthzSyncDocument,
+} from "@/lib/authz/resource-sync";
 import type { ResourceAuthzSession } from "@/lib/rbac/resource-authz";
 
 import { writeCredentialAuditEvent } from "./audit";
@@ -33,7 +41,7 @@ export interface SecretUsageReference {
   detail?: string;
 }
 
-export interface SecretRefDocument {
+export interface SecretRefDocument extends AuthzSyncDocument {
   id: string;
   owner: CredentialOwnerRef;
   createdBy?: SecretActorRef;
@@ -45,6 +53,7 @@ export interface SecretRefDocument {
   createdAt: Date;
   updatedAt: Date;
   rotatedAt?: Date;
+  authz_previous_state?: Record<string, unknown>;
 }
 
 export interface SecretMetadata {
@@ -62,6 +71,10 @@ export interface SecretMetadata {
   createdAt: string;
   updatedAt: string;
   rotatedAt?: string;
+  authzRevision?: number;
+  authzSyncState?: "pending" | "ready" | "error";
+  authzLastSyncedRevision?: number;
+  authzLastErrorCode?: string;
 }
 
 interface SecretRefsCollection {
@@ -242,6 +255,10 @@ function toMetadata(
     createdAt: doc.createdAt.toISOString(),
     updatedAt: doc.updatedAt.toISOString(),
     rotatedAt: doc.rotatedAt?.toISOString(),
+    authzRevision: doc.authz_revision,
+    authzSyncState: doc.authz_sync_state,
+    authzLastSyncedRevision: doc.authz_last_synced_revision,
+    authzLastErrorCode: doc.authz_last_error_code,
   };
 }
 
@@ -291,6 +308,9 @@ export class SecretService {
       createdAt: now,
       updatedAt: now,
       rotatedAt: now,
+      authz_revision: 1,
+      authz_sync_state: "ready",
+      authz_last_synced_revision: 1,
     };
 
     await this.payloadStore.putSecret({ secretRefId: id, plaintext, maskedPreview });
@@ -531,31 +551,99 @@ export class SecretService {
   }
 
   async shareSecret(input: SecretShareInput): Promise<void> {
-    await this.getSecretRef(input.secretId);
+    const doc = await this.getSecretRef(input.secretId);
     await this.authorize(input.session, { type: "secret_ref", id: input.secretId, action: "share" });
     const teamId = requireNonEmptyString(input.teamId, "teamId");
-    await this.reconcileShare(input.secretId, teamId);
-    await this.secretRefsCollection.updateOne(
-      { id: input.secretId },
-      { $addToSet: { sharedWithTeams: teamId }, $set: { visibility: "team" } },
-    );
+    await this.updateSecretShareAuthorization({ doc, teamId, revoke: false });
   }
 
   async revokeSecretShare(input: SecretShareInput): Promise<void> {
-    await this.getSecretRef(input.secretId);
+    const doc = await this.getSecretRef(input.secretId);
     await this.authorize(input.session, { type: "secret_ref", id: input.secretId, action: "share" });
     const teamId = requireNonEmptyString(input.teamId, "teamId");
-    await this.deleteShare(input.secretId, teamId);
-    await this.secretRefsCollection.updateOne(
-      { id: input.secretId },
-      { $pull: { sharedWithTeams: teamId } },
-    );
-    const updated = await this.getSecretRef(input.secretId);
-    if (updated.owner.type === "user" && updated.sharedWithTeams.length === 0) {
-      await this.secretRefsCollection.updateOne(
-        { id: input.secretId },
-        { $set: { visibility: "private" } },
+    await this.updateSecretShareAuthorization({ doc, teamId, revoke: true });
+  }
+
+  private async updateSecretShareAuthorization(input: {
+    doc: SecretRefDocument;
+    teamId: string;
+    revoke: boolean;
+  }): Promise<void> {
+    if (hasActiveAuthzSync(input.doc)) {
+      throw new ApiError(
+        "This credential's authorization is already being reconciled. Retry shortly.",
+        409,
+        "AUTHZ_SYNC_PENDING",
       );
+    }
+    const nextTeams = input.revoke
+      ? normalizedTeamIds(input.doc.sharedWithTeams).filter((team) => team !== input.teamId)
+      : normalizedTeamIds([...input.doc.sharedWithTeams, input.teamId]);
+    const revision = nextAuthzRevision(input.doc);
+    const pendingResult = await this.secretRefsCollection.updateOne(
+      { id: input.doc.id, ...authzRevisionFilter(input.doc) },
+      {
+        $set: {
+          sharedWithTeams: nextTeams,
+          visibility: input.doc.owner.type === "user" && nextTeams.length === 0
+            ? "private"
+            : "team",
+          authz_revision: revision,
+          authz_sync_state: "pending",
+          authz_sync_started_at: this.now().toISOString(),
+          authz_previous_state: input.doc.authz_previous_state ?? {
+            sharedWithTeams: input.doc.sharedWithTeams,
+            visibility: input.doc.visibility,
+          },
+        },
+        $unset: { authz_last_error_code: "" },
+      },
+    );
+    if (pendingResult.matchedCount === 0) {
+      throw new ApiError(
+        "This credential changed while authorization was being prepared. Retry the update.",
+        409,
+        "AUTHZ_SYNC_SUPERSEDED",
+      );
+    }
+
+    try {
+      await runRevisionedAuthzSync({
+        reconcile: () => input.revoke
+          ? this.deleteShare(input.doc.id, input.teamId)
+          : this.reconcileShare(input.doc.id, input.teamId),
+        markError: async (errorCode) => {
+          await this.secretRefsCollection.updateOne(
+            { id: input.doc.id, authz_revision: revision, authz_sync_state: "pending" },
+            {
+              $set: { authz_sync_state: "error", authz_last_error_code: errorCode },
+              $unset: { authz_sync_started_at: "" },
+            },
+          );
+        },
+        markReady: async () => {
+          const result = await this.secretRefsCollection.updateOne(
+            { id: input.doc.id, authz_revision: revision, authz_sync_state: "pending" },
+            {
+              $set: {
+                authz_sync_state: "ready",
+                authz_last_synced_revision: revision,
+              },
+              $unset: {
+                authz_last_error_code: "",
+                authz_previous_state: "",
+                authz_sync_started_at: "",
+              },
+            },
+          );
+          return result.matchedCount === 0 ? null : result;
+        },
+      });
+    } catch (error) {
+      if (error instanceof AuthzSyncSupersededError) {
+        throw new ApiError(error.message, 409, "AUTHZ_SYNC_SUPERSEDED");
+      }
+      throw error;
     }
   }
 

--- a/ui/src/lib/rbac/__tests__/agent-mcp-dependency-scope.test.ts
+++ b/ui/src/lib/rbac/__tests__/agent-mcp-dependency-scope.test.ts
@@ -1,0 +1,84 @@
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn() }));
+jest.mock("@/lib/rbac/resource-authz", () => ({ requireResourcePermission: jest.fn() }));
+
+import { validateAgentMcpDependencyScopes } from "../agent-mcp-dependency-scope";
+import type { MCPServerConfig } from "@/types/dynamic-agent";
+
+function server(
+  id: string,
+  visibility: "private" | "team" | "global",
+  extra: Partial<MCPServerConfig> = {},
+): MCPServerConfig {
+  return {
+    _id: id,
+    name: id,
+    transport: "http",
+    enabled: true,
+    visibility,
+    created_at: "2026-09-08T00:00:00.000Z",
+    updated_at: "2026-09-08T00:00:00.000Z",
+    ...extra,
+  };
+}
+
+describe("agent MCP dependency visibility", () => {
+  it("allows private dependencies only for a private agent with the same owner", async () => {
+    await expect(validateAgentMcpDependencyScopes({
+      agent: { visibility: "private", ownerSubject: "user-a" },
+      allowedTools: { "mcp-private": true },
+      servers: [server("mcp-private", "private", { owner_subject: "user-a" })],
+    })).resolves.toBeUndefined();
+
+    await expect(validateAgentMcpDependencyScopes({
+      agent: { visibility: "private", ownerSubject: "user-a" },
+      allowedTools: { "mcp-private": true },
+      servers: [server("mcp-private", "private", { owner_subject: "user-b" })],
+    })).rejects.toMatchObject({ code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED" });
+  });
+
+  it("rejects a team or global agent that references a narrower MCP server", async () => {
+    await expect(validateAgentMcpDependencyScopes({
+      agent: { visibility: "team", ownerSubject: "user-a", ownerTeamSlug: "primary" },
+      allowedTools: { "mcp-private": true },
+      servers: [server("mcp-private", "private", { owner_subject: "user-a" })],
+    })).rejects.toMatchObject({ code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED" });
+    await expect(validateAgentMcpDependencyScopes({
+      agent: { visibility: "global", ownerSubject: "user-a" },
+      allowedTools: { "mcp-team": true },
+      servers: [server("mcp-team", "team", { owner_team_slug: "primary" })],
+    })).rejects.toMatchObject({ code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED" });
+  });
+
+  it("requires every team that can use an agent to be covered by its MCP server", async () => {
+    const agent = {
+      visibility: "team" as const,
+      ownerSubject: "user-a",
+      ownerTeamSlug: "primary",
+      sharedTeamSlugs: ["secondary"],
+    };
+    await expect(validateAgentMcpDependencyScopes({
+      agent,
+      allowedTools: { "mcp-team": true },
+      servers: [server("mcp-team", "team", {
+        owner_team_slug: "primary",
+        shared_with_teams: ["secondary"],
+      })],
+    })).resolves.toBeUndefined();
+    await expect(validateAgentMcpDependencyScopes({
+      agent,
+      allowedTools: { "mcp-team": true },
+      servers: [server("mcp-team", "team", { owner_team_slug: "primary" })],
+    })).rejects.toMatchObject({ code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED" });
+  });
+
+  it("requires a private-agent owner to be able to invoke a selected team MCP server", async () => {
+    const canInvokeServer = jest.fn(async () => false);
+    await expect(validateAgentMcpDependencyScopes({
+      agent: { visibility: "private", ownerSubject: "user-a" },
+      allowedTools: { "mcp-team": true },
+      servers: [server("mcp-team", "team", { owner_team_slug: "primary" })],
+      canInvokeServer,
+    })).rejects.toMatchObject({ code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED" });
+    expect(canInvokeServer).toHaveBeenCalledWith("mcp-team");
+  });
+});

--- a/ui/src/lib/rbac/__tests__/agent-resource-dependency-scope.test.ts
+++ b/ui/src/lib/rbac/__tests__/agent-resource-dependency-scope.test.ts
@@ -1,0 +1,133 @@
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn() }));
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireResourcePermission: jest.fn(),
+}));
+
+import { getCollection } from "@/lib/mongodb";
+import { requireResourcePermission } from "@/lib/rbac/resource-authz";
+import { validatePersistedAgentResourceDependencies } from "../agent-mcp-dependency-scope";
+
+const mockGetCollection = getCollection as jest.Mock;
+const mockRequireResourcePermission = requireResourcePermission as jest.Mock;
+
+function collectionRows(rows: unknown[]) {
+  return { find: jest.fn(() => ({ toArray: jest.fn(async () => rows) })) };
+}
+
+describe("agent skill and workflow dependency visibility", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireResourcePermission.mockResolvedValue(undefined);
+  });
+
+  it("rejects a global agent that embeds a private skill", async () => {
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "agent_skills"
+        ? collectionRows([
+            {
+              id: "skill-private",
+              visibility: "private",
+              owner_subject: "owner-a",
+            },
+          ])
+        : collectionRows([]),
+    );
+
+    await expect(
+      validatePersistedAgentResourceDependencies({
+        session: { sub: "owner-a" },
+        agent: { visibility: "global", ownerSubject: "owner-a" },
+        skillIds: ["skill-private"],
+      }),
+    ).rejects.toMatchObject({ code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED" });
+  });
+
+  it("allows a private agent to use private skills and workflows from the same owner", async () => {
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "agent_skills"
+        ? collectionRows([
+            {
+              id: "skill-private",
+              visibility: "private",
+              owner_subject: "owner-a",
+            },
+          ])
+        : collectionRows([
+            {
+              _id: "wf-private",
+              visibility: "private",
+              owner_subject: "owner-a",
+            },
+          ]),
+    );
+
+    await expect(
+      validatePersistedAgentResourceDependencies({
+        session: { sub: "owner-a" },
+        agent: { visibility: "private", ownerSubject: "owner-a" },
+        skillIds: ["skill-private"],
+        workflowIds: ["wf-private"],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("matches legacy private dependencies by owner email", async () => {
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "agent_skills"
+        ? collectionRows([
+            {
+              id: "skill-legacy-private",
+              visibility: "private",
+              owner_id: "owner@example.com",
+            },
+          ])
+        : collectionRows([]),
+    );
+
+    await expect(
+      validatePersistedAgentResourceDependencies({
+        session: { sub: "owner-a" },
+        agent: {
+          visibility: "private",
+          ownerSubject: "owner-a",
+          ownerEmail: "OWNER@example.com",
+        },
+        skillIds: ["skill-legacy-private"],
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("fails closed while a selected dependency is awaiting reconciliation", async () => {
+    mockGetCollection.mockImplementation(async (name: string) =>
+      name === "agent_skills"
+        ? collectionRows([
+            {
+              id: "skill-pending",
+              visibility: "global",
+              authz_sync_state: "pending",
+            },
+          ])
+        : collectionRows([]),
+    );
+
+    await expect(
+      validatePersistedAgentResourceDependencies({
+        session: { sub: "owner-a" },
+        agent: { visibility: "global", ownerSubject: "owner-a" },
+        skillIds: ["skill-pending"],
+      }),
+    ).rejects.toMatchObject({ code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED" });
+  });
+
+  it("treats hub catalog skills as global instead of requiring agent_skills rows", async () => {
+    mockGetCollection.mockImplementation(async () => collectionRows([]));
+
+    await expect(
+      validatePersistedAgentResourceDependencies({
+        session: { sub: "owner-a" },
+        agent: { visibility: "global", ownerSubject: "owner-a" },
+        skillIds: ["hub-507f1f77bcf86cd799439011-safe-skill"],
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/ui/src/lib/rbac/__tests__/default-deny-coverage.test.ts
+++ b/ui/src/lib/rbac/__tests__/default-deny-coverage.test.ts
@@ -16,6 +16,10 @@ jest.mock("@/lib/authz", () => ({
   authorizeMany: jest.fn(),
 }));
 
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: jest.fn(),
+}));
+
 import { requireResourcePermission } from "../resource-authz";
 import { UNIVERSAL_REBAC_RESOURCE_TYPES } from "../resource-model";
 import { isUnsafeRbacBypassEnabled } from "../bypass";

--- a/ui/src/lib/rbac/__tests__/openfga.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga.test.ts
@@ -30,6 +30,7 @@ import {
   isOpenFgaReconciliationEnabled,
   readOpenFgaTuples,
   resetOpenFgaStoreIdCacheForTests,
+  verifyOpenFgaTupleDiff,
   writeOpenFgaTupleDiff,
   writeUniversalRebacTupleDiff,
 } from "../openfga";
@@ -618,6 +619,37 @@ describe("OpenFGA team resource tuple reconciliation", () => {
     expect(JSON.parse(String(fetchMock.mock.calls[1][1]?.body))).toMatchObject({
       page_size: 100,
     });
+  });
+
+  it("verifies writes and deletes with higher-consistency tuple reads", async () => {
+    process.env.OPENFGA_RECONCILE_ENABLED = "true";
+    process.env.OPENFGA_HTTP = "http://openfga:8080";
+    process.env.OPENFGA_STORE_NAME = "caipe-openfga";
+    const written = { user: "user:alice", relation: "owner", object: "agent:example" };
+    const deleted = { user: "team:primary#member", relation: "user", object: "agent:example" };
+    const fetchMock = jest.fn(async (url: string, init?: RequestInit) => {
+      if (url.endsWith("/stores")) {
+        return { ok: true, json: async () => ({ stores: [{ id: "store-1", name: "caipe-openfga" }] }) };
+      }
+      const body = JSON.parse(String(init?.body));
+      return {
+        ok: true,
+        json: async () => ({
+          tuples: body.tuple_key.user === written.user ? [{ key: written }] : [],
+        }),
+      };
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await expect(verifyOpenFgaTupleDiff({
+      writes: [written],
+      deletes: [deleted],
+    })).resolves.toBeUndefined();
+    for (const [, init] of fetchMock.mock.calls.slice(1)) {
+      expect(JSON.parse(String(init?.body))).toMatchObject({
+        consistency: "HIGHER_CONSISTENCY",
+      });
+    }
   });
 
   it("builds universal relationship tuple diffs using base writable relations", () => {

--- a/ui/src/lib/rbac/__tests__/resource-authz-admin-bypass.test.ts
+++ b/ui/src/lib/rbac/__tests__/resource-authz-admin-bypass.test.ts
@@ -7,6 +7,11 @@ jest.mock("@/lib/authz", () => ({
   authorizeMany: jest.fn(),
 }));
 
+const mockFindSkill = jest.fn();
+jest.mock("@/lib/mongodb", () => ({
+  getCollection: jest.fn(async () => ({ findOne: mockFindSkill })),
+}));
+
 import { ApiError } from "@/lib/api-error";
 
 import {
@@ -27,6 +32,7 @@ describe("resource-authz org-admin bypass", () => {
 
   beforeEach(() => {
     process.env = { ...originalEnv, CAIPE_ORG_KEY: "caipe" };
+    mockFindSkill.mockResolvedValue(null);
   });
 
   afterAll(() => {
@@ -232,6 +238,23 @@ describe("resource-authz org-admin bypass", () => {
         relation: "can_manage",
         object: "admin_surface:skills",
       });
+    });
+
+    it("does not let an app admin bypass another user's private skill", async () => {
+      mockFindSkill.mockResolvedValue({
+        id: "skill-private",
+        visibility: "private",
+        owner_subject: "owner-sub",
+      });
+      const check = jest.fn(async () => ({ allowed: true }));
+
+      await expect(requireSkillPermission(
+        { sub: "admin-sub", role: "admin", user: { email: "admin@example.com" } },
+        "skill-private",
+        "read",
+        { check },
+      )).rejects.toMatchObject({ statusCode: 403 });
+      expect(check).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/src/lib/rbac/__tests__/workflow-agent-dependency-scope.test.ts
+++ b/ui/src/lib/rbac/__tests__/workflow-agent-dependency-scope.test.ts
@@ -1,0 +1,75 @@
+jest.mock("@/lib/mongodb", () => ({ getCollection: jest.fn() }));
+jest.mock("@/lib/rbac/resource-authz", () => ({
+  requireAgentPermission: jest.fn(),
+}));
+
+import { getCollection } from "@/lib/mongodb";
+import { validateWorkflowAgentDependencies } from "../workflow-agent-dependency-scope";
+
+const mockGetCollection = getCollection as jest.Mock;
+
+function setAgents(agents: unknown[]): void {
+  mockGetCollection.mockResolvedValue({
+    find: jest.fn(() => ({ toArray: jest.fn(async () => agents) })),
+  });
+}
+
+const steps = [
+  {
+    type: "step" as const,
+    display_text: "Run",
+    agent_id: "agent-private",
+    prompt: "Run it",
+    on_error: "abort" as const,
+  },
+];
+
+describe("workflow agent dependency visibility", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("rejects a private agent inside a team or global workflow", async () => {
+    setAgents([
+      {
+        _id: "agent-private",
+        visibility: "private",
+        owner_subject: "owner-a",
+        owner_id: "owner@example.com",
+      },
+    ]);
+
+    await expect(
+      validateWorkflowAgentDependencies({
+        session: { sub: "owner-a" },
+        workflow: {
+          visibility: "team",
+          ownerSubject: "owner-a",
+          ownerEmail: "owner@example.com",
+        },
+        steps,
+      }),
+    ).rejects.toMatchObject({ code: "PRIVATE_RESOURCE_DEPENDENCY_DENIED" });
+  });
+
+  it("allows same-owner private composition", async () => {
+    setAgents([
+      {
+        _id: "agent-private",
+        visibility: "private",
+        owner_subject: "owner-a",
+        owner_id: "owner@example.com",
+      },
+    ]);
+
+    await expect(
+      validateWorkflowAgentDependencies({
+        session: { sub: "owner-a" },
+        workflow: {
+          visibility: "private",
+          ownerSubject: "owner-a",
+          ownerEmail: "owner@example.com",
+        },
+        steps,
+      }),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/ui/src/lib/rbac/__tests__/workflow-config-rebac.test.ts
+++ b/ui/src/lib/rbac/__tests__/workflow-config-rebac.test.ts
@@ -10,12 +10,14 @@ const mockListUserTeamSlugs = jest.fn();
 const mockGetCollection = jest.fn();
 
 jest.mock("@/lib/rbac/resource-authz", () => ({
-  requireResourcePermission: (...args: unknown[]) => mockRequireResourcePermission(...args),
+  requireResourcePermission: (...args: unknown[]) =>
+    mockRequireResourcePermission(...args),
   subjectFromSession: () => "alice-sub",
 }));
 
 jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
-  reconcileShareableResource: (...args: unknown[]) => mockReconcileShareableResource(...args),
+  reconcileShareableResource: (...args: unknown[]) =>
+    mockReconcileShareableResource(...args),
 }));
 
 jest.mock("@/lib/rbac/openfga-team-membership", () => ({
@@ -38,7 +40,11 @@ import {
 describe("workflow-config-rebac", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockReconcileShareableResource.mockResolvedValue({ enabled: true, writes: 2, deletes: 0 });
+    mockReconcileShareableResource.mockResolvedValue({
+      enabled: true,
+      writes: 2,
+      deletes: 0,
+    });
     mockListUserTeamSlugs.mockResolvedValue(["platform-eng"]);
   });
 
@@ -84,7 +90,11 @@ describe("workflow-config-rebac", () => {
     it("allows any user for global workflows", () => {
       expect(
         workflowRunAllowedByVisibility(
-          { visibility: "global", shared_with_teams: null, owner_id: "owner@example.com" },
+          {
+            visibility: "global",
+            shared_with_teams: null,
+            owner_id: "owner@example.com",
+          },
           "bob@example.com",
           [],
         ),
@@ -94,7 +104,12 @@ describe("workflow-config-rebac", () => {
     it("allows any user for system-seeded workflows without a visibility field", () => {
       expect(
         workflowRunAllowedByVisibility(
-          { visibility: undefined, shared_with_teams: null, owner_id: "system", config_driven: true },
+          {
+            visibility: undefined,
+            shared_with_teams: null,
+            owner_id: "system",
+            config_driven: true,
+          },
           "bob@example.com",
           [],
         ),
@@ -165,19 +180,43 @@ describe("workflow-config-rebac", () => {
     it("allows only the owner for private workflows", () => {
       expect(
         workflowRunAllowedByVisibility(
-          { visibility: "private", shared_with_teams: null, owner_id: "alice@example.com" },
+          {
+            visibility: "private",
+            shared_with_teams: null,
+            owner_id: "alice@example.com",
+          },
           "alice@example.com",
           [],
         ),
       ).toBe(true);
       expect(
         workflowRunAllowedByVisibility(
-          { visibility: "private", shared_with_teams: null, owner_id: "alice@example.com" },
+          {
+            visibility: "private",
+            shared_with_teams: null,
+            owner_id: "alice@example.com",
+          },
           "bob@example.com",
           [],
         ),
       ).toBe(false);
     });
+  });
+
+  it("fails closed when workflow authorization reconciliation is pending", async () => {
+    await expect(
+      requireWorkflowConfigRunAccess(
+        { sub: "alice-sub" },
+        {
+          _id: "wf-pending",
+          owner_id: "alice@example.com",
+          visibility: "private",
+          authz_sync_state: "pending",
+        },
+        "alice@example.com",
+        [],
+      ),
+    ).rejects.toMatchObject({ statusCode: 503, code: "AUTHZ_SYNC_PENDING" });
   });
 
   it("skips OpenFGA when global visibility allows run", async () => {
@@ -199,7 +238,9 @@ describe("workflow-config-rebac", () => {
   });
 
   it("allows the documented owner when OpenFGA use is denied", async () => {
-    mockRequireResourcePermission.mockRejectedValue(new ApiError("denied", 403));
+    mockRequireResourcePermission.mockRejectedValue(
+      new ApiError("denied", 403),
+    );
 
     await expect(
       requireWorkflowConfigRunAccess(
@@ -221,7 +262,11 @@ describe("workflow-config-rebac", () => {
   it("allows write only for the workflow owner (not system-owned)", () => {
     expect(
       workflowWriteAllowedByVisibility(
-        { visibility: "global", shared_with_teams: null, owner_id: "alice@example.com" },
+        {
+          visibility: "global",
+          shared_with_teams: null,
+          owner_id: "alice@example.com",
+        },
         "alice@example.com",
       ),
     ).toBe(true);
@@ -233,7 +278,11 @@ describe("workflow-config-rebac", () => {
     ).toBe(false);
     expect(
       workflowWriteAllowedByVisibility(
-        { visibility: "global", shared_with_teams: null, owner_id: "other@example.com" },
+        {
+          visibility: "global",
+          shared_with_teams: null,
+          owner_id: "other@example.com",
+        },
         "alice@example.com",
       ),
     ).toBe(false);
@@ -261,7 +310,11 @@ describe("workflow-config-rebac", () => {
       },
     ];
 
-    const visible = filterWorkflowConfigsByRunAccess(configs, "bob@example.com", ["platform-eng"]);
+    const visible = filterWorkflowConfigsByRunAccess(
+      configs,
+      "bob@example.com",
+      ["platform-eng"],
+    );
     expect(visible.map((c) => c._id)).toEqual(["wf-global", "wf-team"]);
   });
 });

--- a/ui/src/lib/rbac/agent-mcp-dependency-scope.ts
+++ b/ui/src/lib/rbac/agent-mcp-dependency-scope.ts
@@ -1,0 +1,129 @@
+import { ApiError } from "@/lib/api-error";
+import { getCollection } from "@/lib/mongodb";
+import {
+  requireResourcePermission,
+  type ResourceAuthzSession,
+} from "@/lib/rbac/resource-authz";
+import type { MCPServerConfig, VisibilityType } from "@/types/dynamic-agent";
+
+type AllowedTools = Record<string, string[] | boolean>;
+
+export interface AgentMcpScope {
+  visibility: VisibilityType;
+  ownerSubject: string;
+  ownerTeamSlug?: string | null;
+  sharedTeamSlugs?: readonly string[];
+}
+
+function selectedServerIds(allowedTools: AllowedTools): string[] {
+  return Object.entries(allowedTools)
+    .filter(([, tools]) => tools !== false && (!Array.isArray(tools) || tools.length > 0))
+    .map(([serverId]) => serverId);
+}
+
+function mcpVisibility(server: MCPServerConfig): "private" | "team" | "global" {
+  return server.visibility === "private" || server.visibility === "team"
+    ? server.visibility
+    : "global";
+}
+
+function effectiveTeams(input: {
+  ownerTeamSlug?: string | null;
+  sharedTeamSlugs?: readonly string[];
+}): Set<string> {
+  return new Set(
+    [input.ownerTeamSlug, ...(input.sharedTeamSlugs ?? [])]
+      .filter((slug): slug is string => typeof slug === "string" && slug.trim().length > 0)
+      .map((slug) => slug.trim()),
+  );
+}
+
+function dependencyError(serverId: string): ApiError {
+  return new ApiError(
+    `MCP server "${serverId}" is not compatible with this agent's visibility or owner.`,
+    400,
+    "PRIVATE_RESOURCE_DEPENDENCY_DENIED",
+  );
+}
+
+/** Enforce the private < team < global audience ordering for selected MCP servers. */
+export async function validateAgentMcpDependencyScopes(input: {
+  agent: AgentMcpScope;
+  allowedTools: AllowedTools;
+  servers: readonly MCPServerConfig[];
+  canInvokeServer?: (serverId: string) => Promise<boolean>;
+}): Promise<void> {
+  const selected = new Set(selectedServerIds(input.allowedTools));
+  if (selected.size === 0) return;
+
+  const parentTeams = effectiveTeams({
+    ownerTeamSlug: input.agent.ownerTeamSlug,
+    sharedTeamSlugs: input.agent.sharedTeamSlugs,
+  });
+  for (const server of input.servers) {
+    if (!selected.has(server._id)) continue;
+    const visibility = mcpVisibility(server);
+
+    if (input.agent.visibility === "global") {
+      if (visibility !== "global") throw dependencyError(server._id);
+      continue;
+    }
+
+    if (input.agent.visibility === "team") {
+      if (visibility === "private") throw dependencyError(server._id);
+      if (visibility === "team") {
+        const childTeams = effectiveTeams({
+          ownerTeamSlug: server.owner_team_slug,
+          sharedTeamSlugs: server.shared_with_teams,
+        });
+        if ([...parentTeams].some((team) => !childTeams.has(team))) {
+          throw dependencyError(server._id);
+        }
+      }
+      continue;
+    }
+
+    if (visibility === "private") {
+      if (server.owner_subject !== input.agent.ownerSubject) {
+        throw dependencyError(server._id);
+      }
+      continue;
+    }
+    if (visibility === "team") {
+      const allowed = await input.canInvokeServer?.(server._id);
+      if (!allowed) throw dependencyError(server._id);
+    }
+  }
+}
+
+export function selectedMcpServerIds(allowedTools: AllowedTools): string[] {
+  return selectedServerIds(allowedTools);
+}
+
+export async function validatePersistedAgentMcpDependencies(input: {
+  session: ResourceAuthzSession;
+  agent: AgentMcpScope;
+  allowedTools: AllowedTools;
+}): Promise<void> {
+  const ids = selectedMcpServerIds(input.allowedTools);
+  if (ids.length === 0) return;
+  const servers = await getCollection<MCPServerConfig>("mcp_servers")
+    .then((collection) => collection.find({ _id: { $in: ids } }).toArray());
+  await validateAgentMcpDependencyScopes({
+    agent: input.agent,
+    allowedTools: input.allowedTools,
+    servers,
+    canInvokeServer: async (serverId) => {
+      try {
+        await requireResourcePermission(input.session, {
+          type: "mcp_server",
+          id: serverId,
+          action: "invoke",
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+}

--- a/ui/src/lib/rbac/agent-mcp-dependency-scope.ts
+++ b/ui/src/lib/rbac/agent-mcp-dependency-scope.ts
@@ -1,23 +1,36 @@
 import { ApiError } from "@/lib/api-error";
+import {
+  authzSyncPreCheck,
+  type AuthzSyncDocument,
+} from "@/lib/authz/resource-sync";
 import { getCollection } from "@/lib/mongodb";
 import {
   requireResourcePermission,
   type ResourceAuthzSession,
 } from "@/lib/rbac/resource-authz";
 import type { MCPServerConfig, VisibilityType } from "@/types/dynamic-agent";
+import type { AgentSkill, SkillVisibility } from "@/types/agent-skill";
+import type {
+  WorkflowConfig,
+  WorkflowConfigVisibility,
+} from "@/types/workflow-config";
 
 type AllowedTools = Record<string, string[] | boolean>;
 
 export interface AgentMcpScope {
   visibility: VisibilityType;
   ownerSubject: string;
+  ownerEmail?: string;
   ownerTeamSlug?: string | null;
   sharedTeamSlugs?: readonly string[];
 }
 
 function selectedServerIds(allowedTools: AllowedTools): string[] {
   return Object.entries(allowedTools)
-    .filter(([, tools]) => tools !== false && (!Array.isArray(tools) || tools.length > 0))
+    .filter(
+      ([, tools]) =>
+        tools !== false && (!Array.isArray(tools) || tools.length > 0),
+    )
     .map(([serverId]) => serverId);
 }
 
@@ -33,7 +46,10 @@ function effectiveTeams(input: {
 }): Set<string> {
   return new Set(
     [input.ownerTeamSlug, ...(input.sharedTeamSlugs ?? [])]
-      .filter((slug): slug is string => typeof slug === "string" && slug.trim().length > 0)
+      .filter(
+        (slug): slug is string =>
+          typeof slug === "string" && slug.trim().length > 0,
+      )
       .map((slug) => slug.trim()),
   );
 }
@@ -44,6 +60,74 @@ function dependencyError(serverId: string): ApiError {
     400,
     "PRIVATE_RESOURCE_DEPENDENCY_DENIED",
   );
+}
+
+type AgentResourceDependency = AuthzSyncDocument & {
+  id: string;
+  kind: "skill" | "workflow";
+  visibility: SkillVisibility | WorkflowConfigVisibility;
+  ownerSubject?: string;
+  ownerEmail?: string;
+  sharedTeamSlugs: readonly string[];
+};
+
+function resourceDependencyError(
+  dependency: AgentResourceDependency,
+): ApiError {
+  return new ApiError(
+    `${dependency.kind === "skill" ? "Skill" : "Workflow"} "${dependency.id}" is not compatible with this agent's visibility or owner.`,
+    400,
+    "PRIVATE_RESOURCE_DEPENDENCY_DENIED",
+  );
+}
+
+async function validateAgentResourceDependencyScopes(input: {
+  agent: AgentMcpScope;
+  dependencies: readonly AgentResourceDependency[];
+  canUse: (dependency: AgentResourceDependency) => Promise<boolean>;
+}): Promise<void> {
+  const parentTeams = effectiveTeams({
+    ownerTeamSlug: input.agent.ownerTeamSlug,
+    sharedTeamSlugs: input.agent.sharedTeamSlugs,
+  });
+  for (const dependency of input.dependencies) {
+    if (authzSyncPreCheck(dependency))
+      throw resourceDependencyError(dependency);
+    if (input.agent.visibility === "global") {
+      if (dependency.visibility !== "global")
+        throw resourceDependencyError(dependency);
+      continue;
+    }
+    if (input.agent.visibility === "team") {
+      if (dependency.visibility === "private")
+        throw resourceDependencyError(dependency);
+      if (dependency.visibility === "team") {
+        const childTeams = new Set(
+          dependency.sharedTeamSlugs.map((slug) => slug.trim()),
+        );
+        if ([...parentTeams].some((team) => !childTeams.has(team))) {
+          throw resourceDependencyError(dependency);
+        }
+      }
+      continue;
+    }
+    if (dependency.visibility === "private") {
+      const sameOwner = dependency.ownerSubject
+        ? dependency.ownerSubject === input.agent.ownerSubject
+        : Boolean(
+            dependency.ownerEmail &&
+              input.agent.ownerEmail &&
+              dependency.ownerEmail.toLowerCase() ===
+                input.agent.ownerEmail.toLowerCase(),
+          );
+      if (!sameOwner) {
+        throw resourceDependencyError(dependency);
+      }
+      continue;
+    }
+    if (!(await input.canUse(dependency)))
+      throw resourceDependencyError(dependency);
+  }
 }
 
 /** Enforce the private < team < global audience ordering for selected MCP servers. */
@@ -84,7 +168,15 @@ export async function validateAgentMcpDependencyScopes(input: {
     }
 
     if (visibility === "private") {
-      if (server.owner_subject !== input.agent.ownerSubject) {
+      const sameOwner = server.owner_subject
+        ? server.owner_subject === input.agent.ownerSubject
+        : Boolean(
+            server.owner_id &&
+              input.agent.ownerEmail &&
+              server.owner_id.toLowerCase() ===
+                input.agent.ownerEmail.toLowerCase(),
+          );
+      if (!sameOwner) {
         throw dependencyError(server._id);
       }
       continue;
@@ -107,8 +199,9 @@ export async function validatePersistedAgentMcpDependencies(input: {
 }): Promise<void> {
   const ids = selectedMcpServerIds(input.allowedTools);
   if (ids.length === 0) return;
-  const servers = await getCollection<MCPServerConfig>("mcp_servers")
-    .then((collection) => collection.find({ _id: { $in: ids } }).toArray());
+  const servers = await getCollection<MCPServerConfig>("mcp_servers").then(
+    (collection) => collection.find({ _id: { $in: ids } }).toArray(),
+  );
   await validateAgentMcpDependencyScopes({
     agent: input.agent,
     allowedTools: input.allowedTools,
@@ -119,6 +212,91 @@ export async function validatePersistedAgentMcpDependencies(input: {
           type: "mcp_server",
           id: serverId,
           action: "invoke",
+        });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+  });
+}
+
+/** Validate skills and workflow tools that the runtime loads directly from MongoDB. */
+export async function validatePersistedAgentResourceDependencies(input: {
+  session: ResourceAuthzSession;
+  agent: AgentMcpScope;
+  skillIds?: readonly string[];
+  workflowIds?: readonly string[] | null;
+}): Promise<void> {
+  const skillIds = [...new Set(input.skillIds ?? [])];
+  const persistedSkillIds = skillIds.filter((id) => {
+    if (!id.startsWith("hub-")) return true;
+    const rest = id.slice("hub-".length);
+    return rest.indexOf("-", 1) < 0;
+  });
+  const hubSkillIds = skillIds.filter((id) => !persistedSkillIds.includes(id));
+  const workflowIds = [...new Set(input.workflowIds ?? [])];
+  const [skills, workflows] = await Promise.all([
+    persistedSkillIds.length === 0
+      ? Promise.resolve([] as AgentSkill[])
+      : getCollection<AgentSkill>("agent_skills").then((collection) =>
+          collection.find({ id: { $in: persistedSkillIds } }).toArray(),
+        ),
+    workflowIds.length === 0
+      ? Promise.resolve([] as WorkflowConfig[])
+      : getCollection<WorkflowConfig>("workflow_configs").then((collection) =>
+          collection.find({ _id: { $in: workflowIds } }).toArray(),
+        ),
+  ]);
+  if (
+    skills.length !== persistedSkillIds.length ||
+    workflows.length !== workflowIds.length
+  ) {
+    throw new ApiError(
+      "One or more selected skills or workflows no longer exist.",
+      400,
+      "RESOURCE_DEPENDENCY_NOT_FOUND",
+    );
+  }
+  const dependencies: AgentResourceDependency[] = [
+    ...hubSkillIds.map((id) => ({
+      id,
+      kind: "skill" as const,
+      visibility: "global" as const,
+      sharedTeamSlugs: [],
+    })),
+    ...skills.map((skill) => ({
+      id: skill.id,
+      kind: "skill" as const,
+      visibility: skill.visibility ?? ("private" as const),
+      ownerSubject: skill.owner_subject,
+      ownerEmail: skill.owner_id,
+      sharedTeamSlugs: skill.shared_with_teams ?? [],
+      authz_revision: skill.authz_revision,
+      authz_sync_state: skill.authz_sync_state,
+      authz_last_synced_revision: skill.authz_last_synced_revision,
+    })),
+    ...workflows.map((workflow) => ({
+      id: workflow._id,
+      kind: "workflow" as const,
+      visibility: workflow.visibility ?? ("private" as const),
+      ownerSubject: workflow.owner_subject,
+      ownerEmail: workflow.owner_id,
+      sharedTeamSlugs: workflow.shared_with_teams ?? [],
+      authz_revision: workflow.authz_revision,
+      authz_sync_state: workflow.authz_sync_state,
+      authz_last_synced_revision: workflow.authz_last_synced_revision,
+    })),
+  ];
+  await validateAgentResourceDependencyScopes({
+    agent: input.agent,
+    dependencies,
+    canUse: async (dependency) => {
+      try {
+        await requireResourcePermission(input.session, {
+          type: dependency.kind === "skill" ? "skill" : "task",
+          id: dependency.id,
+          action: dependency.kind === "skill" ? "invoke" : "use",
         });
         return true;
       } catch {

--- a/ui/src/lib/rbac/openfga-agent-tools.ts
+++ b/ui/src/lib/rbac/openfga-agent-tools.ts
@@ -107,6 +107,7 @@ export interface AgentToolTupleDiffInput {
 
 export interface ReconcileAgentToolTuplesInput extends AgentToolTupleDiffInput {
   failClosed?: boolean;
+  verifyHigherConsistency?: boolean;
 }
 
 const OPENFGA_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._~@|*+=,/-]{0,191}$/;
@@ -365,6 +366,7 @@ export async function reconcileAgentRelationships(
     return await reconcileTupleDiff(diff, {
       caller: input.ownerSubject ? { type: "user", id: input.ownerSubject } : undefined,
       source: "agent_relationship_reconcile",
+      verifyHigherConsistency: input.verifyHigherConsistency,
     });
   } catch (error) {
     if (input.failClosed ?? true) {

--- a/ui/src/lib/rbac/openfga-owned-resources-reconcile.ts
+++ b/ui/src/lib/rbac/openfga-owned-resources-reconcile.ts
@@ -155,8 +155,9 @@ async function withMcpServerToolWildcardBackfill(
 
 export async function reconcileShareableResource(
   input: ShareableResourceInput,
+  ctx?: TupleReconcileContext,
 ): Promise<OpenFgaReconcileResult> {
-  return reconcileOwnedResource(buildShareableResourceTupleDiff(input));
+  return reconcileOwnedResource(buildShareableResourceTupleDiff(input), ctx);
 }
 
 export async function reconcileMcpServerRelationships(
@@ -291,6 +292,45 @@ async function readAllTuplesForObject(object: string): Promise<OpenFgaTupleKey[]
     continuationToken = page.continuationToken;
   } while (continuationToken);
   return tuples;
+}
+
+async function deleteAllRelationshipTuplesForObject(
+  object: string,
+  source: string,
+  ctx?: TupleReconcileContext,
+): Promise<OpenFgaReconcileResult> {
+  if (!isOpenFgaReconciliationEnabled()) {
+    throw new OpenFgaReconcileRequiredError();
+  }
+  const deletes = await readAllTuplesForObject(object);
+  const diff = {
+    writes: [] as OpenFgaTupleKey[],
+    deletes: uniqueTuples(deletes),
+  };
+  assertReconciliationEnabled(diff);
+  return reconcileTupleDiff(diff, { ...ctx, source: ctx?.source ?? source });
+}
+
+export async function deleteAllSkillRelationshipTuples(
+  skillId: string,
+  ctx?: TupleReconcileContext,
+): Promise<OpenFgaReconcileResult> {
+  return deleteAllRelationshipTuplesForObject(
+    `skill:${skillId}`,
+    "skill_delete",
+    ctx,
+  );
+}
+
+export async function deleteAllWorkflowRelationshipTuples(
+  workflowId: string,
+  ctx?: TupleReconcileContext,
+): Promise<OpenFgaReconcileResult> {
+  return deleteAllRelationshipTuplesForObject(
+    `task:${workflowId}`,
+    "workflow_delete",
+    ctx,
+  );
 }
 
 /**

--- a/ui/src/lib/rbac/openfga.ts
+++ b/ui/src/lib/rbac/openfga.ts
@@ -60,6 +60,7 @@ export interface OpenFgaReadOptions {
   tuple?: Partial<OpenFgaTupleKey>;
   pageSize?: number;
   continuationToken?: string;
+  consistency?: "MINIMIZE_LATENCY" | "HIGHER_CONSISTENCY";
 }
 
 export interface OpenFgaReadResult {
@@ -432,6 +433,7 @@ async function tupleExistsInStore(
   baseUrl: string,
   storeId: string,
   tuple: OpenFgaTupleKey,
+  consistency?: OpenFgaReadOptions["consistency"],
 ): Promise<boolean> {
   const filter = tupleKeyFilter(tuple);
   if (!filter?.user || !filter.relation || !filter.object) {
@@ -440,7 +442,11 @@ async function tupleExistsInStore(
   const response = await fetch(`${baseUrl}/stores/${storeId}/read`, {
     method: "POST",
     headers: openFgaHeaders(),
-    body: JSON.stringify({ tuple_key: filter, page_size: 1 }),
+    body: JSON.stringify({
+      tuple_key: filter,
+      page_size: 1,
+      ...(consistency ? { consistency } : {}),
+    }),
   });
   if (!response.ok) {
     const errorBody = await response.text().catch(() => "");
@@ -593,6 +599,7 @@ export async function readOpenFgaTuples(options: OpenFgaReadOptions = {}): Promi
     ...(tupleKeyFilter(options.tuple) ? { tuple_key: tupleKeyFilter(options.tuple) } : {}),
     page_size: pageSize,
     ...(options.continuationToken ? { continuation_token: options.continuationToken } : {}),
+    ...(options.consistency ? { consistency: options.consistency } : {}),
   };
 
   const response = await fetch(`${baseUrl}/stores/${storeId}/read`, {
@@ -993,6 +1000,33 @@ export async function writeOpenFgaTupleDiff(diff: TeamResourceTupleDiff): Promis
     return { enabled: false, writes: 0, deletes: 0 };
   }
   return writeOpenFgaTuples(diff);
+}
+
+export class OpenFgaVerificationError extends Error {
+  constructor() {
+    super("OpenFGA did not reflect the reconciled tuple state");
+    this.name = "OpenFgaVerificationError";
+  }
+}
+
+/** Verify direct tuple writes and revocations using OpenFGA's primary-read mode. */
+export async function verifyOpenFgaTupleDiff(diff: TeamResourceTupleDiff): Promise<void> {
+  if (!isOpenFgaReconciliationEnabled()) return;
+  const tuples = [...diff.writes, ...diff.deletes];
+  if (tuples.length === 0) return;
+  const baseUrl = openFgaHttpUrl();
+  if (!baseUrl) throw new Error("OPENFGA_HTTP is not set");
+  const storeId = await getOpenFgaStoreId();
+  const present = await mapWithConcurrency(
+    tuples,
+    openFgaReadConcurrency(),
+    (tuple) => tupleExistsInStore(baseUrl, storeId, tuple, "HIGHER_CONSISTENCY"),
+  );
+  const writesVerified = diff.writes.every((_, index) => present[index] === true);
+  const deletesVerified = diff.deletes.every(
+    (_, index) => present[diff.writes.length + index] === false,
+  );
+  if (!writesVerified || !deletesVerified) throw new OpenFgaVerificationError();
 }
 
 export async function writeUniversalRebacTupleDiff(

--- a/ui/src/lib/rbac/resource-authz.ts
+++ b/ui/src/lib/rbac/resource-authz.ts
@@ -1,4 +1,5 @@
 import { ApiError } from "@/lib/api-error";
+import { getCollection } from "@/lib/mongodb";
 import { authorize, authorizeMany, type Action, type Subject, type TrustedAuthorizeContext } from "@/lib/authz";
 import type { UniversalRebacResourceType } from "@/types/rbac-universal";
 
@@ -261,6 +262,29 @@ export async function requireSkillPermission(
       "session_expired",
       "sign_in",
     );
+  }
+
+  const skill = await getCollection<{
+    id: string;
+    visibility?: string;
+    owner_id?: string;
+    owner_subject?: string;
+  }>("agent_skills").then((collection) => collection.findOne({ id: skillId }));
+  if (skill?.visibility === "private") {
+    const stableSubject = typeof session.sub === "string" ? session.sub.trim() : "";
+    const email = session.user?.email?.trim().toLowerCase() ?? "";
+    const ownerMatches = skill.owner_subject
+      ? skill.owner_subject === stableSubject
+      : Boolean(email && skill.owner_id?.trim().toLowerCase() === email);
+    if (!ownerMatches) {
+      throw new ApiError(
+        "You do not have permission to access this private skill.",
+        403,
+        `skill#${action}`,
+        "pdp_denied",
+        "contact_admin",
+      );
+    }
   }
 
   if (!isOrgAdminBypassKillSwitchEnabled() && (await isOrgAdmin(subject, casSubject, options))) {

--- a/ui/src/lib/rbac/skill-team-grants.ts
+++ b/ui/src/lib/rbac/skill-team-grants.ts
@@ -3,13 +3,14 @@ import { ObjectId } from "mongodb";
 import { getCollection } from "@/lib/mongodb";
 import { teamSlugsFromSkillTuples } from "@/lib/rbac/agent-skill-openfga-reconcile";
 import {
-isOpenFgaReconciliationEnabled,
-readOpenFgaTuples,
-writeOpenFgaTupleDiff,
-type OpenFgaReconcileResult,
-type OpenFgaTupleKey,
+  isOpenFgaReconciliationEnabled,
+  readOpenFgaTuples,
+  writeOpenFgaTupleDiff,
+  type OpenFgaReconcileResult,
+  type OpenFgaTupleKey,
 } from "@/lib/rbac/openfga";
 import { reconcileShareableResource } from "@/lib/rbac/openfga-owned-resources-reconcile";
+import type { TupleReconcileContext } from "@/lib/authz";
 
 interface TeamDoc {
   _id?: ObjectId | string;
@@ -128,6 +129,7 @@ export interface ReconcileSkillTeamSharesInput {
  */
 export async function reconcileSkillTeamShares(
   input: ReconcileSkillTeamSharesInput,
+  ctx?: TupleReconcileContext,
 ): Promise<OpenFgaReconcileResult> {
   const visibilityDriven = input.nextVisibility !== undefined;
   const nextVisibility = input.nextVisibility ?? "private";
@@ -147,7 +149,7 @@ export async function reconcileSkillTeamShares(
     typeof input.ownerSubject === "string" && input.ownerSubject.trim()
       ? input.ownerSubject.trim()
       : null;
-  return reconcileShareableResource({
+  const resource = {
     objectType: "skill",
     objectId: input.skillId,
     creatorSubject: ownerSubject,
@@ -157,21 +159,32 @@ export async function reconcileSkillTeamShares(
     previousSharedTeamSlugs,
     memberRelations: ["user"],
     sharedWithOrg: visibilityDriven ? nextVisibility === "global" : undefined,
-    previousSharedWithOrg: visibilityDriven ? previousVisibility === "global" : undefined,
-  });
+    previousSharedWithOrg: visibilityDriven
+      ? previousVisibility === "global"
+      : undefined,
+  };
+  return ctx
+    ? reconcileShareableResource(resource, ctx)
+    : reconcileShareableResource(resource);
 }
 
 /**
  * Team slugs currently granted `team:<slug>#member user skill:<id>` in OpenFGA.
  * Used instead of Mongo `shared_with_teams` (authorization state lives in FGA only).
  */
-export async function readSkillSharedTeamSlugsFromOpenFga(skillId: string): Promise<string[]> {
+export async function readSkillSharedTeamSlugsFromOpenFga(
+  skillId: string,
+): Promise<string[]> {
   if (!isOpenFgaReconciliationEnabled()) return [];
   const object = `skill:${skillId}`;
   const tuples: OpenFgaTupleKey[] = [];
   let continuationToken: string | undefined;
   do {
-    const page = await readOpenFgaTuples({ tuple: { object }, continuationToken, pageSize: 100 });
+    const page = await readOpenFgaTuples({
+      tuple: { object },
+      continuationToken,
+      pageSize: 100,
+    });
     for (const entry of page.tuples) {
       tuples.push(entry.key);
     }

--- a/ui/src/lib/rbac/workflow-agent-dependency-scope.ts
+++ b/ui/src/lib/rbac/workflow-agent-dependency-scope.ts
@@ -1,0 +1,69 @@
+import { ApiError } from "@/lib/api-error";
+import { authzSyncPreCheck } from "@/lib/authz/resource-sync";
+import { getCollection } from "@/lib/mongodb";
+import type { ResourceAuthzSession } from "@/lib/rbac/resource-authz";
+import { requireAgentPermission } from "@/lib/rbac/resource-authz";
+import type { DynamicAgentConfig } from "@/types/dynamic-agent";
+import type {
+  StepEntry,
+  WorkflowConfigVisibility,
+} from "@/types/workflow-config";
+
+function dependencyError(agentId: string): ApiError {
+  return new ApiError(
+    `Agent "${agentId}" is not compatible with this workflow's visibility or owner.`,
+    400,
+    "PRIVATE_RESOURCE_DEPENDENCY_DENIED",
+  );
+}
+
+function agentIdsFromSteps(steps: StepEntry[]): string[] {
+  const ids = new Set<string>();
+  for (const entry of steps) {
+    if (entry.type === "step") ids.add(entry.agent_id.trim());
+  }
+  return [...ids].filter(Boolean);
+}
+
+/** Prevent a shared workflow from becoming an execution tunnel to a private agent. */
+export async function validateWorkflowAgentDependencies(input: {
+  session: ResourceAuthzSession;
+  workflow: {
+    visibility: WorkflowConfigVisibility;
+    ownerSubject: string;
+    ownerEmail: string;
+  };
+  steps: StepEntry[];
+}): Promise<void> {
+  const ids = agentIdsFromSteps(input.steps);
+  if (ids.length === 0) return;
+  const agents = await getCollection<DynamicAgentConfig>("dynamic_agents").then(
+    (collection) => collection.find({ _id: { $in: ids } }).toArray(),
+  );
+  if (agents.length !== ids.length) {
+    throw new ApiError(
+      "One or more selected workflow agents no longer exist.",
+      400,
+      "RESOURCE_DEPENDENCY_NOT_FOUND",
+    );
+  }
+
+  for (const agent of agents) {
+    if (authzSyncPreCheck(agent)) throw dependencyError(agent._id);
+    if (agent.visibility === "private") {
+      if (input.workflow.visibility !== "private")
+        throw dependencyError(agent._id);
+      const sameOwner = agent.owner_subject
+        ? agent.owner_subject === input.workflow.ownerSubject
+        : agent.owner_id.trim().toLowerCase() ===
+          input.workflow.ownerEmail.trim().toLowerCase();
+      if (!sameOwner) throw dependencyError(agent._id);
+      continue;
+    }
+    try {
+      await requireAgentPermission(input.session, agent._id, "use");
+    } catch {
+      throw dependencyError(agent._id);
+    }
+  }
+}

--- a/ui/src/lib/rbac/workflow-config-rebac.ts
+++ b/ui/src/lib/rbac/workflow-config-rebac.ts
@@ -9,6 +9,11 @@
 
 import { getCollection } from "@/lib/mongodb";
 import { ApiError } from "@/lib/api-error";
+import {
+  authzSyncPreCheck,
+  type AuthzSyncDocument,
+} from "@/lib/authz/resource-sync";
+import type { TupleReconcileContext } from "@/lib/authz";
 import type { OpenFgaReconcileResult } from "./openfga";
 import { reconcileShareableResource } from "./openfga-owned-resources-reconcile";
 import { listUserTeamSlugs } from "./openfga-team-membership";
@@ -19,11 +24,12 @@ import {
 } from "./resource-authz";
 import type { WorkflowConfigVisibility } from "@/types/workflow-config";
 
-export interface WorkflowConfigRebacSnapshot {
+export interface WorkflowConfigRebacSnapshot extends AuthzSyncDocument {
   _id: string;
   visibility?: WorkflowConfigVisibility | null;
   shared_with_teams?: string[] | null;
   owner_id: string;
+  owner_subject?: string;
   config_driven?: boolean;
 }
 
@@ -32,14 +38,22 @@ export interface WorkflowConfigRebacSnapshot {
  * `visibility`; platform-seeded workflows (`owner_id: system`) default to global.
  */
 export function effectiveWorkflowVisibility(
-  config: Pick<WorkflowConfigRebacSnapshot, "visibility" | "owner_id" | "config_driven">,
+  config: Pick<
+    WorkflowConfigRebacSnapshot,
+    "visibility" | "owner_id" | "config_driven"
+  >,
 ): WorkflowConfigVisibility {
   const raw =
-    typeof config.visibility === "string" ? config.visibility.trim().toLowerCase() : "";
+    typeof config.visibility === "string"
+      ? config.visibility.trim().toLowerCase()
+      : "";
   if (raw === "global" || raw === "team" || raw === "private") {
     return raw;
   }
-  if (config.owner_id?.trim().toLowerCase() === "system" || config.config_driven) {
+  if (
+    config.owner_id?.trim().toLowerCase() === "system" ||
+    config.config_driven
+  ) {
     return "global";
   }
   return "private";
@@ -79,7 +93,9 @@ export function resolveSharedTeamSlugs(
   const resolved = refs.map((ref) => {
     const trimmed = ref.trim();
     if (!trimmed) return "";
-    const fromMap = teamRefToSlug?.get(trimmed) ?? teamRefToSlug?.get(normalizeTeamSlug(trimmed));
+    const fromMap =
+      teamRefToSlug?.get(trimmed) ??
+      teamRefToSlug?.get(normalizeTeamSlug(trimmed));
     if (fromMap) return fromMap;
     return normalizeTeamSlug(trimmed);
   });
@@ -149,7 +165,10 @@ export function workflowRunAllowedByVisibility(
       return true;
     }
 
-    const shared = resolveSharedTeamSlugs(config.shared_with_teams, teamRefToSlug);
+    const shared = resolveSharedTeamSlugs(
+      config.shared_with_teams,
+      teamRefToSlug,
+    );
     if (shared.length === 0) {
       return false;
     }
@@ -159,6 +178,17 @@ export function workflowRunAllowedByVisibility(
 
   const owner = config.owner_id?.trim().toLowerCase();
   return Boolean(owner && owner === userEmail.trim().toLowerCase());
+}
+
+function privateWorkflowOwnerMatches(
+  config: WorkflowConfigRebacSnapshot,
+  session: ResourceAuthzSession,
+  userEmail: string,
+): boolean {
+  if (effectiveWorkflowVisibility(config) !== "private") return true;
+  const subject = typeof session.sub === "string" ? session.sub.trim() : "";
+  if (config.owner_subject) return Boolean(subject && config.owner_subject === subject);
+  return config.owner_id.trim().toLowerCase() === userEmail.trim().toLowerCase();
 }
 
 export async function resolveUserTeamSlugsForWorkflow(
@@ -183,20 +213,31 @@ export async function resolveUserTeamSlugsForWorkflow(
       .find({ "members.user_id": userEmail })
       .project({ slug: 1 })
       .toArray();
-    return rows.map((team) => team.slug?.trim()).filter((slug): slug is string => Boolean(slug));
+    return rows
+      .map((team) => team.slug?.trim())
+      .filter((slug): slug is string => Boolean(slug));
   } catch {
     return [];
   }
 }
 
-export function filterWorkflowConfigsByRunAccess<T extends WorkflowConfigRebacSnapshot>(
+export function filterWorkflowConfigsByRunAccess<
+  T extends WorkflowConfigRebacSnapshot,
+>(
   configs: T[],
   userEmail: string,
   userTeamSlugs: string[],
   teamRefToSlug?: TeamRefToSlugMap,
 ): T[] {
-  return configs.filter((config) =>
-    workflowRunAllowedByVisibility(config, userEmail, userTeamSlugs, teamRefToSlug),
+  return configs.filter(
+    (config) =>
+      authzSyncPreCheck(config) === null &&
+      workflowRunAllowedByVisibility(
+        config,
+        userEmail,
+        userTeamSlugs,
+        teamRefToSlug,
+      ),
   );
 }
 
@@ -214,11 +255,27 @@ export function mergeWorkflowConfigsById<T extends { _id: string }>(
 
 export async function reconcileWorkflowConfigAccess(
   session: ResourceAuthzSession,
-  config: Pick<WorkflowConfigRebacSnapshot, "_id" | "visibility" | "shared_with_teams">,
-  previous?: Pick<WorkflowConfigRebacSnapshot, "visibility" | "shared_with_teams"> | null,
+  config: Pick<
+    WorkflowConfigRebacSnapshot,
+    "_id" | "visibility" | "shared_with_teams" | "owner_subject"
+  >,
+  previous?: Pick<
+    WorkflowConfigRebacSnapshot,
+    "visibility" | "shared_with_teams" | "owner_subject"
+  > | null,
+  options: {
+    ownerSubject?: string | null;
+    context?: TupleReconcileContext;
+  } = {},
 ): Promise<OpenFgaReconcileResult> {
-  const creatorSubject = subjectFromSession(session);
-  if (!creatorSubject) {
+  const sessionSubject =
+    typeof session.sub === "string" ? session.sub.trim() : "";
+  const ownerSubject =
+    options.ownerSubject === undefined
+      ? (config.owner_subject ?? (sessionSubject || null))
+      : options.ownerSubject;
+  const creatorSubject = ownerSubject ?? (sessionSubject || null);
+  if (!creatorSubject && !ownerSubject) {
     return { enabled: false, writes: 0, deletes: 0 };
   }
 
@@ -227,11 +284,12 @@ export async function reconcileWorkflowConfigAccess(
       ? await buildTeamRefToSlugMap()
       : undefined;
 
-  return reconcileShareableResource({
+  const resource = {
     objectType: "task",
     objectId: config._id,
     creatorSubject,
-    ownerSubject: creatorSubject,
+    ownerSubject,
+    previousOwnerSubject: previous?.owner_subject,
     memberRelations: ["reader", "user"],
     sharedWithOrg: config.visibility === "global",
     previousSharedWithOrg: previous?.visibility === "global",
@@ -243,12 +301,30 @@ export async function reconcileWorkflowConfigAccess(
       previous?.visibility === "team"
         ? resolveSharedTeamSlugs(previous.shared_with_teams, teamRefToSlug)
         : [],
-  });
+  };
+  return options.context
+    ? reconcileShareableResource(resource, options.context)
+    : reconcileShareableResource(resource);
+}
+
+function requireWorkflowAuthorizationReady(config: AuthzSyncDocument): void {
+  const decision = authzSyncPreCheck(config);
+  if (!decision) return;
+  throw new ApiError(
+    "Workflow access is still being synchronized. Retry shortly.",
+    503,
+    decision.reason,
+    "pdp_unavailable",
+    "retry",
+  );
 }
 
 /** Who may edit/delete a workflow (stricter than run). */
 export function workflowWriteAllowedByVisibility(
-  config: Pick<WorkflowConfigRebacSnapshot, "visibility" | "shared_with_teams" | "owner_id">,
+  config: Pick<
+    WorkflowConfigRebacSnapshot,
+    "visibility" | "shared_with_teams" | "owner_id"
+  >,
   userEmail: string,
 ): boolean {
   const owner = config.owner_id?.trim().toLowerCase();
@@ -304,10 +380,16 @@ export async function canViewWorkflowRunsForConfig(
   userTeamSlugs?: string[],
   teamRefToSlug?: TeamRefToSlugMap,
 ): Promise<boolean> {
-  const slugs = userTeamSlugs ?? (await resolveUserTeamSlugsForWorkflow(userEmail, session));
+  if (authzSyncPreCheck(config)) return false;
+  if (!privateWorkflowOwnerMatches(config, session, userEmail)) return false;
+  const slugs =
+    userTeamSlugs ??
+    (await resolveUserTeamSlugsForWorkflow(userEmail, session));
   const map =
     teamRefToSlug ??
-    (effectiveWorkflowVisibility(config) === "team" ? await buildTeamRefToSlugMap() : undefined);
+    (effectiveWorkflowVisibility(config) === "team"
+      ? await buildTeamRefToSlugMap()
+      : undefined);
 
   if (workflowRunAllowedByVisibility(config, userEmail, slugs, map)) {
     return true;
@@ -335,7 +417,14 @@ export async function requireWorkflowConfigRunViewAccess(
   userEmail: string,
   userTeamSlugs?: string[],
 ): Promise<void> {
-  if (await canViewWorkflowRunsForConfig(session, config, userEmail, userTeamSlugs)) {
+  if (
+    await canViewWorkflowRunsForConfig(
+      session,
+      config,
+      userEmail,
+      userTeamSlugs,
+    )
+  ) {
     return;
   }
   throw new ApiError(
@@ -354,9 +443,23 @@ export async function requireWorkflowConfigRunAccess(
   userEmail: string,
   userTeamSlugs?: string[],
 ): Promise<void> {
-  const slugs = userTeamSlugs ?? (await resolveUserTeamSlugsForWorkflow(userEmail, session));
+  requireWorkflowAuthorizationReady(config);
+  if (!privateWorkflowOwnerMatches(config, session, userEmail)) {
+    throw new ApiError(
+      "You do not have permission to run this private workflow.",
+      403,
+      "task#use",
+      "pdp_denied",
+      "contact_admin",
+    );
+  }
+  const slugs =
+    userTeamSlugs ??
+    (await resolveUserTeamSlugsForWorkflow(userEmail, session));
   const teamRefToSlug =
-    effectiveWorkflowVisibility(config) === "team" ? await buildTeamRefToSlugMap() : undefined;
+    effectiveWorkflowVisibility(config) === "team"
+      ? await buildTeamRefToSlugMap()
+      : undefined;
 
   if (workflowRunAllowedByVisibility(config, userEmail, slugs, teamRefToSlug)) {
     return;
@@ -386,7 +489,8 @@ export async function requireWorkflowConfigRunAccess(
  * Safe to run on UI startup after seed.
  */
 export async function repairWorkflowConfigTeamSlugRefs(): Promise<number> {
-  const collection = await getCollection<WorkflowConfigRebacSnapshot>("workflow_configs");
+  const collection =
+    await getCollection<WorkflowConfigRebacSnapshot>("workflow_configs");
   const map = await buildTeamRefToSlugMap();
   const teamConfigs = await collection.find({ visibility: "team" }).toArray();
   let repaired = 0;

--- a/ui/src/lib/rbac/workflow-run-access.ts
+++ b/ui/src/lib/rbac/workflow-run-access.ts
@@ -16,15 +16,31 @@ import type { WorkflowConfig } from "@/types/workflow-config";
 export function workflowConfigAccessSnapshot(
   config: Pick<
     WorkflowConfig,
-    "_id" | "owner_id" | "visibility" | "shared_with_teams" | "config_driven"
+    | "_id"
+    | "owner_id"
+    | "owner_subject"
+    | "visibility"
+    | "shared_with_teams"
+    | "config_driven"
+    | "authz_revision"
+    | "authz_sync_state"
+    | "authz_last_synced_revision"
+    | "authz_last_error_code"
+    | "authz_sync_started_at"
   >,
 ): WorkflowConfigRebacSnapshot {
   return {
     _id: String(config._id),
     owner_id: config.owner_id,
+    owner_subject: config.owner_subject,
     visibility: config.visibility,
     shared_with_teams: config.shared_with_teams,
     config_driven: config.config_driven,
+    authz_revision: config.authz_revision,
+    authz_sync_state: config.authz_sync_state,
+    authz_last_synced_revision: config.authz_last_synced_revision,
+    authz_last_error_code: config.authz_last_error_code,
+    authz_sync_started_at: config.authz_sync_started_at,
   };
 }
 

--- a/ui/src/lib/server/__tests__/workflow-cas-authz.test.ts
+++ b/ui/src/lib/server/__tests__/workflow-cas-authz.test.ts
@@ -110,6 +110,24 @@ describe("filterAccessibleWorkflowConfigs", () => {
     expect(mockAuthorizeMany).not.toHaveBeenCalled();
   });
 
+  it("does not let the org-admin bypass restore an unreconciled workflow", async () => {
+    mockAuthorize.mockResolvedValueOnce(ALLOW);
+    const pendingConfigs = [
+      { _id: "wf-ready", authz_sync_state: "ready", authz_revision: 2, authz_last_synced_revision: 2 },
+      { _id: "wf-pending", authz_sync_state: "pending", authz_revision: 3, authz_last_synced_revision: 2 },
+    ];
+
+    const out = await filterAccessibleWorkflowConfigs(
+      session,
+      pendingConfigs,
+      getId,
+      "read",
+    );
+
+    expect(out).toEqual([pendingConfigs[0]]);
+    expect(mockAuthorizeMany).not.toHaveBeenCalled();
+  });
+
   it("filters non-admins to the accessible subset via one batch call", async () => {
     mockAuthorize.mockResolvedValueOnce(DENY); // not admin
     mockAuthorizeMany.mockResolvedValue(

--- a/ui/src/lib/server/workflow-cas-authz.ts
+++ b/ui/src/lib/server/workflow-cas-authz.ts
@@ -14,8 +14,18 @@
 // one shared decision core + cache + audit.
 
 import { ApiError } from "@/lib/api-error";
-import { authorize, authorizeMany, type AuthorizeResult, type DecisionContext, type Subject } from "@/lib/authz";
+import {
+  authorize,
+  authorizeMany,
+  type AuthorizeResult,
+  type DecisionContext,
+  type Subject,
+} from "@/lib/authz";
 import { emitDecisionAudit } from "@/lib/authz/audit";
+import {
+  authzSyncPreCheck,
+  type AuthzSyncDocument,
+} from "@/lib/authz/resource-sync";
 
 const ORG_KEY = process.env.CAIPE_ORG_KEY ?? "caipe";
 
@@ -29,14 +39,24 @@ export interface WorkflowAuthzSession {
   org?: string;
 }
 
-export function workflowSubjectFromSession(session: WorkflowAuthzSession): Subject | null {
+export function workflowSubjectFromSession(
+  session: WorkflowAuthzSession,
+): Subject | null {
   const sub = typeof session.sub === "string" ? session.sub.trim() : "";
   if (!sub) return null;
-  return { type: session.isServiceAccount === true ? "service_account" : "user", id: sub };
+  return {
+    type: session.isServiceAccount === true ? "service_account" : "user",
+    id: sub,
+  };
 }
 
 function ctxFromSession(session: WorkflowAuthzSession): DecisionContext {
-  return { tenantId: typeof session.org === "string" && session.org.trim() ? session.org.trim() : undefined };
+  return {
+    tenantId:
+      typeof session.org === "string" && session.org.trim()
+        ? session.org.trim()
+        : undefined,
+  };
 }
 
 async function workflowAccessDecision(
@@ -45,15 +65,23 @@ async function workflowAccessDecision(
   action: WorkflowAction,
 ): Promise<AuthorizeResult> {
   const subject = workflowSubjectFromSession(session);
-  if (!subject) return { decision: "DENY", reason: "NOT_AUTHENTICATED", retriable: false };
+  if (!subject)
+    return { decision: "DENY", reason: "NOT_AUTHENTICATED", retriable: false };
   const ctx = ctxFromSession(session);
   const orgAdmin = await authorize(
-    { subject, resource: { type: "organization", id: ORG_KEY }, action: "manage" },
+    {
+      subject,
+      resource: { type: "organization", id: ORG_KEY },
+      action: "manage",
+    },
     ctx,
   );
   if (orgAdmin.decision === "ALLOW") return orgAdmin;
   if (orgAdmin.reason === "AUTHZ_UNAVAILABLE") return orgAdmin;
-  return authorize({ subject, resource: { type: "task", id: configId }, action }, ctx);
+  return authorize(
+    { subject, resource: { type: "task", id: configId }, action },
+    ctx,
+  );
 }
 
 function unavailableError(): ApiError {
@@ -76,8 +104,14 @@ function workflowRunForbiddenError(): ApiError {
   );
 }
 
-function ownerMatches(run: WorkflowRunAccessDocument, subject: Subject): boolean {
-  return run.owner_subject?.type === subject.type && run.owner_subject.id === subject.id;
+function ownerMatches(
+  run: WorkflowRunAccessDocument,
+  subject: Subject,
+): boolean {
+  return (
+    run.owner_subject?.type === subject.type &&
+    run.owner_subject.id === subject.id
+  );
 }
 
 function workflowActionForRunAction(
@@ -188,7 +222,11 @@ export async function requireWorkflowRunAccess(
   if (run.owner_subject) {
     const ctx = ctxFromSession(session);
     const orgAdmin = await authorize(
-      { subject, resource: { type: "organization", id: ORG_KEY }, action: "manage" },
+      {
+        subject,
+        resource: { type: "organization", id: ORG_KEY },
+        action: "manage",
+      },
       ctx,
     );
     if (orgAdmin.reason === "AUTHZ_UNAVAILABLE" || orgAdmin.retriable) {
@@ -244,21 +282,29 @@ export async function filterAccessibleWorkflowConfigs<T>(
   if (!subject) return [];
   if (configs.length === 0) return [];
   const ctx = ctxFromSession(session);
+  const reconciledConfigs = configs.filter(
+    (config) => !authzSyncPreCheck(config as AuthzSyncDocument),
+  );
+  if (reconciledConfigs.length === 0) return [];
   const orgAdmin = await authorize(
-    { subject, resource: { type: "organization", id: ORG_KEY }, action: "manage" },
+    {
+      subject,
+      resource: { type: "organization", id: ORG_KEY },
+      action: "manage",
+    },
     ctx,
   );
-  if (orgAdmin.decision === "ALLOW") return configs;
+  if (orgAdmin.decision === "ALLOW") return reconciledConfigs;
   if (orgAdmin.reason === "AUTHZ_UNAVAILABLE" || orgAdmin.retriable) {
     throw unavailableError();
   }
 
-  const ids = configs.map(getId);
+  const ids = reconciledConfigs.map(getId);
   const results = await authorizeMany(subject, action, "task", ids, ctx);
   for (const result of results.values()) {
-    if (result.reason === "AUTHZ_UNAVAILABLE" || result.retriable) {
-      throw unavailableError();
-    }
+    if (result.reason === "AUTHZ_UNAVAILABLE") throw unavailableError();
   }
-  return configs.filter((config) => results.get(getId(config))?.decision === "ALLOW");
+  return reconciledConfigs.filter(
+    (config) => results.get(getId(config))?.decision === "ALLOW",
+  );
 }

--- a/ui/src/types/agent-skill.ts
+++ b/ui/src/types/agent-skill.ts
@@ -1,6 +1,8 @@
+import type { AuthzSyncMetadata } from "./authz-sync";
+
 /**
  * Agent skill types (catalog source: agent_skills)
- * 
+ *
  * These types define the structure for both:
  * - Agent workflows with multiple tasks (based on task_config.yaml)
  * - Quick-start templates (formerly "Use Cases") - single-step prompts
@@ -58,15 +60,15 @@ export interface AgentSkillTask {
 /**
  * Available subagent types that can execute tasks
  */
-export type AgentSkillSubagent = 
-  | "user_input"  // User input collection via forms
-  | "github"    // GitHub operations via gh CLI
-  | "aws"       // AWS resource provisioning
-  | "argocd"    // ArgoCD deployments
+export type AgentSkillSubagent =
+  | "user_input" // User input collection via forms
+  | "github" // GitHub operations via gh CLI
+  | "aws" // AWS resource provisioning
+  | "argocd" // ArgoCD deployments
   | "aigateway" // LLM API key management
-  | "webex"     // Webex notifications
-  | "jira"      // Jira ticket operations
-  | string;     // Allow custom subagents
+  | "webex" // Webex notifications
+  | "jira" // Jira ticket operations
+  | string; // Allow custom subagents
 
 /**
  * Categories for organizing agent skills
@@ -183,7 +185,7 @@ export type PersistedScanStatus = ScanStatus;
  * Main agent skill interface
  * Represents both multi-task workflows and quick-start templates
  */
-export interface AgentSkill {
+export interface AgentSkill extends AuthzSyncMetadata {
   /** Unique identifier */
   id: string;
   /** Display name (e.g., "Create GitHub Repo") */
@@ -196,6 +198,8 @@ export interface AgentSkill {
   tasks: AgentSkillTask[];
   /** Owner's email address (for user-created skills) */
   owner_id: string;
+  /** Stable OIDC subject used for ownership checks and reconciliation. */
+  owner_subject?: string;
   /** Whether this is a system/built-in skill row in MongoDB (may be edited or removed; restore via import/seed) */
   is_system: boolean;
   /** Creation timestamp */
@@ -204,7 +208,7 @@ export interface AgentSkill {
   updated_at: Date;
   /** Additional metadata */
   metadata?: AgentSkillMetadata;
-  
+
   // Quick-start template fields (for single-step workflows)
   /** Whether this is a quick-start template (single prompt, executes in chat) */
   is_quick_start?: boolean;
@@ -220,7 +224,7 @@ export interface AgentSkill {
   visibility?: SkillVisibility;
   /**
    * Team slugs/refs shared via OpenFGA when `visibility` is `team`.
-   * Populated on API read only — not stored in MongoDB.
+   * Persisted as the desired authorization state and hydrated from OpenFGA on read.
    */
   shared_with_teams?: string[];
   /**
@@ -308,12 +312,12 @@ export interface UpdateAgentSkillInput {
 /**
  * Execution status for a task step
  */
-export type TaskExecutionStatus = 
-  | "pending"     // Not yet started
+export type TaskExecutionStatus =
+  | "pending" // Not yet started
   | "in_progress" // Currently executing
-  | "completed"   // Successfully finished
-  | "failed"      // Execution failed
-  | "skipped";    // Skipped due to condition
+  | "completed" // Successfully finished
+  | "failed" // Execution failed
+  | "skipped"; // Skipped due to condition
 
 /**
  * Runtime state for a task during execution
@@ -378,10 +382,10 @@ export function extractPromptVariables(prompt: string): PromptVariable[] {
   const singleBracePattern = /\{([a-zA-Z_][a-zA-Z0-9_]*)\}/g;
   // Capture inner content which may contain "name:default"
   const doubleBracePattern = /\{\{([^}]+)\}\}/g;
-  
+
   const variables: PromptVariable[] = [];
   const seen = new Set<string>();
-  
+
   let match;
   while ((match = singleBracePattern.exec(prompt)) !== null) {
     const name = match[1];
@@ -390,7 +394,7 @@ export function extractPromptVariables(prompt: string): PromptVariable[] {
       variables.push({ name, required: true });
     }
   }
-  
+
   while ((match = doubleBracePattern.exec(prompt)) !== null) {
     const inner = match[1].trim();
     if (!inner) continue;
@@ -411,7 +415,7 @@ export function extractPromptVariables(prompt: string): PromptVariable[] {
       }
     }
   }
-  
+
   return variables;
 }
 
@@ -420,11 +424,11 @@ export function extractPromptVariables(prompt: string): PromptVariable[] {
  */
 export function generateInputFormFromPrompt(
   prompt: string,
-  title: string
+  title: string,
 ): WorkflowInputForm | null {
   const variables = extractPromptVariables(prompt);
   if (variables.length === 0) return null;
-  
+
   const fields: WorkflowInputField[] = variables.map((variable) => {
     // Convert variable name to label
     let label = variable.name
@@ -433,13 +437,13 @@ export function generateInputFormFromPrompt(
       .replace(/([A-Z])/g, " $1")
       .replace(/\s+/g, " ")
       .trim();
-    
+
     // Capitalize first letter of each word
     label = label
       .split(" ")
       .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
       .join(" ");
-    
+
     // Determine field type based on name
     let type: "text" | "url" | "number" = "text";
     const nameLower = variable.name.toLowerCase();
@@ -448,7 +452,7 @@ export function generateInputFormFromPrompt(
     } else if (nameLower.includes("count") || nameLower.includes("number")) {
       type = "number";
     }
-    
+
     return {
       name: variable.name,
       label,
@@ -460,7 +464,7 @@ export function generateInputFormFromPrompt(
       defaultValue: variable.defaultValue,
     };
   });
-  
+
   return {
     title,
     description: `Please provide the following information`,
@@ -473,42 +477,69 @@ export function generateInputFormFromPrompt(
  * Parse a task_config.yaml style object into AgentSkill array
  */
 export function parseTaskConfigObject(
-  config: Record<string, { tasks: Array<{ display_text: string; llm_prompt: string; subagent: string }> }>,
-  ownerId: string = "system"
+  config: Record<
+    string,
+    {
+      tasks: Array<{
+        display_text: string;
+        llm_prompt: string;
+        subagent: string;
+      }>;
+    }
+  >,
+  ownerId: string = "system",
 ): AgentSkill[] {
   const now = new Date();
-  
+
   return Object.entries(config).map(([name, value]) => {
     // Infer category from name
     let category: AgentSkillCategory = "Custom";
-    if (name.toLowerCase().includes("github") || name.toLowerCase().includes("repo")) {
+    if (
+      name.toLowerCase().includes("github") ||
+      name.toLowerCase().includes("repo")
+    ) {
       category = "GitHub Operations";
-    } else if (name.toLowerCase().includes("aws") || name.toLowerCase().includes("ec2") || name.toLowerCase().includes("eks") || name.toLowerCase().includes("s3")) {
+    } else if (
+      name.toLowerCase().includes("aws") ||
+      name.toLowerCase().includes("ec2") ||
+      name.toLowerCase().includes("eks") ||
+      name.toLowerCase().includes("s3")
+    ) {
       category = "AWS Operations";
-    } else if (name.toLowerCase().includes("argocd") || name.toLowerCase().includes("deploy")) {
+    } else if (
+      name.toLowerCase().includes("argocd") ||
+      name.toLowerCase().includes("deploy")
+    ) {
       category = "ArgoCD Operations";
-    } else if (name.toLowerCase().includes("llm") || name.toLowerCase().includes("api key") || name.toLowerCase().includes("aigateway")) {
+    } else if (
+      name.toLowerCase().includes("llm") ||
+      name.toLowerCase().includes("api key") ||
+      name.toLowerCase().includes("aigateway")
+    ) {
       category = "AI Gateway Operations";
-    } else if (name.toLowerCase().includes("group") || name.toLowerCase().includes("user")) {
+    } else if (
+      name.toLowerCase().includes("group") ||
+      name.toLowerCase().includes("user")
+    ) {
       category = "Group Management";
     }
-    
+
     // Extract env vars from prompts
     const envVarPattern = /\$\{([A-Z_][A-Z0-9_]*)\}/g;
     const envVars = new Set<string>();
-    value.tasks.forEach(task => {
+    value.tasks.forEach((task) => {
       let match;
       while ((match = envVarPattern.exec(task.llm_prompt)) !== null) {
         envVars.add(match[1]);
       }
     });
-    
+
     return {
       id: `config-${name.toLowerCase().replace(/\s+/g, "-")}-${Date.now()}`,
       name,
       description: `Workflow for: ${name}`,
       category,
-      tasks: value.tasks.map(task => ({
+      tasks: value.tasks.map((task) => ({
         display_text: task.display_text,
         llm_prompt: task.llm_prompt,
         subagent: task.subagent as AgentSkillSubagent,

--- a/ui/src/types/authz-sync.ts
+++ b/ui/src/types/authz-sync.ts
@@ -1,0 +1,11 @@
+export type AuthzSyncState = "pending" | "ready" | "error";
+
+/** Persisted reconciliation metadata shared by user-owned resources. */
+export interface AuthzSyncMetadata {
+  authz_revision?: number;
+  authz_sync_state?: AuthzSyncState;
+  authz_last_synced_revision?: number;
+  authz_last_error_code?: string;
+  authz_sync_started_at?: string;
+  authz_previous_state?: Record<string, unknown>;
+}

--- a/ui/src/types/dynamic-agent.ts
+++ b/ui/src/types/dynamic-agent.ts
@@ -30,11 +30,22 @@ export type VisibilityType = 'private' | 'team' | 'global';
  */
 export type LegacyVisibilityType = VisibilityType;
 
+export type AuthzSyncState = "pending" | "ready" | "error";
+
+export interface AuthzSyncMetadata {
+  authz_revision?: number;
+  authz_sync_state?: AuthzSyncState;
+  authz_last_synced_revision?: number;
+  authz_last_error_code?: string;
+  authz_sync_started_at?: string;
+  authz_previous_state?: Record<string, unknown>;
+}
+
 // =============================================================================
 // MCP Server Types
 // =============================================================================
 
-export interface MCPServerConfig {
+export interface MCPServerConfig extends AuthzSyncMetadata {
   _id: string;
   name: string;
   description?: string;
@@ -390,7 +401,7 @@ export type ResumeData =
   | { type: "tool_approval"; decision: "edit"; edited_args: Record<string, unknown> }
   | { type: "tool_approval"; decisions: Array<{ decision: string; tool_name?: string; edited_args?: Record<string, unknown> }> };
 
-export interface DynamicAgentConfig {
+export interface DynamicAgentConfig extends AuthzSyncMetadata {
   _id: string;
   name: string;
   description?: string;

--- a/ui/src/types/dynamic-agent.ts
+++ b/ui/src/types/dynamic-agent.ts
@@ -2,6 +2,9 @@
  * TypeScript types for Dynamic Agents feature.
  */
 
+import type { AuthzSyncMetadata } from "./authz-sync";
+export type { AuthzSyncMetadata, AuthzSyncState } from "./authz-sync";
+
 // =============================================================================
 // Enums
 // =============================================================================
@@ -29,17 +32,6 @@ export type VisibilityType = 'private' | 'team' | 'global';
  * surfaces a deprecation warning in the response.
  */
 export type LegacyVisibilityType = VisibilityType;
-
-export type AuthzSyncState = "pending" | "ready" | "error";
-
-export interface AuthzSyncMetadata {
-  authz_revision?: number;
-  authz_sync_state?: AuthzSyncState;
-  authz_last_synced_revision?: number;
-  authz_last_error_code?: string;
-  authz_sync_started_at?: string;
-  authz_previous_state?: Record<string, unknown>;
-}
 
 // =============================================================================
 // MCP Server Types

--- a/ui/src/types/workflow-config.ts
+++ b/ui/src/types/workflow-config.ts
@@ -1,3 +1,5 @@
+import type { AuthzSyncMetadata } from "./authz-sync";
+
 /**
  * Workflow Config Types
  *
@@ -52,7 +54,7 @@ export type StepEntry = WorkflowStep | ParallelGroup;
 // Workflow Config (MongoDB document)
 // ---------------------------------------------------------------------------
 
-export interface WorkflowConfig {
+export interface WorkflowConfig extends AuthzSyncMetadata {
   /** Unique identifier (MongoDB _id), e.g. "wf-<timestamp>-<random>" */
   _id: string;
   /** Workflow name (unique) */
@@ -63,6 +65,8 @@ export interface WorkflowConfig {
   steps: StepEntry[];
   /** Creator's email */
   owner_id: string;
+  /** Stable OIDC subject used for ownership checks and reconciliation. */
+  owner_subject?: string;
   /** Visibility level */
   visibility: WorkflowConfigVisibility;
   /** Team IDs when visibility is "team" */
@@ -100,7 +104,9 @@ export interface UpdateWorkflowConfigInput {
 // ---------------------------------------------------------------------------
 
 /** Create a blank WorkflowStep with sensible defaults */
-export function createBlankStep(overrides?: Partial<WorkflowStep>): WorkflowStep {
+export function createBlankStep(
+  overrides?: Partial<WorkflowStep>,
+): WorkflowStep {
   return {
     type: "step",
     display_text: "",
@@ -115,7 +121,7 @@ export function createBlankStep(overrides?: Partial<WorkflowStep>): WorkflowStep
 
 /** Flatten StepEntry[] into a flat list of (globalIndex, WorkflowStep) tuples */
 export function flattenStepEntries(
-  entries: StepEntry[]
+  entries: StepEntry[],
 ): { index: number; step: WorkflowStep }[] {
   const result: { index: number; step: WorkflowStep }[] = [];
   let idx = 0;


### PR DESCRIPTION
# Description

Harden private-resource ownership, visibility, reconciliation, and execution across dynamic agents, MCP servers, skills, workflows, and credentials. MongoDB remains the desired-state source of truth while OpenFGA is projected safely.

This PR is intentionally based on the private-resources feature branch because private/personal agents are not yet present on upstream main. It is intended to be folded into #2384 before that feature merges.

This change:

- fixes team-to-private agent and direct MCP update conflicts
- persists monotonic authorization revisions in pending state before ownership, visibility, sharing, or agent-tool changes are projected
- verifies grants and revocations at higher consistency before marking the matching revision ready
- leaves failed transitions retriable and fails discovery/execution closed while keeping the builder available for repair
- applies owner-only private discovery and management to skills and workflows, including skill catalog content and workflow runs
- persists stable owner subjects and desired team shares for skill saves and ZIP imports
- prevents global/team agents and workflows from embedding narrower private dependencies; same-owner private composition remains supported
- preserves hub skills as global dependencies and supports legacy owner-email rows until stable subjects are backfilled
- shows a subtle authorization sync status beside Agent, MCP, Skill, and Workflow builder controls

Mirror counterpart: cisco-eti/ai-platform-engineering-mirror#646

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other

## Validation

- Full UI Jest suite: 572 suites, 6,984 tests passed
- Focused upstream authorization and builder matrix: 13 suites, 196 tests passed
- TypeScript: `tsc --noEmit` passed
- ESLint passed
- `git diff --check` passed

## Checklist

- [x] I have read the contributing guidelines
- [x] I have verified this change is not present in other open pull requests
- [x] Existing upstream feature PR #2384 is referenced
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All relevant existing tests pass