### PR TITLE
fix(rag): surface webpage ingestion failures instead of 500s or silence

### DIFF
--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
@@ -161,12 +161,6 @@ class WorkerSpider(Spider):
         Meta dict for Request objects
     """
     meta = dict(extra_meta)
-    # Without this, Scrapy's HttpErrorMiddleware silently drops any non-2xx
-    # response (e.g. 401/403 from an auth-walled page) before it reaches
-    # parse_page/handle_error, so the failure never gets recorded in
-    # self.errors and the caller sees only a generic "No pages were
-    # crawled." instead of the real reason.
-    meta["handle_httpstatus_all"] = True
 
     if self.crawl_request.render_javascript:
       from scrapy_playwright.page import PageMethod
@@ -585,10 +579,7 @@ class WorkerSpider(Spider):
 
     # Handle non-200 responses
     if response.status != 200:
-      if response.status in (401, 403):
-        error_msg = f"HTTP {response.status} (page requires authentication): {response.url}"
-      else:
-        error_msg = f"HTTP {response.status}: {response.url}"
+      error_msg = f"Ignoring non-200 response ({response.status}): {response.url}"
       self._log(logging.WARNING, error_msg)
       self.pages_failed += 1
       if len(self.errors) < self.max_errors:

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
@@ -161,6 +161,12 @@ class WorkerSpider(Spider):
         Meta dict for Request objects
     """
     meta = dict(extra_meta)
+    # Without this, Scrapy's HttpErrorMiddleware silently drops any non-2xx
+    # response (e.g. 401/403 from an auth-walled page) before it reaches
+    # parse_page/handle_error, so the failure never gets recorded in
+    # self.errors and the caller sees only a generic "No pages were
+    # crawled." instead of the real reason.
+    meta["handle_httpstatus_all"] = True
 
     if self.crawl_request.render_javascript:
       from scrapy_playwright.page import PageMethod
@@ -579,7 +585,10 @@ class WorkerSpider(Spider):
 
     # Handle non-200 responses
     if response.status != 200:
-      error_msg = f"Ignoring non-200 response ({response.status}): {response.url}"
+      if response.status in (401, 403):
+        error_msg = f"HTTP {response.status} (page requires authentication): {response.url}"
+      else:
+        error_msg = f"HTTP {response.status}: {response.url}"
       self._log(logging.WARNING, error_msg)
       self.pages_failed += 1
       if len(self.errors) < self.max_errors:

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
@@ -105,6 +105,11 @@ class WorkerSpider(Spider):
     # Tracking
     self.pages_crawled = 0
     self.pages_failed = 0
+    # Pages that loaded (HTTP 200) but had no extractable content. A login
+    # wall commonly redirects to a 200 sign-in page rather than a 401/403,
+    # so this is the only signal available to tell that failure mode apart
+    # from a page that is genuinely empty.
+    self.pages_fetched_no_content = 0
     self.documents: List[dict] = []
     self.visited_urls: set = set()
     self.start_time = time.time()
@@ -628,6 +633,7 @@ class WorkerSpider(Spider):
       else:
         # Skip pages with no meaningful content (redirects, images, etc.)
         # This is not an error, just nothing to extract
+        self.pages_fetched_no_content += 1
         self._log(logging.DEBUG, f"Skipped page with no content: {response.url}")
 
     except Exception as e:
@@ -926,6 +932,19 @@ class WorkerSpider(Spider):
           parts.append(f"Sitemaps checked: {', '.join(self.sitemap_urls_checked)}.")
         if self.robots_urls_checked:
           parts.append(f"robots.txt checked: {', '.join(self.robots_urls_checked)}.")
+      elif self.pages_failed == 0 and self.pages_fetched_no_content > 0:
+        # Every request returned 200, so nothing tripped the non-200 error
+        # path above, yet no content could be extracted. A login wall
+        # commonly redirects an unauthenticated request to a 200 sign-in
+        # page rather than a 401/403, so say so instead of implying the
+        # page was simply empty.
+        parts.append(
+          f"{self.pages_fetched_no_content} page(s) loaded successfully but had "
+          "no extractable content. If this site requires signing in, an "
+          "unauthenticated request commonly lands on a login page instead of "
+          "returning an error - confirm the URL is reachable without "
+          "authentication."
+        )
       else:
         parts.append("No pages were crawled.")
 

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/src/ingestors/webloader/loader/scrapy_worker.py
@@ -932,24 +932,27 @@ class WorkerSpider(Spider):
           parts.append(f"Sitemaps checked: {', '.join(self.sitemap_urls_checked)}.")
         if self.robots_urls_checked:
           parts.append(f"robots.txt checked: {', '.join(self.robots_urls_checked)}.")
