### PR TITLE
fix(ui): prevent recursive stream timeline updates

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -485,6 +485,9 @@ services:
       - .env
     environment:
       - NODE_ENV=development
+      # Safe release metadata shown by System Health. A specific
+      # PLATFORM_COMPONENT_VERSION_* value may override this shared tag.
+      - CAIPE_RELEASE_VERSION=${IMAGE_TAG:-localtag}
       # Pass the active Compose profile set through to the UI so product
       # health can show profile-enabled integrations as degraded/down even
       # when their container crashes before serving traffic.
@@ -765,6 +768,9 @@ services:
       - .env
     environment:
       - NODE_ENV=production
+      # Safe release metadata shown by System Health. A specific
+      # PLATFORM_COMPONENT_VERSION_* value may override this shared tag.
+      - CAIPE_RELEASE_VERSION=${IMAGE_TAG:-localtag}
       # Pass the active Compose profile set through to the UI so product
       # health can show profile-enabled integrations as degraded/down even
       # when their container crashes before serving traffic.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.8"
+version = "1.0.1-dev.9"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/hooks/__tests__/useDynamicAgentTimeline.test.tsx
+++ b/ui/src/hooks/__tests__/useDynamicAgentTimeline.test.tsx
@@ -1,0 +1,61 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { renderHook } from "@testing-library/react";
+
+import { useAgentTimeline } from "@/hooks/useDynamicAgentTimeline";
+import type { StreamEvent } from "@/lib/streaming/types";
+
+function contentEvent(id: number,content: string): StreamEvent {
+  return {
+    id: `content-${id}`,
+    timestamp: new Date(id),
+    type: "content",
+    raw: content,
+    namespace: [],
+    content,
+  };
+}
+
+describe("useAgentTimeline",() => {
+  it("handles a fresh empty event array without scheduling derived state updates",() => {
+    let renderCount = 0;
+    const { result } = renderHook(() => {
+      renderCount += 1;
+      return useAgentTimeline([],false);
+    });
+
+    expect(result.current.data).toEqual({
+      segments: [],
+      finalAnswer: null,
+      isStreaming: false,
+      hasTools: false,
+    });
+    expect(renderCount).toBe(1);
+  });
+
+  it("projects rapidly growing stream event arrays without losing content",() => {
+    const initialEvents = [contentEvent(0,"0")];
+    let renderCount = 0;
+    const { result,rerender } = renderHook(
+      ({ events }: { events: StreamEvent[] }) => {
+        renderCount += 1;
+        return useAgentTimeline(events,true);
+      },
+      { initialProps: { events: initialEvents } },
+    );
+
+    let events = initialEvents;
+    for (let index = 1; index < 150; index += 1) {
+      events = [...events,contentEvent(index,String(index))];
+      rerender({ events });
+    }
+
+    expect(result.current.data.finalAnswer).toBe(
+      Array.from({ length: 150 },(_,index) => String(index)).join(""),
+    );
+    expect(result.current.data.isStreaming).toBe(true);
+    expect(renderCount).toBe(150);
+  });
+});

--- a/ui/src/hooks/useDynamicAgentTimeline.ts
+++ b/ui/src/hooks/useDynamicAgentTimeline.ts
@@ -9,7 +9,7 @@
  * <AgentTimeline data={data} ... />
  */
 
-import { TimelineManager,createTimelineManager } from "@/lib/da-timeline-manager";
+import { createTimelineManager } from "@/lib/da-timeline-manager";
 import type {
 StreamEvent,
 ToolEndEventData,
@@ -17,7 +17,7 @@ ToolStartEventData,
 } from "@/lib/streaming/types";
 import { isToolStartData } from "@/lib/streaming/types";
 import type { StatusType,TimelineData } from "@/types/dynamic-agent-timeline";
-import { useEffect,useRef,useState } from "react";
+import { useMemo } from "react";
 
 // ═══════════════════════════════════════════════════════════════
 // Types
