### PR TITLE
fix(ui): restore legacy Agentic App URL compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.7"
+version = "1.0.1-dev.8"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/app/(app)/apps/embed/[appId]/[[...path]]/__tests__/page.test.tsx
+++ b/ui/src/app/(app)/apps/embed/[appId]/[[...path]]/__tests__/page.test.tsx
@@ -1,0 +1,62 @@
+import { redirect } from "next/navigation";
+
+import LegacyAgenticAppEmbedPage from "../page";
+
+jest.mock("next/navigation", () => ({
+  redirect: jest.fn(() => {
+    throw new Error("redirect");
+  }),
+}));
+
+const mockRedirect = redirect as unknown as jest.Mock;
+
+describe("LegacyAgenticAppEmbedPage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("redirects an old embed URL to the canonical app route", async () => {
+    await expect(
+      LegacyAgenticAppEmbedPage({
+        params: Promise.resolve({ appId: "kaleidoscope" }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow("redirect");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/apps/kaleidoscope");
+  });
+
+  it("preserves and encodes the app id and nested app path", async () => {
+    await expect(
+      LegacyAgenticAppEmbedPage({
+        params: Promise.resolve({
+          appId: "research / insights",
+          path: ["studies", "Q3/2026", "résumé 100%"],
+        }),
+        searchParams: Promise.resolve({}),
+      }),
+    ).rejects.toThrow("redirect");
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      "/apps/research%20%2F%20insights/studies/Q3%2F2026/r%C3%A9sum%C3%A9%20100%25",
+    );
+  });
+
+  it("preserves repeated, empty, and encoded query parameters", async () => {
+    await expect(
+      LegacyAgenticAppEmbedPage({
+        params: Promise.resolve({ appId: "weather", path: ["forecast"] }),
+        searchParams: Promise.resolve({
+          returnTo: "/studies/a b?mode=edit",
+          filter: ["new/open", "high priority"],
+          empty: "",
+          ignored: undefined,
+        }),
+      }),
+    ).rejects.toThrow("redirect");
+
+    expect(mockRedirect).toHaveBeenCalledWith(
+      "/apps/weather/forecast?returnTo=%2Fstudies%2Fa+b%3Fmode%3Dedit&filter=new%2Fopen&filter=high+priority&empty=",
+    );
+  });
+});

--- a/ui/src/app/(app)/apps/embed/[appId]/[[...path]]/page.tsx
+++ b/ui/src/app/(app)/apps/embed/[appId]/[[...path]]/page.tsx
@@ -1,0 +1,38 @@
+import { redirect } from "next/navigation";
+
+type LegacyEmbedPageProps = {
+  params: Promise<{ appId: string; path?: string[] }>;
+  searchParams: Promise<Record<string, string | string[] | undefined>>;
+};
+
+/**
+ * Preserve links created before hosted Agentic Apps moved to `/apps/<id>`.
+ *
+ * The canonical route owns authentication and app access checks. This route
+ * only translates the legacy URL shape, so an old link cannot bypass those
+ * controls.
+ */
+export default async function LegacyAgenticAppEmbedPage({
+  params,
+  searchParams,
+}: LegacyEmbedPageProps): Promise<never> {
+  const [{ appId, path = [] }, query] = await Promise.all([
+    params,
+    searchParams,
+  ]);
+  const targetPath = `/apps/${[appId, ...path]
+    .map((segment) => encodeURIComponent(segment))
+    .join("/")}`;
+  const targetQuery = new URLSearchParams();
+
+  for (const [key, value] of Object.entries(query)) {
+    if (Array.isArray(value)) {
+      value.forEach((item) => targetQuery.append(key, item));
+    } else if (value !== undefined) {
+      targetQuery.set(key, value);
+    }
+  }
+
+  const queryString = targetQuery.toString();
+  redirect(queryString ? `${targetPath}?${queryString}` : targetPath);
+}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev7"
+version = "1.0.1.dev8"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Hosted Agentic Apps now use `/apps/<app-id>` as their canonical UI route, but bookmarks and integrations may still point at the former `/apps/embed/<app-id>` shape. Today those requests fall into the canonical catch-all route with `embed` interpreted as the app ID and return a 404.

This change adds a compatibility-only page that redirects the complete legacy route to its canonical equivalent:

- `/apps/embed/kaleidoscope` becomes `/apps/kaleidoscope`
- `/apps/embed/kaleidoscope/studies/123?tab=results` becomes `/apps/kaleidoscope/studies/123?tab=results`
- decoded app IDs and nested path segments are encoded independently, so reserved characters cannot turn one segment into another
- single, repeated, and empty query parameters are retained; undefined parameters are omitted

The redirect does not make an authorization decision. The existing canonical page continues to apply its `AuthGuard`, and calls to the existing runtime proxy continue to use the established Agentic App authorization checks. Keeping the compatibility shim limited to URL translation avoids changing authentication behavior for unrelated application pages.

This draft supersedes #2654. That PR contains the same basic compatibility goal but is now conflicted with `main`, does not carry a nested legacy app path forward, and combines the redirect with a separate global application-layout authentication change. This PR is rebased on current `main` and deliberately excludes that unrelated gate.

## Verification

- `npm test -- --runTestsByPath 'src/app/(app)/apps/embed/[appId]/[[...path]]/__tests__/page.test.tsx' 'src/app/api/agentic-apps/runtime/[appId]/[[...path]]/route.test.ts' 'src/lib/agentic-apps/__tests__/config.test.ts' 'src/lib/agentic-apps/__tests__/security.test.ts' --runInBand` — 24 tests passed
- `npx eslint 'src/app/(app)/apps/embed/[appId]/[[...path]]/page.tsx' 'src/app/(app)/apps/embed/[appId]/[[...path]]/__tests__/page.test.tsx'` — passed
- `npm run build` — passed, including route-tree generation and TypeScript validation

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

No chart changes.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [ ] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests — this intentionally supersedes #2654
- [x] Functionality is documented
- [x] New selection controls follow the [selection-control decision table](https://github.com/caipe-io/ai-platform-engineering/blob/main/docs/docs/ui/selection-controls.md), or the custom interaction is justified — not applicable; no selection control changes
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [ ] All new and existing tests pass — focused new/existing tests and the production UI build pass; the full suite is delegated to CI