-      elif self.pages_failed == 0 and self.pages_fetched_no_content > 0:
-        # Every request returned 200, so nothing tripped the non-200 error
-        # path above, yet no content could be extracted. A login wall
-        # commonly redirects an unauthenticated request to a 200 sign-in
-        # page rather than a 401/403, so say so instead of implying the
-        # page was simply empty.
-        parts.append(
-          f"{self.pages_fetched_no_content} page(s) loaded successfully but had "
-          "no extractable content. If this site requires signing in, an "
-          "unauthenticated request commonly lands on a login page instead of "
-          "returning an error - confirm the URL is reachable without "
-          "authentication."
-        )
       else:
         parts.append("No pages were crawled.")
 
       if self.pages_failed > 0:
         parts.append(f"{self.pages_failed} requests failed.")
+
+    # At least one page returned 200 with nothing to extract. A login wall
+    # commonly redirects an unauthenticated request to a 200 sign-in page
+    # rather than a 401/403, so that's a signal worth naming even when other
+    # pages also failed outright - it can be the dominant cause when most
+    # pages are empty-200 and only a few hit a real error. Applies regardless
+    # of which branch above ran, including a sitemap crawl that found URLs
+    # and dispatched them to parse_page but scraped none of them.
+    if self.pages_fetched_no_content > 0:
+      parts.append(
+        f"{self.pages_fetched_no_content} page(s) loaded successfully but had "
+        "no extractable content. If this site requires signing in, an "
+        "unauthenticated request commonly lands on a login page instead of "
+        "returning an error - confirm the URL is reachable without "
+        "authentication."
+      )
 
     # Include collected error messages for more detail
     if self.errors:

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
@@ -411,6 +411,40 @@ class TestWorkerSpiderRedirectHandling:
     # effective_domain should remain None since no redirect occurred
     assert spider.effective_domain is None
 
+  def test_parse_page_tracks_200_responses_with_no_extractable_content(self):
+    """A 200 response with nothing to extract must not look like a real error."""
+    from scrapy.http import HtmlResponse
+
+    spider = self._make_worker_spider(start_url="https://docs.example.com")
+
+    response = HtmlResponse(
+      url="https://docs.example.com/",
+      body=b"<html><body></body></html>",
+    )
+
+    list(spider.parse_page(response))
+
+    assert spider.pages_fetched_no_content == 1
+    assert spider.pages_failed == 0
+    assert spider.errors == []
+
+  def test_failure_message_calls_out_a_likely_login_wall(self):
+    """A crawl where every page 200'd but nothing was extracted should hint at a login wall.
+
+    A site behind auth commonly redirects an unauthenticated request to a
+    200 sign-in page rather than a 401/403, so genuine request failures
+    (pages_failed) give no signal here - pages_fetched_no_content is the
+    only distinguishing evidence available.
+    """
+    spider = self._make_worker_spider(start_url="https://docs.example.com")
+    spider.pages_fetched_no_content = 3
+
+    message = spider._build_failure_message()
+
+    assert "3 page(s) loaded successfully but had no extractable content" in message
+    assert "requires signing in" in message
+    assert message != "No pages were crawled."
+
   def test_legacy_host_redirects_to_canonical_domain(self):
     """A crawl should follow links on the canonical domain after redirecting from a legacy host."""
     spider = self._make_worker_spider(start_url="https://legacy.example.com", crawl_mode="recursive")

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
@@ -411,51 +411,6 @@ class TestWorkerSpiderRedirectHandling:
     # effective_domain should remain None since no redirect occurred
     assert spider.effective_domain is None
 