@@ -56,38 +56,14 @@ export function useAgentTimeline(
   isStreaming: boolean,
   turnStatus?: StatusType
 ): UseAgentTimelineResult {
-  // Keep a stable manager reference across renders
-  // We'll recreate when events array identity changes (new message)
-  const managerRef = useRef<TimelineManager | null>(null);
-  const prevEventsRef = useRef<StreamEvent[]>([]);
-
-  // Store computed timeline data in state so refs are only accessed inside useEffect (not during render)
-  const [data, setData] = useState<TimelineData>(() => ({ ...EMPTY_DATA, isStreaming }));
-
-  useEffect(() => {
-    // If no events, return empty data with streaming flag
+  const data = useMemo<TimelineData>(() => {
     if (events.length === 0) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional: update timeline data state from events in effect
-      setData({ ...EMPTY_DATA, isStreaming });
-      return;
+      return isStreaming ? { ...EMPTY_DATA, isStreaming: true } : EMPTY_DATA;
     }
 
-    // Check if we need to reset the manager (new events array)
-    // Compare by first event id to detect new turn
-    const prevFirst = prevEventsRef.current[0]?.id;
-    const currFirst = events[0]?.id;
-
-    if (prevFirst !== currFirst) {
-      // New turn - create fresh manager
-      managerRef.current = createTimelineManager();
-    }
-
-    const manager = managerRef.current || createTimelineManager();
-    managerRef.current = manager;
-
-    // Reset and replay all events to get consistent state
-    // This is simpler than incremental updates and handles reordering
-    manager.reset();
+    // Timeline data is a deterministic projection of the current turn. Keeping
+    // it out of state avoids a second render for every streamed token.
+    const manager = createTimelineManager();
 
     for (const event of events) {
       const namespace = event.namespace || [];
@@ -134,15 +110,11 @@ export function useAgentTimeline(
       }
     }
 
-    // Finalize if not streaming
     if (!isStreaming) {
       manager.finalize(turnStatus || "done");
     }
 
-    // Update prev events ref
-    prevEventsRef.current = events;
-
-    setData(manager.getGroupedData());
+    return manager.getGroupedData();
   }, [events, isStreaming, turnStatus]);
 
   return { data };

--- a/ui/src/lib/rbac/__tests__/rebac/rebac-graph-performance.test.ts
+++ b/ui/src/lib/rbac/__tests__/rebac/rebac-graph-performance.test.ts
@@ -32,13 +32,15 @@ describe("ReBAC graph performance", () => {
 
   it("loads a filtered graph page without scanning beyond the requested page", async () => {
     const { queryRebacGraph } = await import("../../rebac-graph");
-    const started = performance.now();
     const result = await queryRebacGraph({ resourceType: "agent", resourceId: "agent-42", limit: 100 });
-    const elapsedMs = performance.now() - started;
 
     expect(result.edges).toHaveLength(1);
     expect(mockReadOpenFgaTuples).toHaveBeenCalledTimes(1);
-    expect(elapsedMs).toBeLessThan(250);
+    expect(mockReadOpenFgaTuples).toHaveBeenCalledWith({
+      tuple: { object: "agent:agent-42" },
+      pageSize: 100,
+      continuationToken: undefined,
+    });
   });
 
   it("loads a selected user's neighborhood and expands team membership", async () => {

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev8"
+version = "1.0.1.dev9"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Split the stream-stability and local release-metadata fixes from #2598 into a focused change based on current `main`.

- Compute dynamic-agent timeline state as a pure projection of stream events, avoiding recursive React updates during high-volume streams.
- Expose `CAIPE_RELEASE_VERSION` consistently to both development UI services.
- Make the ReBAC graph performance boundary assertion deterministic.

This is an intentional replacement slice of #2598; the source PR remains unchanged.

Validation:

- Focused Jest: 2 suites, 11 tests passed.
- Production and minimal development Compose configurations render successfully.
- Rendered development services receive `CAIPE_RELEASE_VERSION`.
- UI lint passes with four existing warnings.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [x] Other (Compose metadata and deterministic test coverage)

## Temporary Helm Charts (Optional)

The `prebuild/` branch enables PR-specific build artifacts for validation.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests (intentional replacement slice of #2598)
- [x] Functionality is documented
- [x] New selection controls follow the [selection-control decision table](https://github.com/caipe-io/ai-platform-engineering/blob/main/docs/docs/ui/selection-controls.md), or the custom interaction is justified (not applicable)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing relevant tests pass
