### PR TITLE
refactor(ui): consolidate security and account settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ai-platform-engineering"
-version = "1.0.1-dev.8"
+version = "1.0.1-dev.9"
 description = "Multi-Agent Collaboration & Workflow Automation - AI agents collaborating across tools and teams to deliver high quality results"
 authors = [
   {name = "CAIPE Contributors"}

--- a/ui/e2e/rbac/access-explorer.spec.ts
+++ b/ui/e2e/rbac/access-explorer.spec.ts
@@ -288,13 +288,13 @@ async function installAccessExplorerMocks(
 }
 
 async function gotoAccessExplorer(page: Page) {
-  await page.goto("/admin/security/access-explorer", {
+  await page.goto("/admin/security/access-operations?operationsTab=access-explorer", {
     waitUntil: "domcontentloaded",
   });
   await expect(
     page
       .getByRole("navigation",{ name: "Admin sections" })
-      .getByRole("link", { name: "Access Explorer" }),
+      .getByRole("link", { name: "Access Operations" }),
   ).toHaveAttribute("aria-current","page");
 }
 
@@ -323,9 +323,10 @@ test.describe("mocked Access Explorer browser regression", () => {
     await installAccessExplorerMocks(page);
     await gotoAccessExplorer(page);
 
-    await expect(page).toHaveURL(/\/admin\/security\/access-explorer$/);
+    await expect(page).toHaveURL(/\/admin\/security\/access-operations\?operationsTab=access-explorer$/);
     await expect(page.getByRole("button", { name: "Security & Policy" })).toHaveAttribute("data-active", "true");
-    await expect(page.getByRole("heading", { level: 1,name: "Access Explorer" })).toBeVisible();
+    await expect(page.getByRole("heading", { level: 1,name: "Access Operations" })).toBeVisible();
+    await expect(page.getByRole("tab", { name: "Access Explorer" })).toHaveAttribute("data-state","active");
     await expect(page.getByTestId("access-explorer-search-stage")).toBeVisible();
     await expect(page.getByTestId("access-explorer-header")).toHaveCount(0);
     await expect(

--- a/ui/e2e/rbac/audit-log.spec.ts
+++ b/ui/e2e/rbac/audit-log.spec.ts
@@ -239,7 +239,7 @@ test.describe("audit log — mocked regression", () => {
       handlers: [makeAuditConfigHandler(), makeAuditEventsHandler(baseAuditRecords(), queries)],
     });
 
-    await page.goto("/admin/security/rbac-audit", { waitUntil: "domcontentloaded" });
+    await page.goto("/admin/security/audit?auditTab=rbac", { waitUntil: "domcontentloaded" });
 
     await expect(page.getByText("RBAC Audit Log", { exact: true })).toBeVisible();
     await expect(page.getByText("Storage: S3 s3://caipe-audit/audit")).toBeVisible();
@@ -270,7 +270,7 @@ test.describe("audit log — mocked regression", () => {
       handlers: [makeAuditConfigHandler(), makeAuditEventsHandler(baseAuditRecords(), queries)],
     });
 
-    await page.goto("/admin/security/rbac-audit", { waitUntil: "domcontentloaded" });
+    await page.goto("/admin/security/audit?auditTab=rbac", { waitUntil: "domcontentloaded" });
     await expect(page.getByText("3 events found")).toBeVisible();
 
     await page.getByLabel("Audit time range").selectOption("6h");
@@ -328,7 +328,7 @@ test.describe("audit log — mocked regression", () => {
       handlers: [makeAuditConfigHandler(), makeAuditEventsHandler(records, queries)],
     });
 
-    await page.goto("/admin/security/rbac-audit", { waitUntil: "domcontentloaded" });
+    await page.goto("/admin/security/audit?auditTab=rbac", { waitUntil: "domcontentloaded" });
     await expect(page.getByText("205 events found")).toBeVisible();
 
     const downloadPromise = page.waitForEvent("download");
@@ -373,7 +373,7 @@ test.describe("audit log — mocked regression", () => {
       ],
     });
 
-    await page.goto("/admin/security/rbac-audit", { waitUntil: "domcontentloaded" });
+    await page.goto("/admin/security/audit?auditTab=rbac", { waitUntil: "domcontentloaded" });
 
     await expect(page.getByText("Storage: audit-service unavailable")).toBeVisible();
     await expect(page.getByText("1 event found")).toBeVisible();

--- a/ui/e2e/rbac/audit-service-writers.spec.ts
+++ b/ui/e2e/rbac/audit-service-writers.spec.ts
@@ -176,7 +176,7 @@ test.describe("audit-service-backed admin audit browser flows", () => {
       handlers: [auditHandler],
     });
 
-    await page.goto("/admin/security/rbac-audit", {
+    await page.goto("/admin/security/audit?auditTab=rbac", {
       waitUntil: "domcontentloaded",
     });
 
@@ -241,7 +241,7 @@ test.describe("audit-service-backed admin audit browser flows", () => {
       handlers: [makeAuditHandler(records, auditQueries)],
     });
 
-    await page.goto("/admin/security/rbac-audit", {
+    await page.goto("/admin/security/audit?auditTab=rbac", {
       waitUntil: "domcontentloaded",
     });
 
@@ -298,7 +298,7 @@ test.describe("audit-service-backed admin audit browser flows", () => {
       handlers: [auditHandler],
     });
 
-    await page.goto("/admin/security/rbac-audit", {
+    await page.goto("/admin/security/audit?auditTab=rbac", {
       waitUntil: "domcontentloaded",
     });
 

--- a/ui/e2e/rbac/audit-storage-settings.spec.ts
+++ b/ui/e2e/rbac/audit-storage-settings.spec.ts
@@ -151,7 +151,7 @@ function makeRetentionPutHandler(
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
 async function navigateToAuditPage(page: import("@playwright/test").Page) {
-  await page.goto("/admin/security/rbac-audit", { waitUntil: "domcontentloaded" });
+  await page.goto("/admin/security/audit?auditTab=rbac", { waitUntil: "domcontentloaded" });
   await expect(page.getByText("RBAC Audit Log", { exact: true })).toBeVisible();
 }
 

--- a/ui/e2e/rbac/credential-secrets-management.spec.ts
+++ b/ui/e2e/rbac/credential-secrets-management.spec.ts
@@ -553,7 +553,7 @@ test.describe("RBAC e2e — credential secrets management", () => {
     });
 
     await signIn(page, env);
-    await page.goto("/admin/security/migrations", { waitUntil: "domcontentloaded" });
+    await page.goto("/admin/security/access-operations?operationsTab=migrations", { waitUntil: "domcontentloaded" });
     await dismissReleaseUpgradeDialog(page);
 
     await expect(page.getByRole("heading", { name: "Platform Data Updates" })).toBeVisible({

--- a/ui/e2e/rbac/rbac-admin-regression.spec.ts
+++ b/ui/e2e/rbac/rbac-admin-regression.spec.ts
@@ -101,7 +101,7 @@ test.describe("mocked RBAC admin browser regression", () => {
       handlers: [auditHandler],
     });
 
-    await page.goto("/admin/security/rbac-audit", {
+    await page.goto("/admin/security/audit?auditTab=rbac", {
       waitUntil: "domcontentloaded",
     });
 

--- a/ui/e2e/rbac/rbac-self-check.spec.ts
+++ b/ui/e2e/rbac/rbac-self-check.spec.ts
@@ -325,7 +325,7 @@ test.describe("mocked RBAC Self Check browser regression", () => {
   test("surfaces OpenFGA drift and repairs safe missing tuples", async ({ page }) => {
     const requests = await installRbacSelfCheckMocks(page);
 
-    await page.goto("/admin/security/self-check", {
+    await page.goto("/admin/security/audit?auditTab=self-check", {
       waitUntil: "domcontentloaded",
     });
 
@@ -333,11 +333,12 @@ test.describe("mocked RBAC Self Check browser regression", () => {
     await expect(
       page
         .getByRole("navigation",{ name: "Admin sections" })
-        .getByRole("link", { name: "Self Check" }),
+        .getByRole("link", { name: "Audit" }),
     ).toHaveAttribute(
       "aria-current",
       "page",
     );
+    await expect(page.getByRole("tab", { name: "Self-check" })).toHaveAttribute("data-state","active");
     await expect(page.getByTestId("rbac-self-check-tab")).toBeVisible();
     await expect(page.getByText("Drift detected")).toBeVisible();
     await expect(page.getByText("Missing team membership tuple")).toBeVisible();
@@ -358,7 +359,7 @@ test.describe("mocked RBAC Self Check browser regression", () => {
   test("bulk revokes selected unowned OpenFGA tuples", async ({ page }) => {
     const requests = await installRbacSelfCheckMocks(page);
 
-    await page.goto("/admin/security/self-check", {
+    await page.goto("/admin/security/audit?auditTab=self-check", {
       waitUntil: "domcontentloaded",
     });
 
@@ -377,7 +378,7 @@ test.describe("mocked RBAC Self Check browser regression", () => {
   test("runs the RBAC API matrix from the UI", async ({ page }) => {
     const requests = await installRbacSelfCheckMocks(page);
 
-    await page.goto("/admin/security/self-check", {
+    await page.goto("/admin/security/audit?auditTab=self-check", {
       waitUntil: "domcontentloaded",
     });
 

--- a/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
+++ b/ui/src/app/(app)/admin/__tests__/admin-page.test.tsx
@@ -1030,7 +1030,7 @@ describe('Admin Dashboard Page', () => {
     });
 
     it('orders Security & Policy destinations and omits Permissions Tool', async () => {
-      currentPathname = '/admin/security/rbac-audit';
+      currentPathname = '/admin/security/audit';
 
       render(<AdminPage />);
 
@@ -1039,29 +1039,53 @@ describe('Admin Dashboard Page', () => {
         'Access before sign-in',
         'AI Review',
         'Autonomous Enablement',
-        'RBAC Audit',
+        'Audit',
         'Approvals',
-        'Access Explorer',
-        'Self Check',
-        'Chat Audit',
-        'Keycloak',
-        'Migrations',
+        'Access Operations',
       ];
       const renderedLinks = within(navigation)
         .getAllByRole('link')
         .map((link) => link.textContent?.trim())
         .filter((label): label is string => destinationLabels.includes(label ?? ''));
       expect(renderedLinks).toEqual(destinationLabels);
-      expect(within(navigation).getByRole('link', { name: /^RBAC Audit$/i })).toHaveAttribute(
+      expect(within(navigation).getByRole('link', { name: /^Audit$/i })).toHaveAttribute(
         'aria-current',
         'page',
       );
       expect(
         within(navigation).queryByRole('link', { name: /^Permissions Tool$/i }),
       ).not.toBeInTheDocument();
-      for (const subgroup of ['Policy', 'Authorization', 'Audit', 'Identity & maintenance']) {
+      for (const subgroup of ['Policy', 'Authorization']) {
         expect(within(navigation).queryByText(subgroup)).not.toBeInTheDocument();
       }
+    });
+
+    it.each([
+      ["auditTab=rbac", "RBAC", "unified-audit-tab"],
+      ["auditTab=chat", "Chat", "audit-logs-tab"],
+      ["auditTab=self-check", "Self-check", "rbac-self-check-tab"],
+    ])('selects the Audit %s submenu',async (query,tabLabel,testId) => {
+      currentPathname = "/admin/security/audit";
+      currentSearchParams = new URLSearchParams(query);
+
+      render(<AdminPage />);
+
+      expect(await screen.findByRole("tab",{ name: tabLabel })).toHaveAttribute("data-state","active");
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
+    });
+
+    it.each([
+      ["operationsTab=access-explorer", "Access Explorer", "access-explorer-tab"],
+      ["operationsTab=keycloak", "Keycloak", "keycloak-health-tab"],
+      ["operationsTab=migrations", "Migrations", "migration-tab"],
+    ])('selects the Access Operations %s submenu',async (query,tabLabel,testId) => {
+      currentPathname = "/admin/security/access-operations";
+      currentSearchParams = new URLSearchParams(query);
+
+      render(<AdminPage />);
+
+      expect(await screen.findByRole("tab",{ name: tabLabel })).toHaveAttribute("data-state","active");
+      expect(screen.getByTestId(testId)).toBeInTheDocument();
     });
 
     it('does not show Keycloak role badges for listed users', async () => {
@@ -1150,12 +1174,19 @@ describe('Admin Dashboard Page', () => {
       ["/admin/platform/rag", "RAG"],
       ["/admin/integrations/slack", "Slack"],
       ["/admin/integrations/webex", "Webex"],
-      ["/admin/security/access-explorer", "Access Explorer"],
-      ["/admin/security/self-check", "Self Check"],
+      ["/admin/security/audit", "Audit"],
+      ["/admin/security/access-operations", "Access Operations"],
       ["/admin/operations/metrics", "Metrics"],
       ["/admin/operations/health", "Health"],
     ])("selects canonical destination %s", async (path, label) => {
       currentPathname = path;
+      currentSearchParams = new URLSearchParams(
+        path === "/admin/security/audit"
+          ? "auditTab=rbac"
+          : path === "/admin/security/access-operations"
+            ? "operationsTab=access-explorer"
+            : "",
+      );
       render(<AdminPage />);
 
       expect(await screen.findByRole("heading", { level: 1, name: label })).toBeInTheDocument();

--- a/ui/src/app/(app)/admin/page.tsx
+++ b/ui/src/app/(app)/admin/page.tsx
@@ -41,6 +41,7 @@ import { MigrationTab } from "@/components/admin/security/MigrationTab";
 import { PublicationApprovalQueue } from "@/components/admin/security/PublicationApprovalQueue";
 import { AccessExplorerTab } from "@/components/admin/security/AccessExplorerTab";
 import { RbacSelfCheckTab } from "@/components/admin/security/RbacSelfCheckTab";
+import { SecurityWorkspaceTabs } from "@/components/admin/security/SecurityWorkspaceTabs";
 import { UnifiedAuditTab } from "@/components/admin/security/UnifiedAuditTab";
 import { ImportAgentsFromConfigCard } from "@/components/admin/settings/ImportAgentsFromConfigCard";
 import { MCPCatalogSettingsCard } from "@/components/admin/settings/MCPCatalogSettingsCard";
@@ -573,7 +574,11 @@ function AdminPage() {
     if (adminRoleLoading || adminTabGatesLoading) return;
     if (visibleCategories.length === 0) return;
     const params = new URLSearchParams(searchParams.toString());
-    if (activeDestination.id !== 'access-explorer') {
+    if (activeDestination.id !== 'audit') {
+      params.delete('auditTab');
+    }
+    if (activeDestination.id !== 'access-operations') {
+      params.delete('operationsTab');
       params.delete('subtab');
       params.delete('openfgaTab');
     }
@@ -3154,15 +3159,29 @@ function AdminPage() {
                 <HealthTab />
               </TabsContent>
 
-              {tabGateValues.audit_logs && (
-                <TabsContent value="audit-logs" className="space-y-4">
-                  <AuditLogsTab onUserClick={setSelectedUserEmail} />
-                </TabsContent>
-              )}
-
-              {tabGateValues.action_audit && (
-                <TabsContent value="action-audit" className="space-y-4">
-                  <UnifiedAuditTab isAdmin={canMutateAdminData} />
+              {(tabGateValues.action_audit || tabGateValues.audit_logs || tabGateValues.openfga) && (
+                <TabsContent value="audit" className="space-y-4">
+                  <SecurityWorkspaceTabs
+                    ariaLabel="Audit sections"
+                    items={[
+                      ...(tabGateValues.action_audit ? [{
+                        id: "rbac",
+                        label: "RBAC",
+                        content: <UnifiedAuditTab isAdmin={canMutateAdminData} />,
+                      }] : []),
+                      ...(tabGateValues.audit_logs ? [{
+                        id: "chat",
+                        label: "Chat",
+                        content: <AuditLogsTab onUserClick={setSelectedUserEmail} />,
+                      }] : []),
+                      ...(tabGateValues.openfga ? [{
+                        id: "self-check",
+                        label: "Self-check",
+                        content: <RbacSelfCheckTab isAdmin={canMutateAdminData} />,
+                      }] : []),
+                    ]}
+                    queryKey="auditTab"
+                  />
                 </TabsContent>
               )}
 
@@ -3172,27 +3191,29 @@ function AdminPage() {
                 </TabsContent>
               )}
 
-              {tabGateValues.openfga && (
-                <TabsContent value="access-explorer" className="space-y-4">
-                  <AccessExplorerTab isAdmin={canMutateAdminData} />
-                </TabsContent>
-              )}
-
-              {tabGateValues.openfga && (
-                <TabsContent value="rbac-self-check" className="space-y-4">
-                  <RbacSelfCheckTab isAdmin={canMutateAdminData} />
-                </TabsContent>
-              )}
-
-              {tabGateValues.migrations && (
-                <TabsContent value="keycloak" className="space-y-4">
-                  <KeycloakMigrationHealthPanel />
-                </TabsContent>
-              )}
-
-              {tabGateValues.migrations && (
-                <TabsContent value="migrations" className="space-y-4">
-                  <MigrationTab isAdmin={canMutateAdminData && tabGateValues.migrations} />
+              {(tabGateValues.openfga || tabGateValues.migrations) && (
+                <TabsContent value="access-operations" className="space-y-4">
+                  <SecurityWorkspaceTabs
+                    ariaLabel="Access operations sections"
+                    items={[
+                      ...(tabGateValues.openfga ? [{
+                        id: "access-explorer",
+                        label: "Access Explorer",
+                        content: <AccessExplorerTab isAdmin={canMutateAdminData} />,
+                      }] : []),
+                      ...(tabGateValues.migrations ? [{
+                        id: "keycloak",
+                        label: "Keycloak",
+                        content: <KeycloakMigrationHealthPanel />,
+                      },{
+                        id: "migrations",
+                        label: "Migrations",
+                        content: <MigrationTab isAdmin={canMutateAdminData && tabGateValues.migrations} />,
+                      }] : []),
+                    ]}
+                    queryKey="operationsTab"
+                    resetParams={["subtab","openfgaTab"]}
+                  />
                 </TabsContent>
               )}
 

--- a/ui/src/app/api/platform/health/route.ts
+++ b/ui/src/app/api/platform/health/route.ts
@@ -345,7 +345,7 @@ async function probeOpenFgaBootstrap(openfgaUrl: string): Promise<DiagnosticProb
   const storeName = envValue("OPENFGA_STORE_NAME") || "caipe-openfga";
   const remediation = {
     label: "OpenFGA",
-    href: "/admin/security/access-explorer",
+    href: "/admin/security/access-operations?operationsTab=access-explorer",
     description: "Inspect OpenFGA connectivity and seeded authorization model.",
   };
 
@@ -434,7 +434,7 @@ async function probeOpenFgaBootstrap(openfgaUrl: string): Promise<DiagnosticProb
 async function probeKeycloakBootstrap(): Promise<DiagnosticProbeResult> {
   const remediation = {
     label: "Keycloak Health",
-    href: "/admin/security/keycloak",
+    href: "/admin/security/access-operations?operationsTab=keycloak",
     description: "Inspect Keycloak realm, credentials, and reconciliation status.",
   };
   try {
@@ -494,7 +494,7 @@ async function probeKeycloakBootstrap(): Promise<DiagnosticProbeResult> {
 async function probeRebacMigrations(): Promise<DiagnosticProbeResult> {
   const remediation = {
     label: "Migration Assistant",
-    href: "/admin/security/migrations",
+    href: "/admin/security/access-operations?operationsTab=migrations",
     description: "Open the migration assistant to review and apply required schema migrations.",
   };
   try {
@@ -594,7 +594,7 @@ async function buildDiagnosticProbes(): Promise<DiagnosticProbeResult[]> {
       target: `${keycloakUrl}/realms/${keycloakRealm}/protocol/openid-connect/certs`,
       remediation: {
         label: "Keycloak Health",
-        href: "/admin/security/keycloak",
+        href: "/admin/security/access-operations?operationsTab=keycloak",
         description: "Inspect Keycloak realm, credentials, and reconciliation status.",
       },
     }),
@@ -605,7 +605,7 @@ async function buildDiagnosticProbes(): Promise<DiagnosticProbeResult[]> {
       target: `${openfgaUrl}/healthz`,
       remediation: {
         label: "OpenFGA",
-        href: "/admin/security/access-explorer",
+        href: "/admin/security/access-operations?operationsTab=access-explorer",
         description: "Inspect OpenFGA connectivity and seeded authorization model.",
       },
     }),

--- a/ui/src/components/admin/security/SecurityWorkspaceTabs.tsx
+++ b/ui/src/components/admin/security/SecurityWorkspaceTabs.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { Tabs,TabsContent,TabsList,TabsTrigger } from "@/components/ui/tabs";
+import { usePathname,useRouter,useSearchParams } from "next/navigation";
+import { useCallback,useEffect } from "react";
+
+const NO_RESET_PARAMS: string[] = [];
+
+export interface SecurityWorkspaceTab {
+  content: React.ReactNode;
+  id: string;
+  label: string;
+}
+
+interface SecurityWorkspaceTabsProps {
+  ariaLabel: string;
+  items: SecurityWorkspaceTab[];
+  queryKey: string;
+  resetParams?: string[];
+}
+
+export function SecurityWorkspaceTabs({
+  ariaLabel,
+  items,
+  queryKey,
+  resetParams = NO_RESET_PARAMS,
+}: SecurityWorkspaceTabsProps): React.ReactElement | null {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const query = searchParams.toString();
+  const resetParamNames = resetParams.join("\0");
+  const requestedId = searchParams.get(queryKey);
+  const activeId = items.some((item) => item.id === requestedId)
+    ? requestedId!
+    : items[0]?.id;
+
+  const selectTab = useCallback((nextId: string) => {
+    const params = new URLSearchParams(query);
+    params.set(queryKey,nextId);
+    for (const key of resetParamNames.split("\0").filter(Boolean)) params.delete(key);
+    const nextQuery = params.toString();
+    router.replace(nextQuery ? `${pathname}?${nextQuery}` : pathname,{ scroll: false });
+  },[pathname,query,queryKey,resetParamNames,router]);
+
+  useEffect(() => {
+    if (activeId && requestedId !== activeId) selectTab(activeId);
+  },[activeId,requestedId,selectTab]);
+
+  if (!activeId) return null;
+
+  return (
+    <Tabs className="space-y-4" onValueChange={selectTab} value={activeId}>
+      <TabsList aria-label={ariaLabel}>
+        {items.map((item) => (
+          <TabsTrigger key={item.id} value={item.id}>{item.label}</TabsTrigger>
+        ))}
+      </TabsList>
+      {items.map((item) => (
+        <TabsContent className="space-y-4" key={item.id} value={item.id}>
+          {item.content}
+        </TabsContent>
+      ))}
+    </Tabs>
+  );
+}

--- a/ui/src/components/admin/security/__tests__/SecurityWorkspaceTabs.test.tsx
+++ b/ui/src/components/admin/security/__tests__/SecurityWorkspaceTabs.test.tsx
@@ -1,0 +1,55 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { fireEvent,render,screen } from "@testing-library/react";
+
+const replaceMock = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock("next/navigation",() => ({
+  usePathname: () => "/admin/security/audit",
+  useRouter: () => ({ replace: replaceMock }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+import { SecurityWorkspaceTabs } from "../SecurityWorkspaceTabs";
+
+const ITEMS = [
+  { id: "rbac",label: "RBAC",content: <div>RBAC content</div> },
+  { id: "chat",label: "Chat",content: <div>Chat content</div> },
+];
+
+describe("SecurityWorkspaceTabs",() => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSearchParams = new URLSearchParams();
+  });
+
+  it("selects and canonicalizes the first available section",() => {
+    render(<SecurityWorkspaceTabs ariaLabel="Audit sections" items={ITEMS} queryKey="auditTab" />);
+
+    expect(screen.getByText("RBAC content")).toBeInTheDocument();
+    expect(replaceMock).toHaveBeenCalledWith(
+      "/admin/security/audit?auditTab=rbac",
+      { scroll: false },
+    );
+  });
+
+  it("uses a valid URL selection and updates it from the submenu",() => {
+    mockSearchParams = new URLSearchParams("auditTab=chat");
+    render(<SecurityWorkspaceTabs ariaLabel="Audit sections" items={ITEMS} queryKey="auditTab" />);
+
+    expect(screen.getByText("Chat content")).toBeInTheDocument();
+    expect(replaceMock).not.toHaveBeenCalled();
+
+    fireEvent.mouseDown(screen.getByRole("tab",{ name: "RBAC" }),{
+      button: 0,
+      ctrlKey: false,
+    });
+    expect(replaceMock).toHaveBeenCalledWith(
+      "/admin/security/audit?auditTab=rbac",
+      { scroll: false },
+    );
+  });
+});

--- a/ui/src/components/admin/workspace/AdminNavigation.tsx
+++ b/ui/src/components/admin/workspace/AdminNavigation.tsx
@@ -27,7 +27,11 @@ export function adminDestinationHref(
     params.delete("from");
     params.delete("to");
   }
-  if (destination.id !== "access-explorer") {
+  if (destination.id !== "audit") {
+    params.delete("auditTab");
+  }
+  if (destination.id !== "access-operations") {
+    params.delete("operationsTab");
     params.delete("subtab");
     params.delete("openfgaTab");
   }

--- a/ui/src/components/admin/workspace/__tests__/admin-routes.test.ts
+++ b/ui/src/components/admin/workspace/__tests__/admin-routes.test.ts
@@ -28,6 +28,10 @@ describe("admin route registry", () => {
       "autonomous",
     );
     expect(findAdminDestinationByPath("/admin/security/ai-review/")?.id).toBe("ai-review");
+    expect(findAdminDestinationByPath("/admin/security/audit")?.id).toBe("audit");
+    expect(findAdminDestinationByPath("/admin/security/access-operations")?.id).toBe("access-operations");
+    expect(findAdminDestinationByPath("/admin/security/rbac-audit")).toBeUndefined();
+    expect(findAdminDestinationByPath("/admin/security/access-explorer")).toBeUndefined();
     expect(findAdminDestinationByPath("/admin/configuration/defaults")?.id).toBe("defaults");
     expect(findAdminDestinationByPath("/admin/configuration/announcements")?.id).toBe("announcements");
     expect(findAdminDestinationByPath("/admin/platform/defaults")).toBeUndefined();
@@ -36,7 +40,9 @@ describe("admin route registry", () => {
 
   it("filters destinations by access and removes empty categories", () => {
     const gates = Object.fromEntries(
-      [...new Set(ADMIN_DESTINATIONS.map((destination) => destination.gateKey))].map(
+      [...new Set(ADMIN_DESTINATIONS.flatMap(
+        (destination) => destination.gateKeys ?? [destination.gateKey],
+      ))].map(
         (gateKey) => [gateKey, false],
       ),
     );
@@ -48,6 +54,23 @@ describe("admin route registry", () => {
     expect(categories.map((category) => category.id)).toEqual(["people", "operations"]);
     expect(categories[0].destinations.map((destination) => destination.id)).toEqual(["users"]);
     expect(categories[1].destinations.map((destination) => destination.id)).toEqual(["health"]);
+  });
+
+  it("shows consolidated security destinations when any child gate is available",() => {
+    const categories = filterAdminCategories({
+      action_audit: false,
+      approvals: false,
+      audit_logs: true,
+      migrations: true,
+      openfga: false,
+      platform_settings: false,
+    });
+
+    expect(categories).toHaveLength(1);
+    expect(categories[0].destinations.map((destination) => destination.id)).toEqual([
+      "audit",
+      "access-operations",
+    ]);
   });
 
   it("keeps deterministic defaults for admins and read-only viewers", () => {

--- a/ui/src/components/admin/workspace/admin-routes.ts
+++ b/ui/src/components/admin/workspace/admin-routes.ts
@@ -52,17 +52,14 @@ export type AdminDestinationId =
   | "health"
   | "access-before-sign-in"
   | "ai-review"
-  | "action-audit"
+  | "audit"
   | "approvals"
-  | "access-explorer"
-  | "rbac-self-check"
-  | "audit-logs"
-  | "keycloak"
-  | "migrations";
+  | "access-operations";
 
 export interface AdminDestinationDefinition {
   description: string;
   gateKey: string;
+  gateKeys?: string[];
   href: string;
   icon: LucideIcon;
   id: AdminDestinationId;
@@ -289,13 +286,14 @@ export const ADMIN_CATEGORIES: AdminCategoryDefinition[] = [
         subgroup: "Policy",
       },
       {
-        id: "action-audit",
-        href: "/admin/security/rbac-audit",
-        label: "RBAC Audit",
-        description: "Review authorization mutations and administrative actions.",
-        icon: Shield,
+        id: "audit",
+        href: "/admin/security/audit",
+        label: "Audit",
+        description: "Review authorization activity, conversations, and policy self-checks.",
+        icon: FileText,
         gateKey: "action_audit",
-        subgroup: "Authorization",
+        gateKeys: ["action_audit", "audit_logs", "openfga"],
+        subgroup: "Audit",
       },
       {
         id: "approvals",
@@ -307,49 +305,14 @@ export const ADMIN_CATEGORIES: AdminCategoryDefinition[] = [
         subgroup: "Authorization",
       },
       {
-        id: "access-explorer",
-        href: "/admin/security/access-explorer",
-        label: "Access Explorer",
-        description: "Explore effective access and authorization relationships.",
-        icon: Shield,
-        gateKey: "openfga",
-        subgroup: "Authorization",
-      },
-      {
-        id: "rbac-self-check",
-        href: "/admin/security/self-check",
-        label: "Self Check",
-        description: "Validate the current authorization configuration.",
-        icon: ListChecks,
-        gateKey: "openfga",
-        subgroup: "Authorization",
-      },
-      {
-        id: "audit-logs",
-        href: "/admin/security/chat-audit",
-        label: "Chat Audit",
-        description: "Review retained conversation activity and audit records.",
-        icon: FileText,
-        gateKey: "audit_logs",
-        subgroup: "Audit",
-      },
-      {
-        id: "keycloak",
-        href: "/admin/security/keycloak",
-        label: "Keycloak",
-        description: "Review identity-provider migration health.",
+        id: "access-operations",
+        href: "/admin/security/access-operations",
+        label: "Access Operations",
+        description: "Inspect authorization state, identity health, and required migrations.",
         icon: ShieldCheck,
-        gateKey: "migrations",
-        subgroup: "Identity & maintenance",
-      },
-      {
-        id: "migrations",
-        href: "/admin/security/migrations",
-        label: "Migrations",
-        description: "Run and monitor platform data migrations.",
-        icon: Database,
-        gateKey: "migrations",
-        subgroup: "Identity & maintenance",
+        gateKey: "openfga",
+        gateKeys: ["openfga","migrations"],
+        subgroup: "Authorization",
       },
     ],
   },
@@ -390,7 +353,9 @@ export function filterAdminCategories(
   return ADMIN_CATEGORIES.map((category) => ({
     ...category,
     destinations: category.destinations.filter(
-      (destination) => gateValues[destination.gateKey],
+      (destination) => (destination.gateKeys ?? [destination.gateKey]).some(
+        (gateKey) => gateValues[gateKey],
+      ),
     ),
   })).filter((category) => category.destinations.length > 0);
 }

--- a/ui/src/components/layout/AppHeader.tsx
+++ b/ui/src/components/layout/AppHeader.tsx
@@ -190,7 +190,7 @@ export function AppHeader() {
                 : `Keycloak realm ${keycloakSummary.realm} unreachable`,
           count: 1,
           severity: "red" as const,
-          href: "/admin/security/keycloak",
+          href: "/admin/security/access-operations?operationsTab=keycloak",
         }
       : null;
   const adminOnlyAlerts: AdminAlertSource[] = isAdmin
@@ -202,7 +202,7 @@ export function AppHeader() {
               label: "Migrations required",
               count: migrationStatus.status.blocking_required_count ?? 0,
               severity: "red" as const,
-              href: "/admin/security/migrations",
+              href: "/admin/security/access-operations?operationsTab=migrations",
             }
           : null,
         keycloakHealth.summary?.invariants && keycloakHealth.summary.invariants.failing > 0
@@ -211,7 +211,7 @@ export function AppHeader() {
               label: `Keycloak invariant${keycloakHealth.summary.invariants.failing === 1 ? "" : "s"} failing`,
               count: keycloakHealth.summary.invariants.failing,
               severity: "amber" as const,
-              href: "/admin/security/keycloak",
+              href: "/admin/security/access-operations?operationsTab=keycloak",
             }
           : null,
         !migrationStatus.status?.is_blocking && migrationStatus.status?.needs_version_bootstrap
@@ -220,7 +220,7 @@ export function AppHeader() {
               label: "Version metadata needed",
               count: migrationStatus.status.version_bootstrap_required_count ?? 0,
               severity: "amber" as const,
-              href: "/admin/security/migrations",
+              href: "/admin/security/access-operations?operationsTab=migrations",
             }
           : null,
         !migrationStatus.status?.is_blocking && migrationStatus.status?.override_active
@@ -229,7 +229,7 @@ export function AppHeader() {
               label: "Migration override active",
               count: 1,
               severity: "amber" as const,
-              href: "/admin/security/migrations",
+              href: "/admin/security/access-operations?operationsTab=migrations",
             }
           : null,
       ].filter(Boolean) as AdminAlertSource[])

--- a/ui/src/components/layout/__tests__/AppHeader.test.tsx
+++ b/ui/src/components/layout/__tests__/AppHeader.test.tsx
@@ -1227,7 +1227,7 @@ describe('AppHeader — Chat tab notification dots', () => {
     // <button>s that programmatically load the route. Verify that the
     // click handler actually fires and targets the migrations tab.
     fireEvent.click(row!)
-    expect(mockRouterPush).toHaveBeenCalledWith('/admin/security/migrations')
+    expect(mockRouterPush).toHaveBeenCalledWith('/admin/security/access-operations?operationsTab=migrations')
   })
 
   it('shows the admin alerts pill for version-metadata bootstrap (amber-severity)', () => {
@@ -1256,7 +1256,7 @@ describe('AppHeader — Chat tab notification dots', () => {
     const row = findAlertRow('Version metadata needed')
     expect(row).not.toBeNull()
     fireEvent.click(row!)
-    expect(mockRouterPush).toHaveBeenCalledWith('/admin/security/migrations')
+    expect(mockRouterPush).toHaveBeenCalledWith('/admin/security/access-operations?operationsTab=migrations')
   })
 
   it('renders one popover row per active admin alert source and picks worst severity for the trigger', () => {
@@ -1311,9 +1311,9 @@ describe('AppHeader — Chat tab notification dots', () => {
     // must load the Keycloak tab and clicking the version row must
     // load the Migrations tab (no cross-talk).
     fireEvent.click(keycloakRow!)
-    expect(mockRouterPush).toHaveBeenLastCalledWith('/admin/security/keycloak')
+    expect(mockRouterPush).toHaveBeenLastCalledWith('/admin/security/access-operations?operationsTab=keycloak')
     fireEvent.click(versionRow!)
-    expect(mockRouterPush).toHaveBeenLastCalledWith('/admin/security/migrations')
+    expect(mockRouterPush).toHaveBeenLastCalledWith('/admin/security/access-operations?operationsTab=migrations')
     expect(mockRouterPush).toHaveBeenCalledTimes(2)
   })
 
@@ -1375,7 +1375,7 @@ describe('AppHeader — Chat tab notification dots', () => {
     expect(row).not.toBeNull()
     expect(row?.textContent ?? '').toContain('4')
     fireEvent.click(row!)
-    expect(mockRouterPush).toHaveBeenCalledWith('/admin/security/keycloak')
+    expect(mockRouterPush).toHaveBeenCalledWith('/admin/security/access-operations?operationsTab=keycloak')
   })
 
   it('hides the admin alerts pill when no admin alert sources are active', () => {
@@ -1457,7 +1457,7 @@ describe('AppHeader — Chat tab notification dots', () => {
     expect(row).not.toBeNull()
     fireEvent.click(row!)
 
-    expect(mockRouterPush).toHaveBeenCalledWith('/admin/security/keycloak')
+    expect(mockRouterPush).toHaveBeenCalledWith('/admin/security/access-operations?operationsTab=keycloak')
     // …AND AppHeader sets alertsPopoverOpen to false on the same
     // click, so the user lands on the destination tab without a
     // dangling floating layer.

--- a/ui/src/components/settings/SettingsWorkspace.tsx
+++ b/ui/src/components/settings/SettingsWorkspace.tsx
@@ -21,9 +21,22 @@ function SettingsContent({ route }: { route: SettingsRouteDefinition }): React.R
     case "notifications":
       return <NotificationsSettings />;
     case "access":
-      return <AccessSettings />;
-    case "developer":
-      return <DeveloperSettings />;
+      return (
+        <div className="space-y-10">
+          <AccessSettings />
+          <section aria-labelledby="developer-settings-heading" className="space-y-6 border-t border-border pt-8">
+            <div className="space-y-1">
+              <h2 className="text-xl font-semibold tracking-tight" id="developer-settings-heading">
+                Developer (Dangerous)
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Debugging and session tools can expose sensitive access information.
+              </p>
+            </div>
+            <DeveloperSettings />
+          </section>
+        </div>
+      );
   }
 }
 

--- a/ui/src/components/settings/__tests__/SettingsWorkspace.test.tsx
+++ b/ui/src/components/settings/__tests__/SettingsWorkspace.test.tsx
@@ -33,4 +33,14 @@ describe("SettingsWorkspace",() => {
     expect(findSettingsRouteBySegment("system-health")).toBeUndefined();
   });
 
+  it("combines developer tools with account access and removes the developer route",() => {
+    render(<SettingsWorkspace activeRouteId="access" />);
+
+    expect(screen.getByText("Access content")).toBeInTheDocument();
+    expect(screen.getByRole("heading",{ level: 2,name: "Developer (Dangerous)" })).toBeInTheDocument();
+    expect(screen.getByText("Developer content")).toBeInTheDocument();
+    expect(findSettingsRouteBySegment("developer")).toBeUndefined();
+    expect(PERSONAL_SETTINGS_ROUTES.some((route) => route.id === "developer")).toBe(false);
+  });
+
 });

--- a/ui/src/components/settings/sections/AccessSettings.tsx
+++ b/ui/src/components/settings/sections/AccessSettings.tsx
@@ -3,18 +3,13 @@
 import { Button } from "@/components/ui/button";
 import { SettingsCard } from "@/components/settings/shared/SettingsCard";
 import { cn } from "@/lib/utils";
-import { KeyRound,Layers,Loader2,RefreshCw,Shield,Users } from "lucide-react";
+import { Loader2,RefreshCw,Shield,Users } from "lucide-react";
 import { useSearchParams } from "next/navigation";
 import { useCallback,useEffect,useState } from "react";
 
 interface RbacPosture {
   email?: string;
-  idp_source: string;
-  legacy_resource_roles_hidden_count?: number;
   name?: string;
-  per_agent_roles: string[];
-  per_kb_roles: string[];
-  realm_roles: string[];
   role: string;
   slack_linked: boolean;
   teams: Array<{ _id: string;name: string;role?: string;slug?: string }>;
@@ -204,36 +199,6 @@ export function AccessSettings(): React.ReactElement {
         )}
       </SettingsCard>
 
-      <SettingsCard
-        description="Technical identity details can help an administrator troubleshoot unexpected access."
-        title={<span className="flex items-center gap-2"><KeyRound className="h-5 w-5 text-primary" />Technical access details</span>}
-      >
-        <details className="rounded-lg border border-border/70 p-4">
-          <summary className="cursor-pointer text-sm font-medium">Show identity-provider details</summary>
-          <dl className="mt-4 space-y-3 text-sm">
-            <div>
-              <dt className="text-xs text-muted-foreground">Identity provider</dt>
-              <dd className="break-all font-mono text-xs">{posture.idp_source}</dd>
-            </div>
-            <div>
-              <dt className="text-xs text-muted-foreground">Realm roles</dt>
-              <dd className="mt-1 flex flex-wrap gap-1.5">
-                {posture.realm_roles.length ? posture.realm_roles.map((role) => (
-                  <span className="rounded-md border border-primary/20 bg-primary/10 px-2 py-0.5 font-mono text-xs text-primary" key={role}>
-                    {role}
-                  </span>
-                )) : <span className="text-xs text-muted-foreground">None</span>}
-              </dd>
-            </div>
-            {posture.legacy_resource_roles_hidden_count ? (
-              <div className="flex items-start gap-2 rounded-md bg-muted p-3 text-xs text-muted-foreground">
-                <Layers className="mt-0.5 h-3.5 w-3.5 shrink-0" />
-                {posture.legacy_resource_roles_hidden_count} legacy resource role(s) are hidden because current access is evaluated by policy.
-              </div>
-            ) : null}
-          </dl>
-        </details>
-      </SettingsCard>
     </div>
   );
 }

--- a/ui/src/components/settings/sections/__tests__/AccessSettings.test.tsx
+++ b/ui/src/components/settings/sections/__tests__/AccessSettings.test.tsx
@@ -14,11 +14,7 @@ import { AccessSettings } from "../AccessSettings";
 
 const BASE_POSTURE = {
   email: "person-1@example.com",
-  idp_source: "keycloak",
   name: "Person One",
-  per_agent_roles: [],
-  per_kb_roles: [],
-  realm_roles: ["user"],
   role: "user",
   slack_linked: false,
   teams: [],
@@ -63,6 +59,7 @@ describe("AccessSettings", () => {
     await screen.findByText("Identity and role");
     expect(screen.queryByText(/Webex account:/)).not.toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /Link Webex account|Relink/ })).not.toBeInTheDocument();
+    expect(screen.queryByText("Technical access details")).not.toBeInTheDocument();
   });
 
   it("shows a Link Webex account button when available and unlinked", async () => {

--- a/ui/src/components/settings/settings-routes.ts
+++ b/ui/src/components/settings/settings-routes.ts
@@ -1,7 +1,6 @@
 import {
   Bell,
   Bot,
-  Code2,
   KeyRound,
   Palette,
   type LucideIcon,
@@ -11,8 +10,7 @@ export type SettingsRouteId =
   | "appearance"
   | "chat"
   | "notifications"
-  | "access"
-  | "developer";
+  | "access";
 
 export interface SettingsRouteDefinition {
   description: string;
@@ -55,14 +53,6 @@ export const PERSONAL_SETTINGS_ROUTES: SettingsRouteDefinition[] = [
     label: "Account & access",
     description: "Your role, teams, and linked identity.",
     icon: KeyRound,
-  },
-  {
-    id: "developer",
-    href: "/settings/developer",
-    segment: "developer",
-    label: "Developer",
-    description: "Debug preferences and session diagnostics.",
-    icon: Code2,
   },
 ];
 

--- a/uv.lock
+++ b/uv.lock
@@ -12,7 +12,7 @@ overrides = [{ name = "protobuf", specifier = "==5.29.6" }]
 
 [[package]]
 name = "ai-platform-engineering"
-version = "1.0.1.dev8"
+version = "1.0.1.dev9"
 source = { virtual = "." }
 dependencies = [
     { name = "beautifulsoup4" },


### PR DESCRIPTION
# Description

Split the security and account-settings consolidation from #2598 into a focused refactor based on current `main`.

- Move developer tools under Account & Access as `Developer (Dangerous)` and remove the standalone technical-access section.
- Consolidate Security & Policy into URL-backed Audit and Access Operations workspaces.
- Retarget navigation, health links, alerts, and RBAC browser coverage to the new routes.
- Intentionally omit compatibility redirects for retired routes, matching #2598's behavior.

This is an intentional replacement slice of #2598; the source PR remains unchanged.

Validation:

- Focused Jest: 6 suites, 153 tests passed.
- UI lint passes with four existing warnings.
- The 22-file change matches #2598's final settings tree while preserving current `main`.

## Type of Change

- [ ] Bugfix
- [ ] New Feature
- [ ] Breaking Change
- [x] Refactor
- [ ] Documentation
- [ ] Other (please describe)

## Temporary Helm Charts (Optional)

The `prebuild/` branch enables PR-specific build artifacts for validation.

## Checklist

- [x] I have read the [contributing guidelines](CONTRIBUTING.md)
- [x] Existing issues have been referenced (where applicable)
- [ ] I have verified this change is not present in other open pull requests (intentional replacement slice of #2598)
- [x] Functionality is documented
- [x] New selection controls follow the [selection-control decision table](https://github.com/caipe-io/ai-platform-engineering/blob/main/docs/docs/ui/selection-controls.md), or the custom interaction is justified (not applicable)
- [x] All code style checks pass
- [x] New code contribution is covered by automated tests
- [x] All new and existing relevant tests pass
