### PR TITLE
fix(dynamic-agents): support structured response middleware

### DIFF
--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/routes/chat.py
@@ -224,6 +224,13 @@ async def _collect_invoke_response(
     ):
         pass
 
+    get_structured_response = getattr(runtime, "get_structured_response", None)
+    get_structured_response_schema_id = getattr(runtime, "get_structured_response_schema_id", None)
+    structured_output = get_structured_response() if callable(get_structured_response) else None
+    structured_output_schema_id = (
+        get_structured_response_schema_id() if callable(get_structured_response_schema_id) else None
+    )
+
     interrupt = await runtime.has_pending_interrupt(request.conversation_id)
     if interrupt:
         return JSONResponse(
@@ -246,6 +253,8 @@ async def _collect_invoke_response(
         "success": True,
         "content": encoder.get_accumulated_content(),
         "thinking": encoder.get_thinking_content() or None,
+        "structured_output": structured_output,
+        "structured_output_schema_id": structured_output_schema_id,
         "agent_id": agent.id,
         "conversation_id": request.conversation_id,
         "trace_id": request.trace_id,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/agent_runtime.py
@@ -89,6 +89,12 @@ from dynamic_agents.services.model_capabilities import (
     get_model_capabilities,
 )
 from dynamic_agents.services.skills import build_skills_files, detect_missing_skills, load_skills
+from dynamic_agents.services.structured_response import (
+    StructuredResponseFormat,
+    build_structured_response_instruction,
+    create_submit_structured_response_tool,
+    extract_response_format,
+)
 
 if TYPE_CHECKING:
     from dynamic_agents.services.mongo import MongoDBService
@@ -707,6 +713,8 @@ class AgentRuntime:
         self._failed_skills_error: str = ""  # Error message for display
         self._failed_workflows: list[str] = []  # Workflow config IDs not found
         self._failed_workflows_error: str = ""  # Error message for display
+        self._structured_response: dict[str, Any] | None = None
+        self._structured_response_schema_id: str | None = None
         self._mcp_credential_warnings: list[str] = []
         self._mcp_credential_failed_server_ids: set[str] = set()
         self._valid_workflow_configs: list[str] = []  # Validated workflow config IDs
@@ -976,6 +984,10 @@ class AgentRuntime:
             logger.error(f"Agent '{self.config.name}' failed to initialize: {exc}")
             raise RuntimeError(f"Agent '{self.config.name}' failed to initialize: {exc}") from exc
 
+        response_format = self._get_allowed_structured_response_format(client_ctx)
+        if response_format:
+            system_prompt += build_structured_response_instruction(response_format)
+
         # 5. Instantiate LLM
         logger.info(
             f"[llm] Instantiating LLM for agent '{self.config.name}': "
@@ -1235,6 +1247,50 @@ class AgentRuntime:
             f"tools={len(tools)}, subagents={len(subagents) if subagents else 0}"
         )
 
+    def _capture_structured_response(
+        self, payload: dict[str, Any], schema_id: str | None
+    ) -> None:
+        """Capture the latest validated structured response submitted by the agent."""
+        self._structured_response = payload
+        self._structured_response_schema_id = schema_id
+
+    def get_structured_response(self) -> dict[str, Any] | None:
+        """Return the latest validated structured response for this runtime turn."""
+        return self._structured_response
+
+    def get_structured_response_schema_id(self) -> str | None:
+        """Return the schema ID for the captured structured response."""
+        return self._structured_response_schema_id
+
+    def _get_allowed_structured_response_format(
+        self, client_context: dict | None
+    ) -> StructuredResponseFormat | None:
+        """Return requested structured output only when the agent allows it."""
+        response_format = extract_response_format(client_context)
+        if response_format is None or self.config.features is None:
+            return None
+
+        for entry in self.config.features.middleware:
+            if entry.type != "structured_response" or not entry.enabled:
+                continue
+
+            allowed_schema_ids = str(entry.params.get("allowed_schema_ids", "")).strip()
+            if not allowed_schema_ids:
+                return response_format
+
+            allowed = {item.strip() for item in allowed_schema_ids.split(",") if item.strip()}
+            if response_format.schema_id in allowed:
+                return response_format
+
+            logger.warning(
+                "Agent '%s': structured response schema '%s' not allowed",
+                self.config.name,
+                response_format.schema_id,
+            )
+            return None
+
+        return None
+
     def _build_builtin_tools(
         self,
         user: UserContext | None = None,
@@ -1256,7 +1312,25 @@ class AgentRuntime:
         tools = []
         config_summary: dict[str, Any] = {}
 
+        response_format = self._get_allowed_structured_response_format(client_context)
+        is_parent_agent = agent_config is None or config.id == self.config.id
+        if response_format and is_parent_agent:
+            tools.append(
+                create_submit_structured_response_tool(
+                    response_format=response_format,
+                    on_submit=lambda payload: self._capture_structured_response(
+                        payload,
+                        response_format.schema_id,
+                    ),
+                )
+            )
+            config_summary["submit_structured_response"] = {
+                "schema_id": response_format.schema_id
+            }
+
         if not config.builtin_tools:
+            if tools:
+                logger.info(f"Agent '{config.name}': added built-in tools: {config_summary}")
             return tools
 
         # fetch_url tool (disabled by default)
@@ -1759,6 +1833,8 @@ class AgentRuntime:
         assert encoder is not None, "encoder must be provided"
 
         self._cancelled = False
+        self._structured_response = None
+        self._structured_response_schema_id = None
 
         config = self._build_stream_config(session_id, user_id, trace_id)
         run_id = f"run-{uuid4().hex[:12]}"
@@ -1887,6 +1963,16 @@ class AgentRuntime:
             for frame in self._emit_interrupt(encoder, interrupt_data):
                 yield frame
             return
+
+        structured_response = self.get_structured_response()
+        if structured_response is not None:
+            on_structured_output = getattr(encoder, "on_structured_output", None)
+            if callable(on_structured_output):
+                for frame in on_structured_output(
+                    structured_response,
+                    self.get_structured_response_schema_id(),
+                ):
+                    yield frame
 
         # ── Core lifecycle: run finish ──
         logger.info(
@@ -2169,6 +2255,8 @@ class AgentRuntime:
         assert encoder is not None, "encoder must be provided"
 
         self._cancelled = False
+        self._structured_response = None
+        self._structured_response_schema_id = None
 
         config = self._build_stream_config(session_id, user_id, trace_id)
         run_id = f"run-{uuid4().hex[:12]}"
@@ -2218,6 +2306,16 @@ class AgentRuntime:
             for frame in self._emit_interrupt(encoder, interrupt_data):
                 yield frame
             return
+
+        structured_response = self.get_structured_response()
+        if structured_response is not None:
+            on_structured_output = getattr(encoder, "on_structured_output", None)
+            if callable(on_structured_output):
+                for frame in on_structured_output(
+                    structured_response,
+                    self.get_structured_response_schema_id(),
+                ):
+                    yield frame
 
         # ── Core lifecycle: run finish ──
         logger.info(

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/middleware.py
@@ -409,6 +409,18 @@ MIDDLEWARE_REGISTRY: dict[str, MiddlewareSpec] = {
             "exit_behavior": "end|error|continue",
         },
     ),
+    "structured_response": MiddlewareSpec(
+        cls=object,
+        default_params={"allowed_schema_ids": "", "require_tool_submission": True},
+        enabled_by_default=False,
+        allow_multiple=False,
+        label="Structured Response",
+        description="Allows app clients to request validated structured JSON output",
+        param_schema={
+            "allowed_schema_ids": "string",
+            "require_tool_submission": "boolean",
+        },
+    ),
     "tool_call_limit": MiddlewareSpec(
         cls=ToolCallLimitMiddleware,
         default_params={"run_limit": 500, "exit_behavior": "continue"},
@@ -554,8 +566,18 @@ def _build_model_fallback(params: dict[str, Any]) -> ModelFallbackMiddleware | N
     return ModelFallbackMiddleware(fallback_model)
 
 
+def _build_structured_response(_params: dict[str, Any]) -> None:
+    """Structured response is handled by AgentRuntime tool injection.
+
+    The registry entry exists so the UI can configure the capability per
+    agent. It does not add a LangChain middleware object to the stack.
+    """
+    return None
+
+
 # Keys that need special construction instead of simple cls(**params)
 _SPECIAL_BUILDERS: dict[str, Callable[..., Any]] = {
+    "structured_response": _build_structured_response,
     "context_editing": _build_context_editing,
     "pii": _build_pii,
     "llm_tool_selector": _build_llm_tool_selector,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/custom_sse.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/stream_encoders/custom_sse.py
@@ -102,6 +102,20 @@ class CustomStreamEncoder(StreamEncoder):
     def on_warning(self, message: str) -> list[str]:
         return [_sse_frame("warning", {"message": message, "namespace": []})]
 
+    def on_structured_output(
+        self, payload: dict[str, Any], schema_id: str | None = None
+    ) -> list[str]:
+        """Emit app-requested structured output before the terminal done event."""
+        return [
+            _sse_frame(
+                "structured_output",
+                {
+                    "payload": payload,
+                    "schema_id": schema_id,
+                },
+            )
+        ]
+
     def on_input_required(
         self,
         interrupt_id: str,

--- a/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/structured_response.py
+++ b/ai_platform_engineering/dynamic_agents/src/dynamic_agents/services/structured_response.py
@@ -1,0 +1,122 @@
+"""Structured response support for app-driven agent invocations."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from langchain_core.tools import tool
+
+_JSON_TYPE_NAMES = {
+    "object": dict,
+    "array": list,
+    "string": str,
+    "number": (int, float),
+    "integer": int,
+    "boolean": bool,
+}
+
+
+@dataclass(frozen=True)
+class StructuredResponseFormat:
+    """Normalized structured response request from client context."""
+
+    schema_id: str | None
+    schema: dict[str, Any]
+
+    @property
+    def required(self) -> list[str]:
+        required = self.schema.get("required")
+        return [str(field) for field in required] if isinstance(required, list) else []
+
+
+def extract_response_format(client_context: dict[str, Any] | None) -> StructuredResponseFormat | None:
+    """Return a normalized structured response format from client context."""
+    if not client_context:
+        return None
+
+    raw = client_context.get("response_format")
+    if not isinstance(raw, dict) or raw.get("type") != "json_schema":
+        return None
+
+    schema = raw.get("schema")
+    if not isinstance(schema, dict) or schema.get("type") not in (None, "object"):
+        return None
+
+    schema_id = raw.get("schema_id")
+    return StructuredResponseFormat(
+        schema_id=str(schema_id) if schema_id else None,
+        schema=schema,
+    )
+
+
+def _validate_payload(payload: Any, response_format: StructuredResponseFormat) -> str | None:
+    if not isinstance(payload, dict):
+        return "structured response payload must be a JSON object"
+
+    for field in response_format.required:
+        if field not in payload:
+            return f"structured response payload is missing required field '{field}'"
+
+    properties = response_format.schema.get("properties")
+    if not isinstance(properties, dict):
+        return None
+
+    for field, rules in properties.items():
+        if field not in payload or payload[field] is None or not isinstance(rules, dict):
+            continue
+        expected_type = rules.get("type")
+        expected_python_type = _JSON_TYPE_NAMES.get(expected_type)
+        if expected_python_type is None:
+            continue
+        value = payload[field]
+        if expected_type == "number" and isinstance(value, bool):
+            return f"structured response field '{field}' must be a number"
+        if expected_type == "integer" and isinstance(value, bool):
+            return f"structured response field '{field}' must be an integer"
+        if not isinstance(value, expected_python_type):
+            return f"structured response field '{field}' must be a {expected_type}"
+
+    return None
+
+
+def create_submit_structured_response_tool(
+    response_format: StructuredResponseFormat,
+    on_submit: Callable[[dict[str, Any]], None],
+):
+    """Create a final-answer tool that captures validated structured output."""
+
+    @tool
+    def submit_structured_response(payload: dict[str, Any], thought: str = "") -> dict[str, Any]:
+        """Submit the final structured response for the calling app UI.
+
+        The payload must be a JSON object matching the requested response schema.
+        """
+        error = _validate_payload(payload, response_format)
+        if error:
+            return {
+                "accepted": False,
+                "schema_id": response_format.schema_id,
+                "error": error,
+            }
+
+        on_submit(payload)
+        return {
+            "accepted": True,
+            "schema_id": response_format.schema_id,
+        }
+
+    return submit_structured_response
+
+
+def build_structured_response_instruction(response_format: StructuredResponseFormat) -> str:
+    """Build concise system instructions for the structured-response tool."""
+    schema_id = response_format.schema_id or "client-provided-schema"
+    return (
+        "\n\nStructured response requirement:\n"
+        f"- The client requested schema `{schema_id}`.\n"
+        "- Before your final prose response, call `submit_structured_response` exactly once.\n"
+        "- The `payload` argument must be a JSON object that satisfies this schema:\n"
+        f"{response_format.schema}\n"
+        "- Do not invent values. Use null or an empty list only when data is unavailable."
+    )

--- a/ai_platform_engineering/dynamic_agents/tests/test_structured_response.py
+++ b/ai_platform_engineering/dynamic_agents/tests/test_structured_response.py
@@ -1,0 +1,69 @@
+"""Tests for app-requested structured dashboard responses."""
+
+from __future__ import annotations
+
+import json
+
+from dynamic_agents.services.middleware import get_middleware_definitions
+from dynamic_agents.services.stream_encoders.custom_sse import CustomStreamEncoder
+from dynamic_agents.services.structured_response import (
+    StructuredResponseFormat,
+    create_submit_structured_response_tool,
+    extract_response_format,
+)
+
+
+def _response_format() -> StructuredResponseFormat:
+    return StructuredResponseFormat(
+        schema_id="jira_project.dashboard.v1",
+        schema={
+            "type": "object",
+            "required": ["summary"],
+            "properties": {"summary": {"type": "string"}},
+        },
+    )
+
+
+def test_structured_response_format_is_extracted_from_client_context() -> None:
+    response_format = extract_response_format(
+        {
+            "response_format": {
+                "type": "json_schema",
+                "schema_id": "jira_project.dashboard.v1",
+                "schema": {"type": "object", "required": ["summary"]},
+            }
+        }
+    )
+
+    assert response_format is not None
+    assert response_format.schema_id == "jira_project.dashboard.v1"
+    assert response_format.required == ["summary"]
+
+
+def test_submit_structured_response_validates_and_captures_payload() -> None:
+    captured: list[dict] = []
+    submit = create_submit_structured_response_tool(_response_format(), captured.append)
+
+    accepted = submit.invoke({"payload": {"summary": "Healthy"}})
+    rejected = submit.invoke({"payload": {"summary": 42}})
+
+    assert accepted["accepted"] is True
+    assert accepted["schema_id"] == "jira_project.dashboard.v1"
+    assert captured == [{"summary": "Healthy"}]
+    assert rejected["accepted"] is False
+    assert "must be a string" in rejected["error"]
+
+
+def test_structured_response_is_registered_and_emitted_as_sse() -> None:
+    definitions = {item["key"]: item for item in get_middleware_definitions()}
+    assert definitions["structured_response"]["enabled_by_default"] is False
+    assert definitions["structured_response"]["param_schema"]["allowed_schema_ids"] == "string"
+
+    frame = CustomStreamEncoder().on_structured_output(
+        {"summary": "Healthy"}, "jira_project.dashboard.v1"
+    )[0]
+    payload = json.loads(next(line[6:] for line in frame.splitlines() if line.startswith("data: ")))
+    assert payload == {
+        "payload": {"summary": "Healthy"},
+        "schema_id": "jira_project.dashboard.v1",
+    }


### PR DESCRIPTION
## Summary

- add structured-response middleware for dynamic agents
- normalize structured output for runtime and custom SSE streaming
- add focused regression coverage

This ports the change from [cisco-eti/ai-platform-engineering-mirror#645](https://github.com/cisco-eti/ai-platform-engineering-mirror/pull/645).

## Testing

- `uv run ruff check` on all changed Python files
- `uv run pytest -q tests/test_structured_response.py` (3 passed)