### PR TITLE
fix(rbac): self-heal config-driven MCP authorization

### DIFF
--- a/ui/src/lib/__tests__/seed-config-openfga-reconcile.test.ts
+++ b/ui/src/lib/__tests__/seed-config-openfga-reconcile.test.ts
@@ -1,0 +1,81 @@
+/**
+ * @jest-environment node
+ */
+
+const mockCollection = {
+  find: jest.fn(),
+};
+const mockReconcileAgentRelationships = jest.fn();
+
+jest.mock("@/lib/mongodb", () => ({
+  isMongoDBConfigured: true,
+  getCollection: jest.fn(async () => mockCollection),
+}));
+jest.mock("@/lib/rbac/openfga", () => ({
+  isOpenFgaReconciliationEnabled: jest.fn(() => true),
+  writeOpenFgaTuples: jest.fn(),
+}));
+jest.mock("@/lib/rbac/openfga-agent-tools", () => ({
+  reconcileAgentRelationships: (...args: unknown[]) =>
+    mockReconcileAgentRelationships(...args),
+}));
+jest.mock("@/lib/rbac/openfga-owned-resources-reconcile", () => ({
+  deleteAllIngestionSourceRelationshipTuples: jest.fn(),
+  reconcileConfigDrivenLlmModelRelationships: jest.fn(),
+  reconcileConfigDrivenMcpServerRelationships: jest.fn(),
+  reconcileDataSourceRelationships: jest.fn(),
+  reconcileIngestionSourceRelationships: jest.fn(),
+  reconcileKnowledgeBaseRelationships: jest.fn(),
+  reconcileShareableResource: jest.fn(),
+}));
+jest.mock("@/lib/rbac/unlinked-service-account", () => ({
+  resolveUnlinkedServiceAccountSub: jest.fn(async () => null),
+  resolveUnlinkedServiceAccountGrantState: jest.fn(async () => ({
+    sub: null,
+    explicitAgentIds: new Set<string>(),
+  })),
+}));
+jest.mock("@/lib/rbac/platform-default", () => ({
+  getPlatformDefaultAgentId: jest.fn(async () => null),
+}));
+jest.mock("@/lib/rbac/workflow-config-rebac", () => ({
+  normalizeSharedWithTeamSlugs: jest.fn(async (slugs: string[]) => slugs),
+  repairWorkflowConfigTeamSlugRefs: jest.fn(async () => 0),
+}));
+
+import { reconcileExistingAgentOpenFgaTuples } from "../seed-config";
+
+describe("reconcileExistingAgentOpenFgaTuples", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockReconcileAgentRelationships.mockResolvedValue({
+      enabled: true,
+      writes: 1,
+      deletes: 0,
+    });
+  });
+
+  it("reasserts configured tool grants so missing caller tuples self-heal", async () => {
+    const allowedTools = { "mcp-gh-user": true };
+    mockCollection.find.mockReturnValue({
+      toArray: jest.fn(async () => [
+        {
+          _id: "agent-personal-assistant",
+          allowed_tools: allowedTools,
+          owner_subject: "alice-sub",
+          visibility: "global",
+        },
+      ]),
+    });
+
+    await expect(reconcileExistingAgentOpenFgaTuples()).resolves.toBe(1);
+
+    expect(mockReconcileAgentRelationships).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "agent-personal-assistant",
+        previousAllowedTools: {},
+        nextAllowedTools: allowedTools,
+      }),
+    );
+  });
+});

--- a/ui/src/lib/rbac/__tests__/openfga-owned-resources-reconcile.test.ts
+++ b/ui/src/lib/rbac/__tests__/openfga-owned-resources-reconcile.test.ts
@@ -331,6 +331,46 @@ describe("reconcileMcpServerRelationships", () => {
     );
   });
 
