### PR TITLE
fix(docs): resolve versioned agent builder links

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -18,6 +18,9 @@ const versionsConfigPath = path.join(__dirname, 'versions-config.json');
 const versionsConfig: VersionsConfig | null = fs.existsSync(versionsConfigPath)
   ? (JSON.parse(fs.readFileSync(versionsConfigPath, 'utf8')) as VersionsConfig)
   : null;
+const currentDocsPrefix = versionsConfig?.versions.current.path
+  ? `/docs/${versionsConfig.versions.current.path}`
+  : '/docs';
 
 // Release notes are published once per minor series, under the series' `x.y.0` slug, and
 // cover everything since the previous minor. Every retired per-patch post and standalone
@@ -68,6 +71,9 @@ const config: Config = {
   // GitHub Pages serves the project from the custom domain root.
   url: 'https://caipe.io',
   baseUrl: '/',
+  customFields: {
+    currentDocsPrefix,
+  },
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
@@ -108,7 +114,7 @@ const config: Config = {
           // historically published docs links also omitted the /docs route.
           {from: '/getting-started/quick-start', to: '/docs/getting-started/quick-start'},
           {from: '/knowledge_bases/graph_rag', to: '/docs/knowledge_bases/'},
-          {from: '/docs/features/custom-agents', to: '/docs/features/agent-builder'},
+          {from: '/docs/features/custom-agents', to: `${currentDocsPrefix}/features/agent-builder`},
           // /docs/index has no real page; redirect to Quick Start
           {from: '/docs/index', to: '/docs/getting-started/quick-start'},
           ...releaseRedirects,

--- a/docs/src/pages/features.tsx
+++ b/docs/src/pages/features.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
+import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import Layout from '@theme/Layout';
 import Heading from '@theme/Heading';
 import styles from './features.module.css';
@@ -171,6 +172,9 @@ const FEATURES = [
 ];
 
 export default function FeaturesPage() {
+  const {siteConfig} = useDocusaurusContext();
+  const currentDocsPrefix = siteConfig.customFields?.currentDocsPrefix ?? '/docs';
+
   return (
     <Layout
       title="Features · CAIPE"
@@ -207,8 +211,11 @@ export default function FeaturesPage() {
         <section className={styles.grid}>
           <div className={styles.gridInner}>
             {FEATURES.map((f) => {
+              const target = f.title === 'Agent Builder'
+                ? `${currentDocsPrefix}/features/agent-builder`
+                : f.to;
               const card = (
-                <div key={f.title} className={styles.card} style={f.to ? {cursor: 'pointer'} : undefined}>
+                <div key={f.title} className={styles.card} style={target ? {cursor: 'pointer'} : undefined}>
                   <div className={styles.cardHeader} style={{'--card-color': f.color} as React.CSSProperties}>
                     <span className={styles.cardIcon}>{f.icon}</span>
                     <Heading as="h2" className={styles.cardTitle}>{f.title}</Heading>
@@ -220,8 +227,8 @@ export default function FeaturesPage() {
                   </ul>
                 </div>
               );
-              return f.to
-                ? <Link key={f.title} to={f.to} style={{textDecoration: 'none', color: 'inherit'}}>{card}</Link>
+              return target
+                ? <Link key={f.title} to={target} style={{textDecoration: 'none', color: 'inherit'}}>{card}</Link>
                 : card;
             })}
           </div>


### PR DESCRIPTION
## Description

Fixes the docs publish failure from [GitHub Actions run 34279272846](https://github.com/caipe-io/ai-platform-engineering/actions/runs/34279272846/job/102240963554). The build rejected the redirect to `/docs/features/agent-builder` because the generated versioned docs use different prefixes for the current docs and published snapshots.

The redirect and Features page Agent Builder card now derive the current docs prefix from `versions-config.json`, so the current site uses `/docs/next/features/agent-builder` while published docs retain `/docs/features/agent-builder`.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [x] All code style checks pass
- [ ] New code contribution is covered by automated tests
- [x] All new and existing tests pass

## Verification

- `npm --prefix docs run typecheck`
- `node docs/scripts/generate-versioned-docs.js`
- `NODE_OPTIONS=--max-old-space-size=8192 npm --prefix docs run build`

The build completes successfully with only pre-existing broken-anchor warnings.