### PR TITLE
fix(setup-caipe): wire dynamic agents authorization endpoint

### DIFF
--- a/setup-caipe.sh
+++ b/setup-caipe.sh
@@ -6184,6 +6184,10 @@ dynamic-agents:
   config:
     # MongoDB URI baked in at deploy time so the pod can start before post_deploy_patches.
     MONGODB_URI: "mongodb://admin:${_mongo_pw}@caipe-mongodb:27017/caipe?authSource=caipe"
+    # Dynamic-agents delegates agent authorization to the UI/BFF CAS endpoint.
+    # Set this explicitly because older packaged charts omit empty config keys
+    # and therefore do not render their deployment-level fallback.
+    AUTHZ_SERVICE_URL: "http://caipe-caipe-ui:3000"
 DAEOF
     if [[ -n "$CAIPE_DOMAIN" && -n "$da_oidc_issuer" ]]; then
       cat >> "$_da_values_file" <<DAEOF


### PR DESCRIPTION
## Description

Fresh installs could return HTTP 503 when starting the first chat. The dynamic-agents pod failed closed because `AUTHZ_SERVICE_URL` was empty, so it could not reach the UI/BFF CAS authorization endpoint.

This change explicitly writes the in-cluster BFF URL into the generated dynamic-agents Helm values:

```yaml
AUTHZ_SERVICE_URL: "http://caipe-caipe-ui:3000"
```

This also works with older packaged charts that omit empty configuration keys and therefore do not render the chart-side fallback.

## Validation

- `bash -n setup-caipe.sh`
- `git diff --check`
- `uv run pytest -q tests/test_dynamic_agents_chart_caipe_api_url.py tests/test_dynamic_agents_chart_keycloak_env.py` — 17 passed
- Reproduced the failure on the EC2 Kind deployment:
  - `POST /api/v1/chat/stream/start` returned 503 with `PDP_UNAVAILABLE`
  - dynamic-agents logged `AUTHZ_SERVICE_URL is not configured`
- Applied the equivalent runtime setting on EC2 and confirmed the deployment rolled out with `AUTHZ_SERVICE_URL=http://caipe-caipe-ui:3000`
- No new 503/authz warnings appeared after the rollout

Related: #2730

## Checklist

- [x] Conventional commit
- [x] DCO sign-off
- [x] Existing tests pass
- [x] Change is isolated to the installer configuration
