### PR TITLE
fix(ui): include resource names in agent breadcrumbs

### DIFF
--- a/ui/src/app/(app)/dynamic-agents/__tests__/page.test.tsx
+++ b/ui/src/app/(app)/dynamic-agents/__tests__/page.test.tsx
@@ -28,48 +28,64 @@ jest.mock("@/components/auth-guard", () => ({
 }));
 
 jest.mock("@/components/dynamic-agents/DynamicAgentsTab", () => ({
-  DynamicAgentsTab: ({
+  DynamicAgentsTab: function DynamicAgentsTabMock({
     selectedAgentId,
     initialStep,
     onSelectedAgentChange,
+    onSelectedAgentNameChange,
     onStepChange,
   }: {
     selectedAgentId?: string | null;
     initialStep?: string;
     onSelectedAgentChange?: (id: string | null) => void;
+    onSelectedAgentNameChange?: (name: string | null) => void;
     onStepChange?: (step: string) => void;
-  }) => (
-    <div
-      data-testid="dynamic-agents-tab"
-      data-selected-id={selectedAgentId ?? ""}
-      data-step={initialStep ?? ""}
-    >
-      DynamicAgentsTab
-      <button type="button" onClick={() => onStepChange?.("tools")}>
-        Open tools step
-      </button>
-      <button type="button" onClick={() => onSelectedAgentChange?.("agent-ops")}>
-        Open agent editor
-      </button>
-    </div>
-  ),
+  }) {
+    React.useEffect(() => {
+      onSelectedAgentNameChange?.(selectedAgentId ? "Example Agent" : null);
+    }, [onSelectedAgentNameChange, selectedAgentId]);
+
+    return (
+      <div
+        data-testid="dynamic-agents-tab"
+        data-selected-id={selectedAgentId ?? ""}
+        data-step={initialStep ?? ""}
+      >
+        DynamicAgentsTab
+        <button type="button" onClick={() => onStepChange?.("tools")}>
+          Open tools step
+        </button>
+        <button type="button" onClick={() => onSelectedAgentChange?.("agent-ops")}>
+          Open agent editor
+        </button>
+      </div>
+    );
+  },
 }));
 
 jest.mock("@/components/dynamic-agents/MCPServersTab", () => ({
-  MCPServersTab: ({
+  MCPServersTab: function MCPServersTabMock({
     selectedServerId,
     onSelectedServerChange,
+    onSelectedServerNameChange,
   }: {
     selectedServerId?: string | null;
     onSelectedServerChange?: (id: string | null) => void;
-  }) => (
-    <div data-testid="mcp-servers-tab" data-selected-id={selectedServerId ?? ""}>
-      MCPServersTab
-      <button type="button" onClick={() => onSelectedServerChange?.("mcp-jira")}>
-        Open server editor
-      </button>
-    </div>
-  ),
+    onSelectedServerNameChange?: (name: string | null) => void;
+  }) {
+    React.useEffect(() => {
+      onSelectedServerNameChange?.(selectedServerId ? "Example MCP Server" : null);
+    }, [onSelectedServerNameChange, selectedServerId]);
+
+    return (
+      <div data-testid="mcp-servers-tab" data-selected-id={selectedServerId ?? ""}>
+        MCPServersTab
+        <button type="button" onClick={() => onSelectedServerChange?.("mcp-jira")}>
+          Open server editor
+        </button>
+      </div>
+    );
+  },
 }));
 
 jest.mock("@/components/dynamic-agents/LLMProvidersTab", () => ({
@@ -236,6 +252,30 @@ describe("DynamicAgentsPage", () => {
 
     expect(screen.getByTestId("dynamic-agents-tab")).toHaveAttribute("data-selected-id", "agent-ops");
     expect(screen.getByTestId("dynamic-agents-tab")).toHaveAttribute("data-step", "instructions");
+  });
+
+  it("includes the selected agent name in the breadcrumb", () => {
+    mockSearchParams = new URLSearchParams("tab=agents&agent=agent-ops&step=basic");
+
+    render(<DynamicAgentsPage />);
+
+    const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
+    expect(within(breadcrumb).getByRole("link", { name: "Example Agent" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
+  });
+
+  it("includes the selected MCP server name in the breadcrumb", () => {
+    mockSearchParams = new URLSearchParams("tab=mcp-servers&server=mcp-example");
+
+    render(<DynamicAgentsPage />);
+
+    const breadcrumb = screen.getByRole("navigation", { name: "Breadcrumb" });
+    expect(within(breadcrumb).getByRole("link", { name: "Example MCP Server" })).toHaveAttribute(
+      "aria-current",
+      "page",
+    );
   });
 
   it("updates the current agent setup step in the URL", () => {

--- a/ui/src/app/(app)/dynamic-agents/page.tsx
+++ b/ui/src/app/(app)/dynamic-agents/page.tsx
@@ -46,6 +46,8 @@ function DynamicAgentsPageContent() {
   const selectedAgentId = searchParams.get("agent");
   const selectedServerId = searchParams.get("server");
   const selectedModelId = searchParams.get("model");
+  const [selectedAgentName, setSelectedAgentName] = React.useState<string | null>(null);
+  const [selectedServerName, setSelectedServerName] = React.useState<string | null>(null);
   const requestedAgentStep = searchParams.get("step");
   const agentStep = isAgentSetupStep(requestedAgentStep) ? requestedAgentStep : "basic";
 
@@ -73,6 +75,8 @@ function DynamicAgentsPageContent() {
   }
 
   function performTabSwitch(tab: string) {
+    setSelectedAgentName(null);
+    setSelectedServerName(null);
     router.push(hrefForTab(tab));
   }
 
@@ -80,6 +84,8 @@ function DynamicAgentsPageContent() {
     const params = new URLSearchParams(searchParams.toString());
     params.set("tab", tab);
     clearResourceSelection(params);
+    if (key === "agent") setSelectedAgentName(null);
+    if (key === "server") setSelectedServerName(null);
     if (id) {
       params.set(key, id);
       if (key === "agent") params.set("step", "basic");
@@ -137,6 +143,11 @@ function DynamicAgentsPageContent() {
   const agentHomeHref = hrefForTab("agents");
   const modelsHref = hrefForTab("model-providers");
   const currentHref = hrefFor(new URLSearchParams(searchParams.toString()));
+  const selectedResourceName = activeTab === "agents" && selectedAgentId
+    ? selectedAgentName
+    : activeTab === "mcp-servers" && selectedServerId
+      ? selectedServerName
+      : null;
   const switchFromBreadcrumb = (
     tab: string,
   ): React.MouseEventHandler<HTMLAnchorElement> => (event) => {
@@ -159,7 +170,10 @@ function DynamicAgentsPageContent() {
             breadcrumbs={[
               { label: "Home",href: "/" },
               ...(activeTab === "agents"
-                ? [{ label: "Agents",href: currentHref }]
+                ? [{
+                    label: "Agents",
+                    href: selectedResourceName ? agentHomeHref : currentHref,
+                  }]
                 : [{
                     label: "Agents",
                     href: agentHomeHref,
@@ -174,7 +188,13 @@ function DynamicAgentsPageContent() {
                 : []),
               ...(activeTab === "agents"
                 ? []
-                : [{ label: activeNavigationItem.label,href: currentHref }]),
+                : [{
+                    label: activeNavigationItem.label,
+                    href: selectedResourceName ? hrefForTab(activeTab) : currentHref,
+                  }]),
+              ...(selectedResourceName
+                ? [{ label: selectedResourceName, href: currentHref }]
+                : []),
             ]}
             description={activeDescription}
             title={activeNavigationItem.label}
@@ -195,6 +215,7 @@ function DynamicAgentsPageContent() {
             selectedAgentId={selectedAgentId}
             initialStep={agentStep}
             onSelectedAgentChange={(id) => selectResource("agents", "agent", id)}
+            onSelectedAgentNameChange={setSelectedAgentName}
             onStepChange={setAgentStep}
           />
         ) : null}
@@ -203,6 +224,7 @@ function DynamicAgentsPageContent() {
           <MCPServersTab
             selectedServerId={selectedServerId}
             onSelectedServerChange={(id) => selectResource("mcp-servers", "server", id)}
+            onSelectedServerNameChange={setSelectedServerName}
           />
         ) : null}
 

--- a/ui/src/components/dynamic-agents/DynamicAgentsTab.tsx
+++ b/ui/src/components/dynamic-agents/DynamicAgentsTab.tsx
@@ -63,6 +63,7 @@ interface DynamicAgentsTabProps {
   selectedAgentId?: string | null;
   initialStep?: AgentSetupStep;
   onSelectedAgentChange?: (agentId: string | null) => void;
+  onSelectedAgentNameChange?: (agentName: string | null) => void;
   onStepChange?: (step: AgentSetupStep) => void;
 }
 
@@ -70,6 +71,7 @@ export function DynamicAgentsTab({
   selectedAgentId,
   initialStep,
   onSelectedAgentChange,
+  onSelectedAgentNameChange,
   onStepChange,
 }: DynamicAgentsTabProps = {}) {
   const router = useRouter();
@@ -130,7 +132,10 @@ export function DynamicAgentsTab({
   }, [fetchAgents]);
 
   React.useEffect(() => {
-    if (selectedAgentId === undefined) return;
+    if (selectedAgentId === undefined) {
+      onSelectedAgentNameChange?.(null);
+      return;
+    }
 
     const requestId = ++selectionRequestRef.current;
     if (!selectedAgentId) {
@@ -138,6 +143,7 @@ export function DynamicAgentsTab({
       setEditingAgent(null);
       setSelectionError(null);
       setSelectionLoading(false);
+      onSelectedAgentNameChange?.(null);
       return;
     }
 
@@ -149,6 +155,7 @@ export function DynamicAgentsTab({
 
     setSelectionLoading(true);
     setSelectionError(null);
+    onSelectedAgentNameChange?.(null);
     void (async () => {
       try {
         const response = await fetch(
@@ -164,12 +171,14 @@ export function DynamicAgentsTab({
             ...data.data,
             permissions: data.data.permissions ?? DEFAULT_ROW_PERMISSIONS,
           });
+          onSelectedAgentNameChange?.(data.data.name ?? null);
         }
       } catch (err: unknown) {
         if (selectionRequestRef.current === requestId) {
           loadedSelectionIdRef.current = null;
           setEditingAgent(null);
           setSelectionError(errorMessage(err, "Failed to load agent"));
+          onSelectedAgentNameChange?.(null);
         }
       } finally {
         if (selectionRequestRef.current === requestId) {
@@ -177,7 +186,7 @@ export function DynamicAgentsTab({
         }
       }
     })();
-  }, [selectedAgentId]);
+  }, [onSelectedAgentNameChange, selectedAgentId]);
 
   // Debounce search input
   React.useEffect(() => {
@@ -319,6 +328,7 @@ export function DynamicAgentsTab({
     setSelectionError(null);
     setEditingAgent(agent);
     onSelectedAgentChange?.(agent._id);
+    onSelectedAgentNameChange?.(agent.name);
   };
 
   const closeAgentEditor = () => {
@@ -329,6 +339,7 @@ export function DynamicAgentsTab({
     setCloningAgent(null);
     setSelectionError(null);
     setSelectionLoading(false);
+    onSelectedAgentNameChange?.(null);
     onSelectedAgentChange?.(null);
   };
 

--- a/ui/src/components/dynamic-agents/MCPServersTab.tsx
+++ b/ui/src/components/dynamic-agents/MCPServersTab.tsx
@@ -77,6 +77,7 @@ interface FetchServersOptions {
 interface MCPServersTabProps {
   selectedServerId?: string | null;
   onSelectedServerChange?: (serverId: string | null) => void;
+  onSelectedServerNameChange?: (serverName: string | null) => void;
 }
 
 interface ToolTestResult {
@@ -201,6 +202,7 @@ function toolHealthDotClass(status: ToolHealthStatus): string {
 export function MCPServersTab({
   selectedServerId,
   onSelectedServerChange,
+  onSelectedServerNameChange,
 }: MCPServersTabProps = {}) {
   const [servers, setServers] = React.useState<MCPServerConfigWithPermissions[]>([]);
   const [listCapabilities, setListCapabilities] = React.useState(DEFAULT_LIST_CAPABILITIES);
@@ -270,7 +272,10 @@ export function MCPServersTab({
   }, [fetchServers]);
 
   React.useEffect(() => {
-    if (selectedServerId === undefined) return;
+    if (selectedServerId === undefined) {
+      onSelectedServerNameChange?.(null);
+      return;
+    }
 
     const requestId = ++selectionRequestRef.current;
     if (!selectedServerId) {
@@ -278,6 +283,7 @@ export function MCPServersTab({
       setEditingServer(null);
       setSelectionError(null);
       setSelectionLoading(false);
+      onSelectedServerNameChange?.(null);
       return;
     }
 
@@ -289,6 +295,7 @@ export function MCPServersTab({
 
     setSelectionLoading(true);
     setSelectionError(null);
+    onSelectedServerNameChange?.(null);
     void (async () => {
       try {
         const response = await fetch(`/api/mcp-servers?id=${encodeURIComponent(selectedServerId)}`, {
@@ -304,12 +311,14 @@ export function MCPServersTab({
             ...data.data,
             permissions: data.data.permissions ?? DEFAULT_ROW_PERMISSIONS,
           });
+          onSelectedServerNameChange?.(data.data.name ?? null);
         }
       } catch (err: unknown) {
         if (selectionRequestRef.current === requestId) {
           loadedSelectionIdRef.current = null;
           setEditingServer(null);
           setSelectionError(errorMessage(err, "Failed to load MCP server"));
+          onSelectedServerNameChange?.(null);
         }
       } finally {
         if (selectionRequestRef.current === requestId) {
@@ -317,7 +326,7 @@ export function MCPServersTab({
         }
       }
     })();
-  }, [selectedServerId]);
+  }, [onSelectedServerNameChange, selectedServerId]);
 
   React.useEffect(() => {
     const refreshFromBackend = () => {
@@ -555,6 +564,7 @@ export function MCPServersTab({
     setSelectionError(null);
     setEditingServer(server);
     onSelectedServerChange?.(server._id);
+    onSelectedServerNameChange?.(server.name);
   };
 
   const closeServerEditor = () => {
@@ -565,6 +575,7 @@ export function MCPServersTab({
     setCatalogInitialValues(null);
     setSelectionError(null);
     setSelectionLoading(false);
+    onSelectedServerNameChange?.(null);
     onSelectedServerChange?.(null);
   };
 

--- a/ui/src/components/dynamic-agents/__tests__/DynamicAgentsTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/DynamicAgentsTab.test.tsx
@@ -327,6 +327,7 @@ describe("DynamicAgentsTab search + pagination", () => {
 
   it("loads a directly linked agent and keeps its setup step and close action URL-controlled", async () => {
     const onSelectedAgentChange = jest.fn();
+    const onSelectedAgentNameChange = jest.fn();
     const onStepChange = jest.fn();
     fetchMock.mockImplementation((url: string) => {
       if (url === "/api/dynamic-agents/agents/agent-1") {
@@ -342,6 +343,7 @@ describe("DynamicAgentsTab search + pagination", () => {
         selectedAgentId="agent-1"
         initialStep="instructions"
         onSelectedAgentChange={onSelectedAgentChange}
+        onSelectedAgentNameChange={onSelectedAgentNameChange}
         onStepChange={onStepChange}
       />,
     );
@@ -350,12 +352,14 @@ describe("DynamicAgentsTab search + pagination", () => {
     expect(fetchMock).toHaveBeenCalledWith("/api/dynamic-agents/agents/agent-1");
     expect(editor).toHaveAttribute("data-agent-id", "agent-1");
     expect(editor).toHaveAttribute("data-step", "instructions");
+    expect(onSelectedAgentNameChange).toHaveBeenCalledWith("Ops Helper");
 
     fireEvent.click(screen.getByRole("button", { name: "Editor tools step" }));
     expect(onStepChange).toHaveBeenCalledWith("tools");
 
     fireEvent.click(screen.getByRole("button", { name: "Close editor" }));
     expect(onSelectedAgentChange).toHaveBeenCalledWith(null);
+    expect(onSelectedAgentNameChange).toHaveBeenCalledWith(null);
   });
 
   it("shows an editor-shaped skeleton while a directly linked agent loads", async () => {

--- a/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/MCPServersTab.test.tsx
@@ -451,11 +451,13 @@ describe("MCPServersTab AgentGateway repair", () => {
 
   it("loads a directly linked MCP server and reports when its editor closes", async () => {
     const onSelectedServerChange = jest.fn();
+    const onSelectedServerNameChange = jest.fn();
 
     render(
       <MCPServersTab
         selectedServerId="jira"
         onSelectedServerChange={onSelectedServerChange}
+        onSelectedServerNameChange={onSelectedServerNameChange}
       />,
     );
 
@@ -464,9 +466,11 @@ describe("MCPServersTab AgentGateway repair", () => {
       "/api/mcp-servers?id=jira",
       { cache: "no-store" },
     );
+    expect(onSelectedServerNameChange).toHaveBeenCalledWith("Jira");
 
     fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
     expect(onSelectedServerChange).toHaveBeenCalledWith(null);
+    expect(onSelectedServerNameChange).toHaveBeenCalledWith(null);
   });
 
   it("keeps the selected row open when the page adds the server ID to the URL", async () => {


### PR DESCRIPTION
## Summary

- Include the selected agent or MCP server display name as the final breadcrumb segment while editing.
- Keep breadcrumb state synchronized when a resource loads, changes, closes, or fails to load.
- Add coverage for both resource types.

## Validation

- Focused page, agent-tab, and MCP-tab Jest suites pass in both mirror and upstream trees.
- ESLint passes for all changed files in both trees.
- Full TypeScript check remains blocked by pre-existing missing dependencies in the local environment.
