### PR TITLE
fix(ui): preserve agent colors in chat avatars

### DIFF
--- a/ui/src/components/chat/DynamicAgentChatPanel.tsx
+++ b/ui/src/components/chat/DynamicAgentChatPanel.tsx
@@ -1748,6 +1748,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
                   <>
                     <AgentAvatar
                       agent={agent}
+                      agentId={agentId}
                       rounded="rounded-2xl"
                       size="w-16 h-16 mx-auto mb-6"
                       iconSize="h-8 w-8"
@@ -1761,6 +1762,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
                     <div className="flex items-center justify-center gap-3">
                       <AgentAvatar
                         agent={agent}
+                        agentId={agentId}
                         rounded="rounded-lg"
                         size="w-8 h-8"
                         iconSize="h-4 w-4"
@@ -1895,6 +1897,7 @@ export function ChatPanel({ conversationId, readOnly, readOnlyReason, agentId, a
                           showTimestamp={showTimestamps}
                           agentGradient={agentGradient}
                           agentCustomTheme={agentCustomTheme}
+                          agentId={agentId}
                           agentName={agentName}
                           turnEvents={turnEvents}
                           // Timeline props (only passed to latest message)
@@ -2370,6 +2373,7 @@ interface ChatMessageProps {
   showTimestamp?: boolean;
   agentGradient?: string | null;
   agentCustomTheme?: import("@/types/dynamic-agent").CustomThemeConfig | null;
+  agentId?: string | null;
   agentName?: string;
   turnEvents?: StreamEvent[];
   // Timeline props (for AgentTimeline)
@@ -2401,6 +2405,7 @@ const ChatMessage = React.memo(function ChatMessage({
   showTimestamp = false,
   agentGradient,
   agentCustomTheme,
+  agentId,
   agentName,
   turnEvents = [],
   // Timeline props
@@ -2462,6 +2467,7 @@ const ChatMessage = React.memo(function ChatMessage({
         </div>
       ) : (
         <AgentAvatar
+          agentId={agentId}
           gradientTheme={agentGradient}
           customThemeConfig={agentCustomTheme}
           rounded="rounded-xl"

--- a/ui/src/components/dynamic-agents/AgentAvatar.tsx
+++ b/ui/src/components/dynamic-agents/AgentAvatar.tsx
@@ -12,6 +12,7 @@
  * 2. agent.gradient_theme + agent.custom_theme_config (legacy, no ui wrapper)
  */
 
+import { getDeterministicAgentThemeId } from "@/lib/agent-theme";
 import { getAccentColor,getGradientStyle } from "@/lib/gradient-themes";
 import { cn } from "@/lib/utils";
 import type { CustomThemeConfig } from "@/types/dynamic-agent";
@@ -20,6 +21,8 @@ import React from "react";
 
 /** Minimal shape the avatar needs — accepts full agent or any subset */
 export interface AgentAvatarAgent {
+  _id?: string;
+  id?: string;
   ui?: {
     gradient_theme?: string;
     custom_theme_config?: CustomThemeConfig;
@@ -33,6 +36,8 @@ export interface AgentAvatarAgent {
 export interface AgentAvatarProps {
   /** Agent object — component extracts theme from agent.ui (or legacy agent.gradient_theme) */
   agent?: AgentAvatarAgent | null;
+  /** Stable identity used for an agent-specific fallback when no theme is configured. */
+  agentId?: string | null;
   /** Override gradient theme (used when agent is null, e.g. editor live preview) */
   gradientTheme?: string | null;
   /** Override custom theme config (used when agent is null, e.g. editor live preview) */
@@ -57,6 +62,7 @@ export interface AgentAvatarProps {
 
 export function AgentAvatar({
   agent,
+  agentId,
   gradientTheme: gradientThemeOverride,
   customThemeConfig: customThemeConfigOverride,
   useGlobalTheme = false,
@@ -82,8 +88,12 @@ export function AgentAvatar({
   }
 
   // Resolve theme: explicit overrides > agent.ui > legacy top-level fields > null
-  const resolvedGradientTheme = gradientThemeOverride ?? agent?.ui?.gradient_theme ?? agent?.gradient_theme ?? null;
+  const explicitGradientTheme = gradientThemeOverride ?? agent?.ui?.gradient_theme ?? agent?.gradient_theme ?? null;
   const resolvedCustomThemeConfig = customThemeConfigOverride ?? agent?.ui?.custom_theme_config ?? agent?.custom_theme_config ?? null;
+  const identity = agentId ?? agent?._id ?? agent?.id ?? null;
+  const resolvedGradientTheme = explicitGradientTheme || (
+    !useGlobalTheme && identity ? getDeterministicAgentThemeId(identity) : null
+  );
 
   const gradientStyle = !useGlobalTheme && resolvedGradientTheme
     ? getGradientStyle(resolvedGradientTheme, resolvedCustomThemeConfig)
@@ -123,6 +133,7 @@ export function AgentAvatar({
         className,
       )}
       style={gradientStyle || undefined}
+      data-agent-theme={resolvedGradientTheme || "neutral"}
     >
       {renderedIcon}
     </div>

--- a/ui/src/components/dynamic-agents/__tests__/AgentAvatar.test.tsx
+++ b/ui/src/components/dynamic-agents/__tests__/AgentAvatar.test.tsx
@@ -1,0 +1,29 @@
+import { render } from "@testing-library/react";
+
+import { AgentAvatar } from "../AgentAvatar";
+
+describe("AgentAvatar", () => {
+  it("derives a stable fallback theme from the agent id", () => {
+    const { container, rerender } = render(
+      <AgentAvatar agent={{ _id: "agent-alpha" }} />,
+    );
+
+    expect(container.firstElementChild).toHaveAttribute("data-agent-theme", "sunset");
+
+    rerender(<AgentAvatar agent={{ _id: "agent-beta" }} />);
+    expect(container.firstElementChild).toHaveAttribute("data-agent-theme", "default");
+  });
+
+  it("preserves an explicitly selected theme", () => {
+    const { container } = render(
+      <AgentAvatar
+        agent={{
+          _id: "agent-alpha",
+          ui: { gradient_theme: "ocean" },
+        }}
+      />,
+    );
+
+    expect(container.firstElementChild).toHaveAttribute("data-agent-theme", "ocean");
+  });
+});

--- a/ui/src/lib/__tests__/agent-theme.test.ts
+++ b/ui/src/lib/__tests__/agent-theme.test.ts
@@ -1,0 +1,19 @@
+import { getDeterministicAgentThemeId } from "../agent-theme";
+
+describe("getDeterministicAgentThemeId", () => {
+  it("returns the same theme for the same agent", () => {
+    expect(getDeterministicAgentThemeId("agent-alpha")).toBe(
+      getDeterministicAgentThemeId("agent-alpha"),
+    );
+  });
+
+  it("provides varied themes for different agents", () => {
+    const themes = new Set([
+      getDeterministicAgentThemeId("agent-alpha"),
+      getDeterministicAgentThemeId("agent-beta"),
+      getDeterministicAgentThemeId("agent-gamma"),
+    ]);
+
+    expect(themes.size).toBe(3);
+  });
+});

--- a/ui/src/lib/agent-theme.ts
+++ b/ui/src/lib/agent-theme.ts
@@ -1,0 +1,29 @@
+import type { GradientThemeId } from "@/lib/gradient-themes";
+
+/**
+ * Pick a stable avatar theme for agents without an explicit theme.
+ * The palette is limited to themes available in the UI.
+ */
+const AGENT_THEME_PALETTE: readonly GradientThemeId[] = [
+  "ocean",
+  "sunset",
+  "forest",
+  "lavender",
+  "ember",
+  "professional",
+  "cyberpunk",
+  "tron",
+  "matrix",
+  "default",
+];
+
+export function getDeterministicAgentThemeId(agentId: string): GradientThemeId {
+  let hash = 0x811c9dc5;
+
+  for (let index = 0; index < agentId.length; index += 1) {
+    hash ^= agentId.charCodeAt(index);
+    hash = Math.imul(hash, 0x01000193);
+  }
+
+  return AGENT_THEME_PALETTE[(hash >>> 0) % AGENT_THEME_PALETTE.length];
+}


### PR DESCRIPTION
# Description

Extract the agent avatar color behavior from [PR #2401](https://github.com/caipe-io/ai-platform-engineering/pull/2401) into a focused UI change. Chat welcome and message avatars now retain an explicitly selected agent theme and derive a stable, agent-specific fallback theme when no theme is configured.

This PR intentionally excludes Harness Engine badges, agent picker changes, chat title updates, and gateway/runtime work from #2401.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation

## Validation

- Targeted Jest: 2 suites, 4 tests passed
- Targeted ESLint: passed
- `npm run lint`: passed
- `git diff --check`: passed
- `npx tsc --noEmit`: existing workspace errors remain in generated route validators and missing `@dnd-kit` modules; no errors in changed files

## Checklist

- [x] I have read the contributing guidelines
- [x] Existing PR context referenced (#2401)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All applicable tests pass