-  def test_build_request_meta_allows_all_http_statuses(self):
-    """Requests must opt out of Scrapy's default HttpErrorMiddleware.
-
-    Without handle_httpstatus_all, a non-2xx response (e.g. 401/403 from an
-    auth-walled page) is silently dropped before reaching parse_page/
-    handle_error, so the failure is never recorded.
-    """
-    spider = self._make_worker_spider()
-
-    assert spider._build_request_meta() == {"handle_httpstatus_all": True}
-
-  def test_parse_page_records_http_401_as_a_failure(self):
-    """parse_page should record an auth-required error instead of ignoring it."""
-    spider = self._make_worker_spider(start_url="https://docs.example.com")
-
-    mock_response = Mock()
-    mock_response.url = "https://docs.example.com/private-page"
-    mock_response.status = 401
-    mock_response.text = ""
-    mock_response.css = Mock(return_value=Mock(getall=Mock(return_value=[])))
-
-    list(spider.parse_page(mock_response))
-
-    assert spider.pages_failed == 1
-    assert len(spider.errors) == 1
-    assert "401" in spider.errors[0]
-    assert "authentication" in spider.errors[0]
-    assert mock_response.url in spider.errors[0]
-
-  def test_parse_page_records_http_403_with_url(self):
-    """parse_page should record the failing URL alongside a 403 status."""
-    spider = self._make_worker_spider(start_url="https://docs.example.com")
-
-    mock_response = Mock()
-    mock_response.url = "https://docs.example.com/forbidden-page"
-    mock_response.status = 403
-    mock_response.text = ""
-    mock_response.css = Mock(return_value=Mock(getall=Mock(return_value=[])))
-
-    list(spider.parse_page(mock_response))
-
-    assert spider.pages_failed == 1
-    assert "403" in spider.errors[0]
-    assert mock_response.url in spider.errors[0]
-
   def test_legacy_host_redirects_to_canonical_domain(self):
     """A crawl should follow links on the canonical domain after redirecting from a legacy host."""
     spider = self._make_worker_spider(start_url="https://legacy.example.com", crawl_mode="recursive")
@@ -1000,13 +955,13 @@ class TestWorkerSpiderPlaywrightMeta:
     return spider
 
   def test_build_request_meta_without_js_rendering(self):
-    """_build_request_meta should skip Playwright settings when JS rendering disabled."""
+    """_build_request_meta should return empty dict when JS rendering disabled."""
     spider = self._make_worker_spider(render_javascript=False)
 
     meta = spider._build_request_meta()
 
     assert "playwright" not in meta
-    assert meta == {"handle_httpstatus_all": True}
+    assert meta == {}
 
   def test_build_request_meta_with_js_rendering(self):
     """_build_request_meta should include Playwright settings when JS rendering enabled."""

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
@@ -445,6 +445,42 @@ class TestWorkerSpiderRedirectHandling:
     assert "requires signing in" in message
     assert message != "No pages were crawled."
 
+  def test_failure_message_calls_out_a_login_wall_even_when_sitemap_found_urls(self):
+    """The login-wall hint must survive the sitemap-found-urls branch too.
+
+    A sitemap crawl that discovers URLs dispatches every one of them to
+    parse_page (see parse_sitemap), so a login wall shows up here exactly
+    the same way it does for a single-URL crawl: 200 responses with nothing
+    to extract. This must not be shadowed by the "Found N URLs in sitemap"
+    message.
+    """
+    spider = self._make_worker_spider(start_url="https://docs.example.com", crawl_mode="sitemap")
+    spider.urls_found_in_sitemap = 5
+    spider.pages_fetched_no_content = 5
+
+    message = spider._build_failure_message()
+
+    assert "Found 5 URLs in sitemap but 0 were scraped." in message
+    assert "5 page(s) loaded successfully but had no extractable content" in message
+    assert "requires signing in" in message
+
+  def test_failure_message_calls_out_a_login_wall_alongside_real_request_failures(self):
+    """The login-wall hint must not be suppressed by unrelated request failures.
+
+    A crawl can have a handful of genuine failures (DNS blips, one real
+    403) *and* a login wall dominating the rest; both are worth surfacing.
+    """
+    spider = self._make_worker_spider(start_url="https://docs.example.com")
+    spider.pages_failed = 1
+    spider.errors = ["HTTP 403: https://docs.example.com/one-off"]
+    spider.pages_fetched_no_content = 99
+
+    message = spider._build_failure_message()
+
+    assert "1 requests failed." in message
+    assert "99 page(s) loaded successfully but had no extractable content" in message
+    assert "requires signing in" in message
+
   def test_legacy_host_redirects_to_canonical_domain(self):
     """A crawl should follow links on the canonical domain after redirecting from a legacy host."""
     spider = self._make_worker_spider(start_url="https://legacy.example.com", crawl_mode="recursive")

