### PR TITLE
Unarchive identity-group-sync teams when their group regains membership

### DIFF
--- a/ui/src/lib/rbac/__tests__/identity-group-sync/sync-planner.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/sync-planner.test.ts
@@ -102,6 +102,53 @@ describe("identity group sync dry-run planner", () => {
     expect(result.teams_to_create).toEqual([]);
   });
 
+  it("flags an archived team for unarchive when its Okta group regains an active managed member", async () => {
+    const result = await planIdentityGroupSync({
+      groups: [group],
+      rules: [rule],
+      existingTeams: [{ id: "platform-id", slug: "platform", name: "Platform", status: "archived" }],
+      existingMembershipSources: [],
+      now: "2026-05-12T01:00:00.000Z",
+      actor: "admin@example.test",
+    });
+
+    expect(result.teams_to_unarchive).toEqual(["platform"]);
+    expect(result.membership_sources_to_add).toEqual(
+      expect.arrayContaining([expect.objectContaining({ team_slug: "platform", user_subject: "bob-sub" })])
+    );
+  });
+
+  it("does not flag an already-active team for unarchive", async () => {
+    const result = await planIdentityGroupSync({
+      groups: [group],
+      rules: [rule],
+      existingTeams: [{ id: "platform-id", slug: "platform", name: "Platform", status: "active" }],
+      existingMembershipSources: [],
+      now: "2026-05-12T01:00:00.000Z",
+      actor: "admin@example.test",
+    });
+
+    expect(result.teams_to_unarchive).toEqual([]);
+  });
+
+  it("does not flag an archived team for unarchive when its group has no active matched members", async () => {
+    const inactiveGroup = {
+      ...group,
+      members: [{ email: "inactive@example.test", display_name: "Inactive User", active: false }],
+    };
+
+    const result = await planIdentityGroupSync({
+      groups: [inactiveGroup],
+      rules: [rule],
+      existingTeams: [{ id: "platform-id", slug: "platform", name: "Platform", status: "archived" }],
+      existingMembershipSources: [],
+      now: "2026-05-12T01:00:00.000Z",
+      actor: "admin@example.test",
+    });
+
+    expect(result.teams_to_unarchive).toEqual([]);
+  });
+
   it("stamps last_seen_at on membership_sources_to_refresh for unchanged active memberships", async () => {
     const existingSource: TeamMembershipSource = {
       team_id: "platform-id",

--- a/ui/src/lib/rbac/__tests__/identity-group-sync/sync-reconciler.test.ts
+++ b/ui/src/lib/rbac/__tests__/identity-group-sync/sync-reconciler.test.ts
@@ -105,6 +105,7 @@ describe("identity group sync apply reconciler", () => {
       tupleDeletes: 0,
       openFgaEnabled: true,
       teamsArchived: 0,
+      teamsUnarchived: 0,
     });
 
     expect(upsertTeamMembershipSource).toHaveBeenCalledTimes(1);
@@ -535,6 +536,107 @@ describe("identity group sync apply reconciler", () => {
     expect(result.teamsArchived).toBe(0);
     expect(teamsUpdateMany).not.toHaveBeenCalled();
     expect(stripArchivedTeamResourceGrants).not.toHaveBeenCalled();
+  });
+
+  describe("Phase 3a — unarchive teams that regained membership", () => {
+    it("unarchives identity_group_sync teams flagged in teams_to_unarchive", async () => {
+      teamsUpdateMany.mockResolvedValueOnce({ matchedCount: 1, modifiedCount: 1 });
+      const { applyIdentityGroupSyncPlan } = await import("../../identity-group-sync-reconciler");
+
+      const result = await applyIdentityGroupSyncPlan({
+        plan: {
+          matched_groups: [],
+          ignored_groups: [],
+          teams_to_create: [],
+          teams_to_unarchive: ["sg-cloud-o11y-ai-in-eng"],
+          membership_sources_to_add: [
+            {
+              team_id: "team-1",
+              team_slug: "sg-cloud-o11y-ai-in-eng",
+              user_subject: "bob-sub",
+              relationship: "member",
+              source_type: "okta",
+              managed: true,
+              status: "active",
+              created_at: "2026-08-31T00:00:00.000Z",
+            },
+          ],
+          membership_sources_to_remove: [],
+          tuple_writes: [{ user: "user:bob-sub", relation: "member", object: "team:sg-cloud-o11y-ai-in-eng" }],
+          tuple_deletes: [],
+          skipped_users: [],
+          conflicts: [],
+        },
+        actor: "admin@example.test",
+        now: "2026-08-31T01:00:00.000Z",
+      });
+
+      expect(result.teamsUnarchived).toBe(1);
+      expect(teamsUpdateMany).toHaveBeenCalledWith(
+        { slug: { $in: ["sg-cloud-o11y-ai-in-eng"] }, source: "identity_group_sync", status: "archived" },
+        expect.objectContaining({
+          $set: expect.objectContaining({ status: "active", updated_by: "admin@example.test" }),
+        }),
+      );
+      // Unarchiving never touches OpenFGA — no grant-strip counterpart to replay.
+      expect(stripArchivedTeamResourceGrants).not.toHaveBeenCalled();
+    });
+
+    it("does not call updateMany when teams_to_unarchive is empty or absent", async () => {
+      const { applyIdentityGroupSyncPlan } = await import("../../identity-group-sync-reconciler");
+
+      const result = await applyIdentityGroupSyncPlan({
+        plan: {
+          matched_groups: [],
+          ignored_groups: [],
+          teams_to_create: [],
+          membership_sources_to_add: [],
+          membership_sources_to_remove: [],
+          tuple_writes: [],
+          tuple_deletes: [],
+          skipped_users: [],
+          conflicts: [],
+        },
+        actor: "admin@example.test",
+        now: "2026-08-31T01:00:00.000Z",
+      });
+
+      expect(result.teamsUnarchived).toBe(0);
+      expect(teamsUpdateMany).not.toHaveBeenCalled();
+    });
+
+    it("swallows an unarchive failure and still resolves the overall call successfully", async () => {
+      const consoleErrSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+      try {
+        teamsUpdateMany.mockRejectedValueOnce(new Error("mongo unreachable"));
+        const { applyIdentityGroupSyncPlan } = await import("../../identity-group-sync-reconciler");
+
+        const result = await applyIdentityGroupSyncPlan({
+          plan: {
+            matched_groups: [],
+            ignored_groups: [],
+            teams_to_create: [],
+            teams_to_unarchive: ["sg-cloud-o11y-ai-in-eng"],
+            membership_sources_to_add: [],
+            membership_sources_to_remove: [],
+            tuple_writes: [],
+            tuple_deletes: [],
+            skipped_users: [],
+            conflicts: [],
+          },
+          actor: "admin@example.test",
+          now: "2026-08-31T01:00:00.000Z",
+        });
+
+        expect(result.teamsUnarchived).toBe(0);
+        expect(consoleErrSpy).toHaveBeenCalledWith(
+          expect.stringContaining("phase 3a team unarchival failed"),
+          expect.any(Error),
+        );
+      } finally {
+        consoleErrSpy.mockRestore();
+      }
+    });
   });
 
   describe("Phase 3 — orphan team archival + grant strip", () => {

--- a/ui/src/lib/rbac/archived-team-grants.ts
+++ b/ui/src/lib/rbac/archived-team-grants.ts
@@ -14,8 +14,13 @@
 //
 // What we KEEP: the membership roster itself — `user:<sub> member team:<slug>`
 // (the team is the OBJECT there, never the subject). Keeping the roster means
-// un-archiving a team can restore its grants by replaying resource
-// reconciliation, and the admin UI still shows who was on the team.
+// the admin UI still shows who was on the team, and identity-group-sync can
+// later flip `team.status` back to "active" if the group regains membership.
+// It does NOT mean grants are auto-restored on unarchive: resource-team
+// assignment is read live from OpenFGA with no other durable record (the
+// legacy `team.resources` Mongo array was intentionally dropped), so once
+// stripped here there is nothing to replay from — an admin must re-grant
+// resources via the Team Resources UI after unarchiving.
 //
 // Deletes go through `deleteExactOpenFgaTuples` with keys read straight from
 // the store. Userset tuples (`team:<slug>#member ...`) MUST be deleted this

--- a/ui/src/lib/rbac/identity-group-sync-planner.ts
+++ b/ui/src/lib/rbac/identity-group-sync-planner.ts
@@ -14,6 +14,7 @@ interface ExistingTeam {
   id: string;
   slug: string;
   name: string;
+  status?: string;
 }
 
 interface ExternalGroupMember {
@@ -223,6 +224,17 @@ export async function planIdentityGroupSync(
     }
   }
 
+  // A team can be archived (all managed memberships previously removed) and
+  // later regain an active managed member when its Okta group is unarchived
+  // or repopulated. Detect that here — before reconciliation — so it applies
+  // whether the member is brand new (`sourcesToAdd`) or already stored as
+  // active (defensive: an archived team should never retain active sources,
+  // but this keeps the check independent of that invariant holding).
+  const teamSlugsWithDesiredMembership = new Set(desiredSources.map((s) => s.team_slug));
+  const teams_to_unarchive = Array.from(existingTeamBySlug.values())
+    .filter((team) => team.status === "archived" && teamSlugsWithDesiredMembership.has(team.slug))
+    .map((team) => team.slug);
+
   const reconciliation = await reconcileTeamMembershipSources({
     existingSources: input.existingMembershipSources,
     desiredSources,
@@ -253,6 +265,7 @@ export async function planIdentityGroupSync(
     ignored_groups: ruleResult.ignored.map((ignored) => ignored.group),
     teams_to_create,
     teams_to_update,
+    teams_to_unarchive,
     membership_sources_to_add: reconciliation.sourcesToAdd,
     membership_sources_to_remove: reconciliation.sourcesToRemove,
     membership_sources_to_refresh,

--- a/ui/src/lib/rbac/identity-group-sync-reconciler.ts
+++ b/ui/src/lib/rbac/identity-group-sync-reconciler.ts
@@ -38,6 +38,7 @@ export interface ApplyIdentityGroupSyncPlanResult {
   tupleDeletes: number;
   openFgaEnabled: boolean;
   teamsArchived: number;
+  teamsUnarchived: number;
 }
 
 /**
@@ -129,7 +130,46 @@ export async function applyIdentityGroupSyncPlan(
       deletes: input.plan.tuple_deletes,
     });
 
-    // ── Phase 3: archive orphaned identity-sync teams ──────────────────────
+    // ── Phase 3a: unarchive teams whose Okta group regained membership ─────
+    // The planner flags a team in `teams_to_unarchive` when it's currently
+    // `status: "archived"` but this run adds/refreshes an active managed
+    // member for it. Flipping status back to "active" is what makes the team
+    // reappear in the admin teams list (`status: { $ne: "archived" }` filter)
+    // and the Slack channel-onboarding picker. Failures here are logged but
+    // never thrown — the membership reconcile already succeeded.
+    //
+    // NOTE: this does NOT restore resource grants (agent/tool/etc. access)
+    // that were stripped when the team was archived. Those grants are read
+    // live from OpenFGA with no other durable record of what they were
+    // (the legacy `team.resources` Mongo array was intentionally dropped —
+    // see api/admin/teams/[id]/resources/route.ts), so there is nothing to
+    // replay them from. An admin must re-assign resources via the Team
+    // Resources UI after an unarchive if the team previously had explicit
+    // grants.
+    let teamsUnarchived = 0;
+    if (input.plan.teams_to_unarchive && input.plan.teams_to_unarchive.length > 0) {
+      try {
+        teamsUnarchived = await unarchiveSyncTeams({
+          slugs: input.plan.teams_to_unarchive,
+          actor: input.actor,
+          now: input.now,
+        });
+        if (teamsUnarchived > 0) {
+          console.log(
+            `[identity-group-sync] unarchived ${teamsUnarchived} team(s) whose Okta group regained ` +
+              "active membership (resource grants, if any were stripped at archive time, are not " +
+              "automatically restored)",
+          );
+        }
+      } catch (unarchiveErr) {
+        console.error(
+          "[identity-group-sync] phase 3a team unarchival failed; teams may remain archived",
+          unarchiveErr,
+        );
+      }
+    }
+
+    // ── Phase 3b: archive orphaned identity-sync teams ──────────────────────
     // After memberships are removed, any identity_group_sync team that the
     // planner flagged as "orphaned_team_membership" (no remaining managed
     // memberships) gets archived. We only do this for teams the sync owns
@@ -152,10 +192,13 @@ export async function applyIdentityGroupSyncPlan(
         // Archiving the Mongo doc is cosmetic on its own — OpenFGA never
         // consults team.status. Strip the team's resource-grant tuples so an
         // archived team stops granting `team:<slug>#member can_use ...`. Only
-        // strips teams we actually archived this run; the roster is kept so
-        // un-archiving can replay grants. Best-effort: the membership reconcile
-        // already committed, and the self-check can repair any grant that
-        // survives here.
+        // strips teams we actually archived this run. The membership roster
+        // (`user:<sub> member team:<slug>`) is left intact, but the resource
+        // grants themselves have no other durable record (see phase 3a above)
+        // — re-granting them after an unarchive is a manual, admin-driven
+        // step, not something this sync replays automatically. Best-effort:
+        // the membership reconcile already committed, and the self-check can
+        // repair any grant that survives here.
         if (teamsArchived > 0) {
           const strip = await stripArchivedTeamResourceGrants(orphanedSlugs);
           if (strip.tuplesDeleted > 0) {
@@ -182,6 +225,7 @@ export async function applyIdentityGroupSyncPlan(
       tupleDeletes: openFgaResult.deletes,
       openFgaEnabled: openFgaResult.enabled,
       teamsArchived,
+      teamsUnarchived,
     };
   } catch (err) {
     // Best-effort rollback. The Mongo team docs and membership-source
@@ -352,6 +396,28 @@ async function rollbackPhase1(input: {
   for (const slug of input.createdTeamSlugs) {
     await teams.deleteOne({ slug });
   }
+}
+
+/**
+ * Unarchive identity_group_sync teams the planner flagged as having regained
+ * an active managed membership. Only touches teams with source
+ * "identity_group_sync" and currently `status: "archived"`, mirroring
+ * `archiveOrphanedSyncTeams` below. Returns the count of teams actually
+ * updated. Does not touch OpenFGA — see the phase 3a note above for why
+ * stripped resource grants aren't replayed here.
+ */
+async function unarchiveSyncTeams(input: {
+  slugs: string[];
+  actor: string;
+  now: string;
+}): Promise<number> {
+  if (input.slugs.length === 0) return 0;
+  const teams = await getCollection<IdentitySyncTeam & Record<string, unknown>>("teams");
+  const result = await teams.updateMany(
+    { slug: { $in: input.slugs }, source: "identity_group_sync", status: "archived" },
+    { $set: { status: "active", updated_by: input.actor, updated_at: new Date(input.now) } },
+  );
+  return result.modifiedCount;
 }
 
 /**

--- a/ui/src/lib/rbac/idp-sync-runner.ts
+++ b/ui/src/lib/rbac/idp-sync-runner.ts
@@ -36,6 +36,7 @@ interface TeamDocument {
   _id?: unknown;
   slug: string;
   name: string;
+  status?: string;
 }
 
 // Directory member as returned by a connector, before we resolve its subject.
@@ -61,13 +62,16 @@ function memberResolveConcurrency(): number {
 }
 
 
-async function listExistingTeams(): Promise<Array<{ id: string; slug: string; name: string }>> {
+async function listExistingTeams(): Promise<
+  Array<{ id: string; slug: string; name: string; status?: string }>
+> {
   const col = await getCollection<TeamDocument>("teams");
-  const teams = await col.find({}).project({ id: 1, slug: 1, name: 1 }).toArray();
+  const teams = await col.find({}).project({ id: 1, slug: 1, name: 1, status: 1 }).toArray();
   return teams.map((t) => ({
     id: t.id ?? String(t._id ?? t.slug),
     slug: t.slug,
     name: t.name,
+    status: t.status,
   }));
 }
 
@@ -414,7 +418,8 @@ export async function executeSyncRun(runId: string, provider: string, actor: str
     console.log(
       `[IdpSync] run ${runId} success: ${groups.length} groups, ` +
         `+${result.membershipSourcesAdded}/-${result.membershipSourcesRemoved} memberships, ` +
-        `${totalArchived} teams archived (${sweptArchived} from sweep)`
+        `${totalArchived} teams archived (${sweptArchived} from sweep), ` +
+        `${result.teamsUnarchived} team(s) unarchived`
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/ui/src/lib/rbac/oidc-claim-reconciler.ts
+++ b/ui/src/lib/rbac/oidc-claim-reconciler.ts
@@ -38,6 +38,7 @@ interface ExistingTeam {
   _id?: unknown;
   slug: string;
   name: string;
+  status?: string;
 }
 
 export interface ClaimGroupUser {
@@ -83,14 +84,17 @@ export function groupsToExternalGroupsForUser(input: {
   }));
 }
 
-async function listExistingTeams(): Promise<Array<{ id: string; slug: string; name: string }>> {
+async function listExistingTeams(): Promise<
+  Array<{ id: string; slug: string; name: string; status?: string }>
+> {
   const { getCollection } = await import("@/lib/mongodb");
   const collection = await getCollection<ExistingTeam>("teams");
-  const teams = await collection.find({}).project({ id: 1, slug: 1, name: 1 }).toArray();
+  const teams = await collection.find({}).project({ id: 1, slug: 1, name: 1, status: 1 }).toArray();
   return teams.map((team) => ({
     id: team.id ?? String(team._id ?? team.slug),
     slug: team.slug,
     name: team.name,
+    status: team.status,
   }));
 }
 

--- a/ui/src/types/identity-group-sync.ts
+++ b/ui/src/types/identity-group-sync.ts
@@ -129,6 +129,14 @@ export interface IdentityGroupSyncDryRunResult {
   ignored_groups: ExternalGroup[];
   teams_to_create: Array<{ slug: string; name: string; source_group_id: string }>;
   teams_to_update: Array<{ slug: string; name: string; source_group_id: string }>;
+  /**
+   * Slugs of existing identity_group_sync teams that are currently
+   * `status: "archived"` but regained at least one active managed
+   * membership in this sync — the reconciler flips these back to
+   * `status: "active"`. Optional so existing plan literals in tests
+   * don't need updating.
+   */
+  teams_to_unarchive?: string[];
   membership_sources_to_refresh: TeamMembershipSource[];
   membership_sources_to_add: TeamMembershipSource[];
   membership_sources_to_remove: TeamMembershipSource[];


### PR DESCRIPTION
## Summary

- Once a team backing an Okta/OIDC-synced group was archived (all managed memberships removed), `status: "archived"` was never cleared — even after the group regained active members and later syncs ran successfully. Since the admin teams listing filters out archived teams by default, the team stayed permanently hidden from the admin UI with no path back.
- The planner now flags a team for unarchive (`teams_to_unarchive`) when it is currently archived but this run produces at least one active managed membership for it. The reconciler flips `status` back to `"active"` for those teams.
- This does **not** restore OpenFGA resource grants stripped at archive time — resource-to-team assignment is read live from OpenFGA with no other durable record, so there is nothing to replay. Corrected two comments that inaccurately implied grants get replayed automatically on unarchive.

## Test plan

- [x] Added planner tests: flags an archived team for unarchive when its group regains an active managed member; does not flag an already-active team; does not flag an archived team when its group has no active matched members.
- [x] Added reconciler tests: unarchives teams flagged in `teams_to_unarchive`; does not call `updateMany` when the list is empty; swallows an unarchive failure without throwing.
- [x] `npx jest identity-group-sync oidc-claim-reconciler idp-sync-runner archived-team-grants` — 113/113 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx eslint` on touched files — clean.