+  it("removes stale direct owners when a user-owned server becomes config-driven", async () => {
+    mockReadOpenFgaTuples.mockImplementation(
+      async (options: { tuple?: { object?: string } }) => {
+        const object = options?.tuple?.object;
+        if (object === "mcp_server:mcp-config-sync") {
+          return tuplePage([
+            { user: "user:alice", relation: "owner", object },
+            { user: "user:alice", relation: "creator", object },
+          ]);
+        }
+        return tuplePage([]);
+      },
+    );
+
+    await reconcileConfigDrivenMcpServerRelationships({
+      serverId: "mcp-config-sync",
+      organizationId: "caipe",
+    });
+
+    const diff = mockReconcileTupleDiff.mock.calls[0][0];
+    expect(diff.deletes).toEqual(
+      expect.arrayContaining([
+        {
+          user: "user:alice",
+          relation: "owner",
+          object: "mcp_server:mcp-config-sync",
+        },
+      ]),
+    );
+    expect(diff.deletes).not.toEqual(
+      expect.arrayContaining([
+        {
+          user: "user:alice",
+          relation: "creator",
+          object: "mcp_server:mcp-config-sync",
+        },
+      ]),
+    );
+  });
+
   it("writes owner tuples with service_account namespace and audit caller", async () => {
     await reconcileMcpServerRelationships(
       {

--- a/ui/src/lib/rbac/openfga-owned-resources-reconcile.ts
+++ b/ui/src/lib/rbac/openfga-owned-resources-reconcile.ts
@@ -187,9 +187,22 @@ export async function reconcileMcpServerRelationships(
 export async function reconcileConfigDrivenMcpServerRelationships(
   input: ConfigDrivenMcpServerRelationshipInput,
 ): Promise<OpenFgaReconcileResult> {
+  const baseDiff = buildConfigDrivenMcpServerRelationshipTupleDiff(input);
+  const existingServerTuples = await readAllTuplesForObject(
+    `mcp_server:${input.serverId}`,
+  );
+  const staleOwnerTuples = existingServerTuples.filter(
+    (tuple) => tuple.relation === "owner",
+  );
   const diff = await withMcpServerToolWildcardBackfill(
     input.serverId,
-    buildConfigDrivenMcpServerRelationshipTupleDiff(input),
+    {
+      writes: baseDiff.writes,
+      // A config-driven server can replace a formerly user-owned server with
+      // the same id. Direct owner tuples make the gateway treat that global
+      // route as private, so remove them while preserving creator provenance.
+      deletes: uniqueTuples([...baseDiff.deletes, ...staleOwnerTuples]),
+    },
   );
   return reconcileOwnedResource(diff);
 }

--- a/ui/src/lib/seed-config.ts
+++ b/ui/src/lib/seed-config.ts
@@ -1713,7 +1713,10 @@ export async function reconcileExistingAgentOpenFgaTuples(): Promise<number> {
       platformDefaultAgentId !== null && agentId === platformDefaultAgentId;
     await reconcileAgentRelationships({
       agentId,
-      previousAllowedTools: allowedTools,
+      // This is a repair sweep, not an edit diff. Treat the current grants as
+      // desired writes so reconcileTupleDiff can restore any missing agent
+      // caller tuple without duplicating tuples that already exist.
+      previousAllowedTools: {},
       nextAllowedTools: allowedTools,
       ownerSubject: agent.owner_subject ?? agent.owner_id,
       organizationId: orgId,


### PR DESCRIPTION
# Description

Fix two OpenFGA reconciliation gaps that can occur when a deployment-managed MCP server replaces a formerly user-owned server with the same ID, or when agent-tool grants drift from the stored agent configuration.

## Problem and concrete examples

### 1. Stale ownership makes a global MCP route look private

Example:

1. A user creates `mcp_server:shared-tools`, so OpenFGA contains a direct `owner` tuple for that user.
2. The deployment later manages `shared-tools` from configuration and intends the server to have global/default visibility.
3. Startup reconciliation writes the configuration-managed grants, but the old direct `owner` tuple remains.
4. AgentGateway sees that stale owner relationship and classifies the route as private. An otherwise valid agent tool call can then fail with `DENY_AGENT_TOOL` even though the MCP route and the agent's `allowed_tools` configuration are correct.

The fix removes stale direct `owner` tuples when reconciling a configuration-managed MCP server, while preserving the `creator` tuple so historical provenance remains available for audit purposes.

### 2. Missing agent-tool caller grants do not self-heal

Example:

- An agent's configuration allows `mcp-git:list_repositories`, but the corresponding OpenFGA `agent:<id> caller tool:mcp-git/list_repositories` tuple is missing because of an earlier partial write, migration, or drift.
- The startup repair sweep previously compared the current `allowed_tools` value with itself. That produced an empty diff, so the missing caller tuple was never written.

The fix treats the current configuration as the desired state during the repair sweep, causing missing caller tuples to be restored. The existing OpenFGA tuple reconciler remains idempotent, so tuples that already exist are not duplicated.

## Why this is needed

OpenFGA is the authorization source of truth, but its tuples can drift during ownership transitions, upgrades, partial failures, or earlier bugs. These repairs make startup reconciliation self-healing, prevent valid agent tool calls from being denied because of stale or missing tuples, and keep the resulting grants aligned with the configured ownership and tool policy.

The change is narrowly scoped: it removes only stale ownership tuples from explicitly configuration-managed MCP servers and reasserts only the agent-tool tuples declared by `allowed_tools`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing issues have been referenced where applicable
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] New code contribution is covered by automated tests
- [x] Focused new and existing tests pass

## Validation

`jest --runInBand src/lib/rbac/__tests__/openfga-owned-resources-reconcile.test.ts src/lib/__tests__/seed-config-openfga-reconcile.test.ts`

Result: 2 suites passed, 11 tests passed.