--- a/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
+++ b/ai_platform_engineering/knowledge_bases/rag/ingestors/tests/webloader/test_spiders.py
@@ -411,6 +411,51 @@ class TestWorkerSpiderRedirectHandling:
     # effective_domain should remain None since no redirect occurred
     assert spider.effective_domain is None
 
+  def test_build_request_meta_allows_all_http_statuses(self):
+    """Requests must opt out of Scrapy's default HttpErrorMiddleware.
+
+    Without handle_httpstatus_all, a non-2xx response (e.g. 401/403 from an
+    auth-walled page) is silently dropped before reaching parse_page/
+    handle_error, so the failure is never recorded.
+    """
+    spider = self._make_worker_spider()
+
+    assert spider._build_request_meta() == {"handle_httpstatus_all": True}
+
+  def test_parse_page_records_http_401_as_a_failure(self):
+    """parse_page should record an auth-required error instead of ignoring it."""
+    spider = self._make_worker_spider(start_url="https://docs.example.com")
+
+    mock_response = Mock()
+    mock_response.url = "https://docs.example.com/private-page"
+    mock_response.status = 401
+    mock_response.text = ""
+    mock_response.css = Mock(return_value=Mock(getall=Mock(return_value=[])))
+
+    list(spider.parse_page(mock_response))
+
+    assert spider.pages_failed == 1
+    assert len(spider.errors) == 1
+    assert "401" in spider.errors[0]
+    assert "authentication" in spider.errors[0]
+    assert mock_response.url in spider.errors[0]
+
+  def test_parse_page_records_http_403_with_url(self):
+    """parse_page should record the failing URL alongside a 403 status."""
+    spider = self._make_worker_spider(start_url="https://docs.example.com")
+
+    mock_response = Mock()
+    mock_response.url = "https://docs.example.com/forbidden-page"
+    mock_response.status = 403
+    mock_response.text = ""
+    mock_response.css = Mock(return_value=Mock(getall=Mock(return_value=[])))
+
+    list(spider.parse_page(mock_response))
+
+    assert spider.pages_failed == 1
+    assert "403" in spider.errors[0]
+    assert mock_response.url in spider.errors[0]
+
   def test_legacy_host_redirects_to_canonical_domain(self):
     """A crawl should follow links on the canonical domain after redirecting from a legacy host."""
     spider = self._make_worker_spider(start_url="https://legacy.example.com", crawl_mode="recursive")
@@ -955,13 +1000,13 @@ class TestWorkerSpiderPlaywrightMeta:
     return spider
 
   def test_build_request_meta_without_js_rendering(self):
-    """_build_request_meta should return empty dict when JS rendering disabled."""
+    """_build_request_meta should skip Playwright settings when JS rendering disabled."""
     spider = self._make_worker_spider(render_javascript=False)
 
     meta = spider._build_request_meta()
 
     assert "playwright" not in meta
-    assert meta == {}
+    assert meta == {"handle_httpstatus_all": True}
 
   def test_build_request_meta_with_js_rendering(self):
     """_build_request_meta should include Playwright settings when JS rendering enabled."""

--- a/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/src/server/restapi.py
@@ -2599,10 +2599,13 @@ async def preview_url_ingestion(
   user: UserContext = Depends(require_authenticated_user),
 ):
   """Crawl a bounded sample without creating a datasource, job, or documents."""
