### PR TITLE
feat(docs): polish homepage and feature navigation

### DIFF
--- a/docs/src/pages/features.module.css
+++ b/docs/src/pages/features.module.css
@@ -108,6 +108,7 @@
   background: var(--ifm-card-background-color, #fff);
   border: 1px solid var(--ifm-color-emphasis-200);
   border-radius: 14px;
+  height: 100%;
   overflow: hidden;
   transition: transform 0.15s, box-shadow 0.15s;
 }

--- a/docs/src/pages/features.tsx
+++ b/docs/src/pages/features.tsx
@@ -62,6 +62,7 @@ const FEATURES = [
     title: 'Multi-Agent Orchestration',
     icon: '🤖',
     color: '#0284c7',
+    to: '/docs/agents/',
     items: [
       'Multi-agent and deep agent interactions with access to multiple tools and sub-agents based on customizable system prompts',
       '10+ first-party curated sub-agents and MCP servers',
@@ -99,6 +100,7 @@ const FEATURES = [
     title: 'Agent Memory',
     icon: '💾',
     color: '#059669',
+    to: '/docs/api/chat-conversations',
     items: [
       'Chat persistence memory with multi-turn conversation',
       'Fact extraction across chats for a user',
@@ -108,6 +110,7 @@ const FEATURES = [
     title: 'Scheduled Runs & External Triggers',
     icon: '📡',
     color: '#d97706',
+    to: '/docs/architecture/autonomous-agents',
     items: [
       'Webhook-based agent triggers for event-driven workflows',
       'Scheduled/cron-based agent runs',
@@ -119,6 +122,7 @@ const FEATURES = [
     title: 'Agent and Tool Communications',
     icon: '🔗',
     color: '#d97706',
+    to: '/docs/api/dynamic-agents-mcp',
     items: [
       'MCP (Model Context Protocol)',
       'Dynamic Agents API',
@@ -130,6 +134,7 @@ const FEATURES = [
     title: 'Enterprise Security',
     icon: '🔒',
     color: '#dc2626',
+    to: '/docs/security/',
     items: [
       'OAuth 2.0 integration with OIDC compatible IdPs',
       'OIDC/Okta groups base RBAC',
@@ -141,6 +146,7 @@ const FEATURES = [
     title: 'Deployment',
     icon: '🚀',
     color: '#2563eb',
+    to: '/docs/installation/',
     items: [
       'Kubernetes based Helm charts',
       'Docker/Containerized Agents and MCP servers',
@@ -154,6 +160,7 @@ const FEATURES = [
     title: 'Integrations',
     icon: '🔌',
     color: '#0891b2',
+    to: '/docs/getting-started/user-interfaces',
     items: [
       'Web UI — rich chat interface with live agent/tool status via streaming',
       'Slack Bot — conversational interface for your team\'s existing workflow',

--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -93,9 +93,37 @@
 .heroSubtitle {
   font-size: 1.05rem;
   color: rgba(255, 255, 255, 0.72);
-  max-width: 560px;
+  max-width: none;
   margin: 0 auto 1rem;
   line-height: 1.65;
+  white-space: nowrap;
+}
+
+.typewriterAudience::after {
+  content: '';
+  display: inline-block;
+  margin-left: 0.04em;
+  width: 0.55em;
+  height: 1em;
+  vertical-align: -0.13em;
+  background: currentColor;
+  animation: typewriterCursor 1.2s steps(1, end) infinite;
+}
+
+.screenReaderOnly {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+@keyframes typewriterCursor {
+  50% { opacity: 0; }
 }
 
 .heroPronunciation {
@@ -254,6 +282,15 @@
   line-height: 1.65;
   margin: 0 auto;
   overflow-wrap: anywhere;
+}
+
+.features .sectionHeader {
+  max-width: 1100px;
+}
+
+.features .sectionSubtitle,
+.visionBody {
+  white-space: nowrap;
 }
 
 [data-theme='dark'] .sectionSubtitle {
@@ -616,7 +653,7 @@
 }
 
 .visionInner {
-  max-width: 760px;
+  max-width: 1200px;
   margin: 0 auto;
 }
 
@@ -691,7 +728,15 @@
   
   .heroButtons { justify-content: center; }
   .heroTitle { white-space: normal; }
-  .heroSubtitle { margin: 0 auto 1rem; }
+  .heroSubtitle { margin: 0 auto 1rem; white-space: normal; }
+  .features .sectionSubtitle,
+  .visionBody { white-space: normal; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .typewriterAudience::after {
+    animation: none;
+  }
 }
 
 @media (max-width: 640px) {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -88,12 +88,6 @@ const HOME_FEATURES = [
     to: '/features',
   },
   {
-    icon: '🎨',
-    title: 'Rich Web UI',
-    description: 'Streaming chat, Agent Builder, Skills Gateway, and admin controls.',
-    to: '/features',
-  },
-  {
     icon: '🧠',
     title: 'Knowledge Bases',
     description: 'Hybrid RAG and optional Graph RAG across web, AWS, Kubernetes, Jira, GitHub, Slack, and more.',
@@ -144,7 +138,7 @@ const HOME_FEATURES = [
   {
     icon: '💻',
     title: 'Multiple Clients',
-    description: 'Web UI, Chat CLI, Slack Bot, and Webex Bot.',
+    description: 'Rich Web UI for streaming chat, Agent Builder, Skills Gateway, and admin controls — plus Chat CLI, Slack, and Webex.',
     to: '/features',
   },
 ];
@@ -173,8 +167,50 @@ const USE_CASES = [
 const AGENTS = [
   'ArgoCD', 'PagerDuty', 'GitHub', 'GitLab', 'Jira', 'Confluence',
   'Kubernetes', 'Slack', 'Webex', 'Splunk', 'VictorOps', 'Komodor',
-  'Backstage', 'AWS', 'Weather',
+  'Backstage', 'AWS',
 ];
+
+const HERO_AUDIENCES = ['enterprises.', 'individuals.', 'you.', 'teams.'];
+
+function TypewriterAudience() {
+  const [audienceIndex, setAudienceIndex] = useState(0);
+  const [displayedAudience, setDisplayedAudience] = useState(HERO_AUDIENCES[0]);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const audience = HERO_AUDIENCES[audienceIndex];
+
+  useEffect(() => {
+    const isComplete = displayedAudience === audience;
+    const delay = isDeleting ? 45 : isComplete ? 3800 : 65;
+    const timer = window.setTimeout(() => {
+      if (isDeleting) {
+        setDisplayedAudience((current) => current.slice(0, -1));
+        if (displayedAudience.length === 1) {
+          setAudienceIndex((current) => (current + 1) % HERO_AUDIENCES.length);
+          setIsDeleting(false);
+        }
+        return;
+      }
+
+      if (isComplete) {
+        setIsDeleting(true);
+        return;
+      }
+
+      setDisplayedAudience(audience.slice(0, displayedAudience.length + 1));
+    }, delay);
+
+    return () => window.clearTimeout(timer);
+  }, [audience, displayedAudience, isDeleting]);
+
+  return (
+    <>
+      <span aria-hidden="true" className={styles.typewriterAudience}>
+        {displayedAudience}
+      </span>
+      <span className={styles.screenReaderOnly}>enterprises, individuals, you, and teams.</span>
+    </>
+  );
+}
 
 function HeroSection() {
   const [stars, setStars] = useState<string | null>(null);
@@ -200,14 +236,11 @@ function HeroSection() {
               <span className={styles.heroAccent}>All</span>
             </Heading>
             <p className={styles.heroSubtitle}>
-              <span className={styles.heroLine}>
-                Build, govern, and operate secure AI agents and agentic workflows
-              </span>{' '}
-              <span className={styles.heroLine}>for enterprises and individuals</span>
+              Build, govern, and operate secure AI agents and workflows for <TypewriterAudience />
             </p>
             <p className={styles.heroPronunciation}>
               <span className={styles.heroLine}>
-                💡 Pronounced like <strong>cape</strong> 🦸 — just as a cape empowers a superhero,
+                💡 Pronounced <strong>cape</strong> 🦸 — just as a cape empowers a superhero,
               </span>{' '}
               <span className={styles.heroLine}>
                 CAIPE empowers teams with 🤖 agentic AI automation.
@@ -260,8 +293,7 @@ function FeaturesSection() {
           Built for teams of all sizes
         </Heading>
         <p className={styles.sectionSubtitle}>
-          Everything you need to run agents in production, plus the controls to
-          let your whole team help themselves safely.
+          Everything you need to run agents in production, plus the controls to let your whole team help themselves safely.
         </p>
       </div>
       <div className={styles.featuresGrid}>
@@ -346,7 +378,7 @@ function QuickStartSection() {
   return (
     <section className={styles.quickstart}>
       <div className={styles.quickstartInner}>
-        <div className={styles.sectionHeader} style={{textAlign: 'left', marginBottom: '1.5rem'}}>
+        <div className={styles.sectionHeader} style={{marginBottom: '1.5rem'}}>
           <p className={styles.sectionLabel}>Quick Install</p>
           <Heading as="h2" className={styles.sectionTitle}>
             Up and running in minutes
@@ -422,7 +454,7 @@ function VideoSection() {
   return (
     <section className={styles.quickstart}>
       <div className={styles.quickstartInner}>
-        <div className={styles.sectionHeader} style={{textAlign: 'left', marginBottom: '1.5rem'}}>
+        <div className={styles.sectionHeader} style={{marginBottom: '1.5rem'}}>
           <p className={styles.sectionLabel}>See It In Action</p>
           <Heading as="h2" className={styles.sectionTitle}>
             Watch the demo


### PR DESCRIPTION
# Description

Improves the Docusaurus homepage with a rotating audience typewriter treatment, streamlined copy, centered section headings, and an updated feature-card layout. Makes every feature-page card link to relevant documentation and aligns cards within each grid row.

## Type of Change

- [ ] Bugfix
- [x] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [x] Documentation
- [ ] Other (please describe)

## Pre-release Helm Charts (Optional)

For chart changes, you can test pre-release versions before merging:
- **Base repo contributors:** Create a branch starting with `pre/` for automatic pre-release builds
- **Fork contributors:** Ask a maintainer to add the `helm-prerelease` label
- Pre-release charts are published to `ghcr.io/caipe-io/pre-release-helm-charts`
- Cleanup happens automatically when the PR closes or label is removed

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass