### PR TITLE
fix(audit): suppress no-op policy reconciliation events

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.8"
+version = "1.0.1-dev.9"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/src/app/api/admin/audit-events/__tests__/route.test.ts
+++ b/ui/src/app/api/admin/audit-events/__tests__/route.test.ts
@@ -462,6 +462,47 @@ describe("GET /api/admin/audit-events", () => {
     expect(body.records[0].user_email).toBeUndefined();
   });
 
+  it("maps legacy reconcile source metadata and tuple counts into the unified event", async () => {
+    global.fetch = jest.fn(async () =>
+      new Response(
+        JSON.stringify({
+          records: [
+            {
+              ts: "2026-08-27T21:37:47.000Z",
+              type: "cas_reconcile",
+              tenant_id: "default",
+              action: "reconcile",
+              outcome: "success",
+              correlation_id: "reconcile-correlation",
+              source: "team_resources",
+              source_system: "cas",
+              component: "cas",
+              pdp: "openfga",
+              writes: 2,
+              deletes: 1,
+            },
+          ],
+          total: 1,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const { GET } = await import("../route");
+
+    const response = await GET(request("/api/admin/audit-events?type=cas_reconcile"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.records[0]).toMatchObject({
+      type: "cas_reconcile",
+      source: "cas",
+      reconcile_scope: "team_resources",
+      writes: 2,
+      deletes: 1,
+    });
+    expect(body.records[0].subject_hash).toBeUndefined();
+  });
+
   it("returns an empty warning response when audit-service is unavailable", async () => {
     global.fetch = jest.fn(async () => new Response("unavailable", { status: 503 }));
     const { GET } = await import("../route");

--- a/ui/src/app/api/admin/audit-events/route.ts
+++ b/ui/src/app/api/admin/audit-events/route.ts
@@ -41,7 +41,7 @@ interface AuditEventDocument {
   ts: Date | string;
   type: string;
   tenant_id: string;
-  subject_hash: string;
+  subject_hash?: string;
   subject_ref?: string;
   user_email?: string;
   action?: string;
@@ -61,6 +61,7 @@ interface AuditEventDocument {
   decision_via?: string;
   pdp?: string;
   source?: string;
+  source_system?: string;
   trace_id?: string;
   span_id?: string;
   trace_url?: string;
@@ -69,6 +70,11 @@ interface AuditEventDocument {
   caller_ref?: string;
   grantee_ref?: string;
   operation?: "grant" | "revoke";
+  reconcile_scope?: string;
+  requested_writes?: number;
+  requested_deletes?: number;
+  writes?: number;
+  deletes?: number;
 }
 
 interface CurrentPrincipal {
@@ -103,8 +109,18 @@ function auditServiceBaseUrl(): string {
   return (process.env.AUDIT_SERVICE_URL ?? process.env.AUDIT_LOG_SERVICE_URL ?? "http://audit-service:8010").replace(/\/$/, "");
 }
 
-function normalizeAuditSource(source: string | undefined): UnifiedAuditEvent["source"] {
-  return (source === "bff" || !source ? "webui_backend" : source) as UnifiedAuditEvent["source"];
+function normalizeAuditSource(
+  source: string | undefined,
+  sourceSystem?: string,
+): UnifiedAuditEvent["source"] {
+  const value = sourceSystem || source;
+  return (value === "bff" || !value ? "webui_backend" : value) as UnifiedAuditEvent["source"];
+}
+
+function reconcileScope(doc: AuditEventDocument): string | undefined {
+  if (doc.reconcile_scope) return doc.reconcile_scope;
+  if (doc.type !== "cas_reconcile" || !doc.source_system) return undefined;
+  return doc.source && doc.source !== doc.source_system ? doc.source : undefined;
 }
 
 function hashSubject(id: string): string {
@@ -366,12 +382,17 @@ function documentToEvent(doc: AuditEventDocument): UnifiedAuditEvent {
     workflow_run_id: doc.workflow_run_id,
     decision_via: doc.decision_via,
     pdp: doc.pdp,
-    source: normalizeAuditSource(doc.source),
+    source: normalizeAuditSource(doc.source, doc.source_system),
     actor_hash: doc.actor_hash,
     actor_ref: doc.actor_ref,
     caller_ref: doc.caller_ref,
     grantee_ref: doc.grantee_ref,
     operation: doc.operation,
+    reconcile_scope: reconcileScope(doc),
+    requested_writes: doc.requested_writes,
+    requested_deletes: doc.requested_deletes,
+    writes: doc.writes,
+    deletes: doc.deletes,
     trace_id: doc.trace_id,
     span_id: doc.span_id,
   };

--- a/ui/src/components/admin/security/UnifiedAuditTab.tsx
+++ b/ui/src/components/admin/security/UnifiedAuditTab.tsx
@@ -137,6 +137,12 @@ const TYPE_FILTER_GROUPS: {
         description:
           "Allow/deny results when the Centralized Authorization Service evaluates whether a subject may act on a resource.",
       },
+      {
+        value: "cas_reconcile",
+        label: "Policy reconciliations",
+        description:
+          "OpenFGA relationship changes applied by CAS, including the reconciliation scope and applied tuple counts.",
+      },
     ],
   },
   {
@@ -302,6 +308,14 @@ function TypeBadge({ type }: { type: AuditEventType }) {
         </Badge>
       );
       break;
+    case "cas_reconcile":
+      badge = (
+        <Badge variant="outline" className="text-amber-700 border-amber-300 bg-amber-50 dark:bg-amber-950 dark:text-amber-400 dark:border-amber-800 gap-1">
+          <RefreshCw className="h-3 w-3" />
+          Policy reconciliation
+        </Badge>
+      );
+      break;
     case "agent_delegation":
       badge = (
         <Badge variant="outline" className="text-purple-600 border-purple-300 bg-purple-50 dark:bg-purple-950 dark:text-purple-400 dark:border-purple-800 gap-1">
@@ -435,7 +449,7 @@ function hasReadableSubject(evt: UnifiedAuditEvent): boolean {
 }
 
 function actorLabel(evt: UnifiedAuditEvent): string {
-  return (
+  const label =
     evt.actor_display ||
     evt.caller_display ||
     evt.subject_display ||
@@ -444,20 +458,23 @@ function actorLabel(evt: UnifiedAuditEvent): string {
     evt.actor_ref ||
     evt.subject_ref ||
     compactHash(evt.actor_hash) ||
-    compactHash(evt.subject_hash) ||
-    "unknown"
-  );
+    compactHash(evt.subject_hash);
+  if (label) return label;
+  return evt.type === "cas_reconcile" ? "CAS reconciler" : "unknown";
 }
 
 function subjectLabel(evt: UnifiedAuditEvent): string {
-  return (
+  if (evt.type === "cas_reconcile") {
+    return "OpenFGA relationships";
+  }
+  const label =
     evt.subject_display ||
     evt.user_email ||
     evt.subject_ref ||
     evt.caller_ref ||
-    compactHash(evt.subject_hash) ||
-    "unknown"
-  );
+    compactHash(evt.subject_hash);
+  if (label) return label;
+  return "unknown";
 }
 
 function decisionPathLabel(evt: UnifiedAuditEvent): string {
@@ -476,6 +493,16 @@ function decisionPathLabel(evt: UnifiedAuditEvent): string {
 function requestStory(evt: UnifiedAuditEvent): string {
   const resource = getResourceParts(evt).label;
   const action = humanizeToken(evt.action);
+  if (evt.type === "cas_reconcile") {
+    const target = evt.reconcile_scope
+      ? humanizeToken(evt.reconcile_scope)
+      : "OpenFGA relationships";
+    if (evt.outcome === "error") return `Failed to reconcile ${target}`;
+    const changes = relationshipChangeSummary(evt.writes, evt.deletes);
+    return changes
+      ? `Reconciled ${target} — ${changes}`
+      : `Reconciled ${target}`;
+  }
   if (evt.type === "cas_grant") {
     const op = evt.operation === "revoke" ? "Revoked" : "Granted";
     return `${op} ${action} on ${resource}`;
@@ -487,6 +514,26 @@ function requestStory(evt: UnifiedAuditEvent): string {
         ? "Denied"
         : "Failed";
   return `${verb} to ${action} ${resource}`;
+}
+
+function relationshipChangeSummary(
+  writes?: number,
+  deletes?: number,
+): string | undefined {
+  if (writes == null && deletes == null) return undefined;
+  if ((writes ?? 0) === 0 && (deletes ?? 0) === 0) return "no policy changes";
+  return `${writes ?? 0} added, ${deletes ?? 0} removed`;
+}
+
+function reconcileRequestSummary(evt: UnifiedAuditEvent): string {
+  const scope = evt.reconcile_scope
+    ? humanizeToken(evt.reconcile_scope)
+    : "OpenFGA relationships";
+  const requested = relationshipChangeSummary(
+    evt.requested_writes,
+    evt.requested_deletes,
+  );
+  return requested ? `Scope ${scope} · Requested ${requested}` : `Scope ${scope}`;
 }
 
 function reasonPhrase(evt: UnifiedAuditEvent): string {
@@ -501,6 +548,18 @@ function reasonPhrase(evt: UnifiedAuditEvent): string {
   if (evt.type === "cas_grant") {
     const op = evt.operation === "revoke" ? "revoke" : "grant";
     return `CAS recorded a ${op} attempt with result ${evt.outcome}.`;
+  }
+  if (evt.type === "cas_reconcile") {
+    const scope = evt.reconcile_scope
+      ? humanizeToken(evt.reconcile_scope)
+      : "OpenFGA relationships";
+    if (evt.outcome === "error") {
+      return `CAS failed to reconcile ${scope} because ${reason}.`;
+    }
+    const changes = relationshipChangeSummary(evt.writes, evt.deletes);
+    return changes === "no policy changes"
+      ? `CAS checked ${scope}; OpenFGA required no relationship changes.`
+      : `CAS applied ${changes ?? "the requested relationship changes"} through OpenFGA.`;
   }
   return `${sentenceCase(displaySource(evt.source))} recorded ${evt.outcome} with reason ${reason}.`;
 }
@@ -1194,8 +1253,12 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
 	                          <td className="px-3 py-2 min-w-[260px]" title={`${evt.action} ${evt.resource_ref || ""}`.trim()}>
 	                            <div className="font-medium text-sm">{story}</div>
 	                            <div className="text-[11px] text-muted-foreground mt-0.5">
-	                              {evt.workflow_run_id ? `Workflow run ${evt.workflow_run_id}` : `Resource ${resource.label}`}
-	                              {evt.action ? ` · Action ${evt.action}` : ""}
+	                              {evt.type === "cas_reconcile"
+	                                ? reconcileRequestSummary(evt)
+	                                : evt.workflow_run_id
+	                                  ? `Workflow run ${evt.workflow_run_id}`
+	                                  : `Resource ${resource.label}`}
+	                              {evt.type !== "cas_reconcile" && evt.action ? ` · Action ${evt.action}` : ""}
 	                            </div>
 	                          </td>
 	                          <td className="px-3 py-2 text-xs max-w-[180px] truncate" title={path}>
@@ -1227,8 +1290,18 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
 	                              </div>
 	                              <div className="grid grid-cols-2 md:grid-cols-3 gap-3 text-xs">
 	                                <DetailField label="Actor" value={actor} />
-	                                <DetailField label="Subject" value={subject} />
-	                                <DetailField label="Request" value={`${humanizeToken(evt.action)} ${resource.label}`} />
+	                                <DetailField
+	                                  label={evt.type === "cas_reconcile" ? "Target" : "Subject"}
+	                                  value={subject}
+	                                />
+	                                <DetailField
+	                                  label="Request"
+	                                  value={
+	                                    evt.type === "cas_reconcile"
+	                                      ? reconcileRequestSummary(evt)
+	                                      : `${humanizeToken(evt.action)} ${resource.label}`
+	                                  }
+	                                />
 	                                <DetailField label="Decision Path" value={path} />
 	                                <DetailField label="Correlation ID" value={evt.correlation_id} />
 	                                <DetailField label="Context ID" value={evt.context_id} />
@@ -1244,6 +1317,11 @@ export function UnifiedAuditTab({ isAdmin }: UnifiedAuditTabProps) {
 	                                <DetailField label="Workflow Run ID" value={evt.workflow_run_id} />
 	                                <DetailField label="Raw Decision Path" value={evt.decision_via} />
                                 <DetailField label="Operation" value={evt.operation} />
+                                <DetailField label="Reconciliation Scope" value={evt.reconcile_scope ? humanizeToken(evt.reconcile_scope) : undefined} />
+                                <DetailField label="Requested Additions" value={evt.requested_writes?.toString()} />
+                                <DetailField label="Requested Removals" value={evt.requested_deletes?.toString()} />
+                                <DetailField label="Applied Additions" value={evt.writes?.toString()} />
+                                <DetailField label="Applied Removals" value={evt.deletes?.toString()} />
                                 <DetailField label="Caller" value={evt.caller_display || evt.caller_ref} />
                                 <DetailField label="Grantee" value={evt.grantee_display || evt.grantee_ref} />
                                 <DetailField label="Actor Hash" value={hasReadableActor(evt) ? undefined : evt.actor_hash} mono />

--- a/ui/src/components/admin/security/__tests__/UnifiedAuditTab.test.tsx
+++ b/ui/src/components/admin/security/__tests__/UnifiedAuditTab.test.tsx
@@ -318,6 +318,54 @@ describe('UnifiedAuditTab', () => {
     expect(screen.getByText(/^grant$/i)).toBeInTheDocument();
   });
 
+  it('renders reconcile events as applied policy changes without unknown fields', async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        records: [
+          {
+            ts: new Date('2026-08-27T21:37:47.000Z').toISOString(),
+            type: 'cas_reconcile',
+            outcome: 'success',
+            action: 'reconcile',
+            tenant_id: 'default',
+            subject_ref: 'system:config-seed',
+            actor_ref: 'system:config-seed',
+            correlation_id: 'reconcile-correlation',
+            source: 'cas',
+            reconcile_scope: 'config_seed',
+            requested_writes: 4,
+            requested_deletes: 1,
+            writes: 3,
+            deletes: 1,
+            component: 'cas',
+            pdp: 'openfga',
+            resource_ref: 'authorization_policy:openfga_relationship_tuples',
+            resource_type: 'authorization_policy',
+            resource_id: 'openfga_relationship_tuples',
+          },
+        ],
+        total: 1,
+        page: 1,
+        limit: 30,
+      }),
+    });
+
+    render(<UnifiedAuditTab isAdmin />);
+
+    const story = await screen.findByText(/Reconciled config seed — 3 added, 1 removed/i);
+    expect(screen.getByText('system:config-seed')).toBeInTheDocument();
+    expect(screen.getByText(/Scope config seed · Requested 4 added, 1 removed/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/Policy reconciliation/i).length).toBeGreaterThan(0);
+    expect(screen.queryByText(/^unknown$/i)).not.toBeInTheDocument();
+
+    fireEvent.click(story);
+    expect(await screen.findByText(/^Target:/i)).toBeInTheDocument();
+    expect(screen.getByText(/^OpenFGA relationships$/i)).toBeInTheDocument();
+    expect(screen.getByText(/^Applied Additions:/i)).toBeInTheDocument();
+    expect(screen.getByText(/^3$/)).toBeInTheDocument();
+  });
+
   it('renders CAS decisions as readable authorization stories', async () => {
     (global.fetch as jest.Mock).mockResolvedValue({
       ok: true,

--- a/ui/src/lib/authz/__tests__/audit.test.ts
+++ b/ui/src/lib/authz/__tests__/audit.test.ts
@@ -9,7 +9,13 @@ jest.mock("@/lib/audit", () => ({
   getAuditBackend: () => mockGetAuditBackend(),
 }));
 
-import { buildDecisionEvent, buildGrantEvent, emitDecisionAudit, emitGrantAudit } from "../audit";
+import {
+  buildDecisionEvent,
+  buildGrantEvent,
+  emitDecisionAudit,
+  emitGrantAudit,
+  emitReconcileAudit,
+} from "../audit";
 
 const subject = { type: "user" as const, id: "alice" };
 const resource = { type: "agent" as const, id: "platform-engineer" };
@@ -193,5 +199,97 @@ describe("emitGrantAudit", () => {
     ).resolves.toBeUndefined();
     expect(warn).toHaveBeenCalledWith("[cas/audit] Failed to enqueue audit event:", expect.any(Error));
     warn.mockRestore();
+  });
+});
+
+describe("emitReconcileAudit", () => {
+  it("does not record a successful reconcile when OpenFGA applies no changes", () => {
+    emitReconcileAudit(
+      { writes: [{ user: "user:alice" }], deletes: [] },
+      { enabled: true, writes: 0, deletes: 0 },
+      { source: "config_seed" },
+    );
+
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("records applied and requested tuple counts with the human caller", () => {
+    emitReconcileAudit(
+      { writes: [{ user: "user:alice" }], deletes: [{ user: "user:bob" }] },
+      { enabled: true, writes: 1, deletes: 1 },
+      {
+        caller,
+        source: "team_resources",
+        tenantId: "acme",
+        correlationId: "reconcile-1",
+        traceId: "trace-1",
+      },
+    );
+
+    expect(mockWrite).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: "cas_reconcile",
+        source: "cas",
+        reconcile_scope: "team_resources",
+        action: "reconcile",
+        resource_ref: "authorization_policy:openfga_relationship_tuples",
+        resource_type: "authorization_policy",
+        resource_id: "openfga_relationship_tuples",
+        requested_writes: 1,
+        requested_deletes: 1,
+        writes: 1,
+        deletes: 1,
+        subject_ref: "user:alice",
+        actor_ref: "user:alice",
+        caller_ref: "user:alice",
+        tenant_id: "acme",
+        correlation_id: "reconcile-1",
+        trace_id: "trace-1",
+      }),
+    );
+  });
+
+  it("uses a readable, sanitized system actor without a fabricated hash", () => {
+    emitReconcileAudit(
+      { writes: [], deletes: [{ user: "user:alice" }] },
+      { enabled: true, writes: 0, deletes: 1 },
+      { source: " Config Seed / Restart " },
+      { outcome: "error", reasonCode: "PDP_WRITE_FAILED" },
+    );
+
+    const event = mockWrite.mock.calls[0][0];
+    expect(event).toMatchObject({
+      source: "cas",
+      reconcile_scope: "Config Seed / Restart",
+      subject_ref: "system:config-seed-restart",
+      actor_ref: "system:config-seed-restart",
+      requested_writes: 0,
+      requested_deletes: 1,
+      writes: 0,
+      deletes: 1,
+      outcome: "error",
+      reason_code: "PDP_WRITE_FAILED",
+    });
+    expect(event.subject_hash).toBeUndefined();
+    expect(event.actor_hash).toBeUndefined();
+    expect(event.caller_ref).toBeUndefined();
+  });
+
+  it("preserves a service-account caller as a service-account principal", () => {
+    emitReconcileAudit(
+      { writes: [{ user: "service_account:reconciler" }], deletes: [] },
+      { enabled: true, writes: 1, deletes: 0 },
+      { caller: { type: "service_account", id: "reconciler" } },
+    );
+
+    const event = mockWrite.mock.calls[0][0];
+    expect(event).toMatchObject({
+      reconcile_scope: "cas-reconciler",
+      subject_ref: "service_account:reconciler",
+      actor_ref: "service_account:reconciler",
+      caller_ref: "service_account:reconciler",
+    });
+    expect(event.subject_hash).toMatch(/^sha256:/);
+    expect(event.actor_hash).toBe(event.subject_hash);
   });
 });

--- a/ui/src/lib/authz/__tests__/reconcile.test.ts
+++ b/ui/src/lib/authz/__tests__/reconcile.test.ts
@@ -61,6 +61,7 @@ describe("reconcileTupleDiff", () => {
     await reconcileTupleDiff({ writes: [sampleWrite], deletes: [] });
 
     expect(mockInvalidateDecisionCache).not.toHaveBeenCalled();
+    expect(mockEmitReconcileAudit).not.toHaveBeenCalled();
   });
 
   it("throws OpenFgaReconcileRequiredError when reconciliation is disabled but a diff was requested", async () => {

--- a/ui/src/lib/authz/audit.ts
+++ b/ui/src/lib/authz/audit.ts
@@ -215,7 +215,15 @@ export interface CasReconcileEvent {
   actor_hash?: string;
   actor_ref?: string;
   caller_ref?: string;
-  source?: string;
+  /** CAS is the emitting subsystem; `reconcile_scope` identifies the caller. */
+  source: "cas";
+  reconcile_scope: string;
+  action: "reconcile";
+  resource_ref: "authorization_policy:openfga_relationship_tuples";
+  resource_type: "authorization_policy";
+  resource_id: "openfga_relationship_tuples";
+  requested_writes: number;
+  requested_deletes: number;
   writes: number;
   deletes: number;
   outcome: ReconcileAuditOutcome;
@@ -228,6 +236,21 @@ export interface CasReconcileEvent {
   span_id?: string;
 }
 
+const DEFAULT_RECONCILE_SCOPE = "cas-reconciler";
+
+function reconcileScope(source: string | undefined): string {
+  return source?.trim() || DEFAULT_RECONCILE_SCOPE;
+}
+
+function systemPrincipalRef(scope: string): string {
+  const normalized = scope
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return `system:${normalized || DEFAULT_RECONCILE_SCOPE}`;
+}
+
 export function emitReconcileAudit(
   diff: { writes: unknown[]; deletes: unknown[] },
   result: { enabled: boolean; writes: number; deletes: number },
@@ -235,7 +258,11 @@ export function emitReconcileAudit(
   options: ReconcileAuditOptions = {},
 ): void {
   const outcome = options.outcome ?? "success";
+  if (outcome === "success" && result.writes === 0 && result.deletes === 0) return;
+
+  const scope = reconcileScope(ctx.source);
   const callerRef = ctx.caller ? principalRef(ctx.caller.type, ctx.caller.id) : undefined;
+  const systemRef = systemPrincipalRef(scope);
   const event: CasReconcileEvent = {
     audit_event_id: randomUUID(),
     ts: new Date(),
@@ -249,8 +276,18 @@ export function emitReconcileAudit(
           actor_ref: callerRef,
           caller_ref: callerRef,
         }
-      : {}),
-    source: ctx.source,
+      : {
+          subject_ref: systemRef,
+          actor_ref: systemRef,
+        }),
+    source: "cas",
+    reconcile_scope: scope,
+    action: "reconcile",
+    resource_ref: "authorization_policy:openfga_relationship_tuples",
+    resource_type: "authorization_policy",
+    resource_id: "openfga_relationship_tuples",
+    requested_writes: diff.writes.length,
+    requested_deletes: diff.deletes.length,
     writes: result.writes,
     deletes: result.deletes,
     outcome,

--- a/ui/src/lib/authz/reconcile.ts
+++ b/ui/src/lib/authz/reconcile.ts
@@ -44,7 +44,8 @@ function assertReconciliationApplied(
 
 /**
  * Apply an OpenFGA tuple diff through CAS: write to the PDP, invalidate cached
- * decisions, and record a `cas_reconcile` audit event.
+ * decisions, and audit policy mutations or failed attempts. Filtered no-ops
+ * do not represent policy changes and stay out of the audit trail.
  */
 export async function reconcileTupleDiff(
   diff: TeamResourceTupleDiff,
@@ -76,6 +77,8 @@ export async function reconcileTupleDiff(
   if (result.enabled && (result.writes > 0 || result.deletes > 0)) {
     invalidateDecisionCache();
   }
-  emitReconcileAudit(diff, result, ctx);
+  if (result.writes > 0 || result.deletes > 0) {
+    emitReconcileAudit(diff, result, ctx);
+  }
   return result;
 }

--- a/ui/src/lib/rbac/types.ts
+++ b/ui/src/lib/rbac/types.ts
@@ -128,7 +128,9 @@ export type AuditEventType =
   | "agent_delegation"
   | "openfga_rebac"
   | "cas_decision"
-  | "cas_grant";
+  | "cas_grant"
+  | "cas_reconcile"
+  | "credential_action";
 
 /** Unified audit event outcome — superset of AuditOutcome for tool/delegation */
 export type UnifiedAuditOutcome = "allow" | "deny" | "success" | "error";
@@ -149,7 +151,7 @@ export interface UnifiedAuditEvent {
   ts: string;
   type: AuditEventType;
   tenant_id: string;
-  subject_hash: string;
+  subject_hash?: string;
   /** Readable subject ref for display (for example user:<sub>). */
   subject_ref?: string;
   /** Canonical subject label for display (for example a user email). */
@@ -190,6 +192,16 @@ export interface UnifiedAuditEvent {
   grantee_display?: string;
   /** CAS grant/revoke: grant | revoke. */
   operation?: "grant" | "revoke";
+  /** CAS reconcile: logical operation that requested the tuple projection. */
+  reconcile_scope?: string;
+  /** CAS reconcile: requested tuple additions before OpenFGA no-op filtering. */
+  requested_writes?: number;
+  /** CAS reconcile: requested tuple removals before OpenFGA no-op filtering. */
+  requested_deletes?: number;
+  /** CAS reconcile: tuple additions actually applied by OpenFGA. */
+  writes?: number;
+  /** CAS reconcile: tuple removals actually applied by OpenFGA. */
+  deletes?: number;
 }
 
 /** Admin dashboard tab keys for RBAC-based visibility */

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev8"
+version = "1.0.1.dev9"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Split the reconciliation-audit correction from #2598 into a focused bugfix based on current `main`.

- Suppress successful CAS reconciliation events when no tuples are written or deleted.
- Preserve mutation and failure events with readable actor, target, scope, and requested/applied tuple counts.
- Render both enriched and historical reconciliation records without generic unknown-resource summaries.

This is an intentional replacement slice of #2598; the source PR remains unchanged.

Validation:

- Focused Jest: 4 suites, 46 tests passed.
- UI lint passes with four existing warnings.
- The patch matches the reviewed `e6d31db0` change exactly.

## Type of Change

- [x] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [ ] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

The `prebuild/` branch enables PR-specific build artifacts for validation.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests (intentional replacement slice of #2598)
- [x] Functionality is documented
- [x] New selection controls follow the [selection-control decision table](https://github.com/caipe-io/ai-platform-engineering/blob/main/docs/docs/ui/selection-controls.md), or the custom interaction is justified (not applicable)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing relevant tests pass