-  url_request.url = sanitize_url(
-    url_request.url,
-    url_request.settings.allow_non_public_urls,
-  )
+  try:
+    url_request.url = sanitize_url(
+      url_request.url,
+      url_request.settings.allow_non_public_urls,
+    )
+  except ValueError as e:
+    raise HTTPException(status_code=400, detail=str(e))
   datasource_id = utils.generate_datasource_id_from_url(url_request.url)
   existing_datasource = (
     await metadata_storage.get_datasource_info(datasource_id)
@@ -2753,7 +2756,10 @@ async def ingest_url(
   logger.info(f"Received URL ingestion request: {url_request.url}")
 
   # Sanitize URL
-  sanitized_url = sanitize_url(url_request.url, url_request.settings.allow_non_public_urls)
+  try:
+    sanitized_url = sanitize_url(url_request.url, url_request.settings.allow_non_public_urls)
+  except ValueError as e:
+    raise HTTPException(status_code=400, detail=str(e))
   url_request.url = sanitized_url
 
   # Generate datasource ID and create datasource

--- a/ai_platform_engineering/knowledge_bases/rag/server/tests/test_webloader_url_sanitize_error.py
+++ b/ai_platform_engineering/knowledge_bases/rag/server/tests/test_webloader_url_sanitize_error.py
@@ -1,0 +1,61 @@
+"""Non-public URLs must be rejected with a 400, not surface as a 500.
+
+sanitize_url() raises ValueError for hosts that are not publicly routable when
+allow_non_public_urls is False; the webloader routes must translate that into
+an HTTPException instead of letting it propagate as an unhandled error.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from common.models.rbac import Role, UserContext
+from common.models.server import UrlIngestRequest
+from server import restapi
+
+
+def _user() -> UserContext:
+  return UserContext(
+    subject="test-user",
+    email="test-user@example.com",
+    role=Role.READONLY,
+    is_authenticated=True,
+  )
+
+
+def _request() -> MagicMock:
+  return MagicMock(headers={})
+
+
+def _non_public_url_request() -> UrlIngestRequest:
+  return UrlIngestRequest(url="http://127.0.0.1/internal", reload_interval=3600)
+
+
+@pytest.mark.asyncio
+async def test_preview_url_ingestion_rejects_non_public_url_with_400() -> None:
+  with pytest.raises(HTTPException) as exc_info:
+    await restapi.preview_url_ingestion(
+      url_request=_non_public_url_request(),
+      request=_request(),
+      user=_user(),
+    )
+  assert exc_info.value.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_ingest_url_rejects_non_public_url_with_400(
+  monkeypatch: pytest.MonkeyPatch,
+) -> None:
+  monkeypatch.setattr(restapi, "metadata_storage", MagicMock(), raising=False)
+  monkeypatch.setattr(restapi, "jobmanager", MagicMock(), raising=False)
+
+  with pytest.raises(HTTPException) as exc_info:
+    await restapi.ingest_url(
+      url_request=_non_public_url_request(),
+      request=_request(),
+      user=_user(),
+    )
+  assert exc_info.value.status_code == 400

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.7"
+version = "1.0.1-dev.8"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev7"
+version = "1.0.1.dev8"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Two related bugs in webpage-datasource ingestion where a real failure either surfaced as an unhandled 500 or gave the user no way to tell what went wrong:

1. **Non-public URL rejected with a 500.** `sanitize_url()` raises a plain `ValueError` when a webpage URL is not publicly routable and `allow_non_public_urls` is disabled (SSRF protection). The `/v1/ingest/webloader/preview` and `/v1/ingest/webloader/url` routes didn't catch it, so the rejection surfaced as an unhandled `500 Internal Server Error` instead of a `400`. Fixed by wrapping both call sites in `try/except ValueError -> HTTPException(400, ...)`, matching the existing pattern already used elsewhere in `restapi.py`.

2. **A page behind a login wall failed with no explanation.** A real HTTP 401/403 already produced a detailed failure message (verified empirically) — that path wasn't broken. But a login wall commonly responds `200` with a sign-in page instead of an auth-error status, so no error is ever recorded for it; the crawl collapses to the same bare `"No pages were crawled."` shown for a genuinely empty site, giving the user no way to distinguish "this site requires login" from "there was nothing here." Fixed by tracking pages that returned 200 but had no extractable content separately, and when a crawl fails with zero real request failures but at least one such page, naming the login-wall possibility explicitly in the failure message instead of implying the page was empty.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Checklist

- [ ] I have read the contributing guidelines
- [ ] Existing issues have been referenced (where applicable)
- [x] I have verified this change is not present in other open pull requests
- [x] Functionality is documented
- [ ] New selection controls follow the selection-control decision table, or the custom interaction is justified
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing tests pass